### PR TITLE
fix(stylelint-plugin): allow icon-size token in width and height

### DIFF
--- a/stylelint-plugin/rules/use-proper-token/token-map.js
+++ b/stylelint-plugin/rules/use-proper-token/token-map.js
@@ -42,7 +42,7 @@ const PROPERTY_TOKEN_MAP = {
   'font-size': ['font-size'],
   'font-weight': ['font-weight'],
   gap: ['space'],
-  height: [],
+  height: ['icon-size'],
   inset: [],
   left: [],
   'letter-spacing': [],
@@ -69,7 +69,7 @@ const PROPERTY_TOKEN_MAP = {
   stroke: ['color-text', 'method-color-text'],
   'text-decoration-color': ['color-text', 'method-color-text'],
   top: [],
-  width: [],
+  width: ['icon-size'],
 }
 
 module.exports = PROPERTY_TOKEN_MAP


### PR DESCRIPTION
# Summary

Allows `icon-size` token to be used in `width` and `height` CSS properties.

## PR Checklist

* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/shared-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
