### PR TITLE
fix(stylelint-plugin): allow letter spacing token for property

### DIFF
--- a/stylelint-plugin/rules/use-proper-token/token-map.js
+++ b/stylelint-plugin/rules/use-proper-token/token-map.js
@@ -45,7 +45,7 @@ const PROPERTY_TOKEN_MAP = {
   height: ['icon-size'],
   inset: [],
   left: [],
-  'letter-spacing': [],
+  'letter-spacing': ['letter-spacing'],
   'line-height': ['line-height'],
   margin: ['space'],
   'margin-bottom': ['space'],


### PR DESCRIPTION
# Summary

Add `letter-spacing` token in map allowed for `letter-spacing` property 

## PR Checklist

* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/shared-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
