### PR TITLE
fix(breakpoint): allow breakpoint tokens in width props

### DIFF
--- a/stylelint-plugin/rules/use-proper-token/token-map.js
+++ b/stylelint-plugin/rules/use-proper-token/token-map.js
@@ -54,9 +54,9 @@ const PROPERTY_TOKEN_MAP = {
   'margin-right': ['space'],
   'margin-top': ['space'],
   'max-height': [],
-  'max-width': [],
+  'max-width': ['breakpoint'],
   'min-height': [],
-  'min-width': [],
+  'min-width': ['breakpoint'],
   outline: [],
   'outline-color': [],
   'outline-width': [],
@@ -70,7 +70,7 @@ const PROPERTY_TOKEN_MAP = {
   stroke: ['color-text', 'method-color-text'],
   'text-decoration-color': ['color-text', 'method-color-text'],
   top: [],
-  width: ['icon-size'],
+  width: ['icon-size', 'breakpoint'],
 }
 
 module.exports = PROPERTY_TOKEN_MAP


### PR DESCRIPTION
# Summary

Allow utilizing `breakpoint` tokens in `width`, `max-width`, and `min-width` attributes.

## PR Checklist

* [ ] **Tests pass:** check the output of all package unit and/or component tests.
  * [ ] If this PR is the result of a bug, test coverage was added accordingly.
* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/shared-ui-components#committing-changes).
* [ ] **Docs:** includes a technically accurate README, and the docs have been updated accordingly based on the changes in this PR.
