### PR TITLE
fix: add icon specific colors

### DIFF
--- a/tokens/source/components/icon.json
+++ b/tokens/source/components/icon.json
@@ -1,5 +1,27 @@
 {
   "icon": {
+    "color": {
+      "danger": {
+        "comment": "Danger color for icons.",
+        "value": "{color.alias.red.50.value}"
+      },
+      "neutral": {
+        "comment": "Neutral color for icons.",
+        "value": "{color.alias.gray.50.value}"
+      },
+      "primary": {
+        "comment": "Primary color for icons.",
+        "value": "{color.alias.blue.50.value}"
+      },
+      "success": {
+        "comment": "Success color for icons.",
+        "value": "{color.alias.green.50.value}"
+      },
+      "warning": {
+        "comment": "Warning color for icons.",
+        "value": "{color.alias.yellow.40.value}"
+      }
+    },
     "size": {
       "10": {
         "comment": "10px icon size.",


### PR DESCRIPTION
# Summary

The design team wanted to add some icon specific tokens to allow us to use slightly different colors from our base `color-text` tokens. Icons don't require the same color contrast requirements as text does, so it makes sense to give more fine tune control over this.

For context, icons only require 3:1 ratio to pass AA while text needs to be 4.5:1.

We followed the 'component-specific' approach here with name, thus why they are `icon-color` versus `color-icon`.

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
