### PR TITLE
fix(stylelint-plugin): allow icon-color token in color property

### DIFF
--- a/stylelint-plugin/rules/use-proper-token/token-map.js
+++ b/stylelint-plugin/rules/use-proper-token/token-map.js
@@ -41,7 +41,7 @@ const PROPERTY_TOKEN_MAP = {
   'border-width': ['border-width'],
   bottom: [],
   'box-shadow': ['border-width', 'color-border', 'shadow'],
-  color: ['color-text'],
+  color: ['color-text', 'icon-color'],
   'column-gap': ['space'],
   'column-width': [],
   fill: ['color-text'],


### PR DESCRIPTION
# Summary

Allow `kui-icon-color-*` token to be used in CSS `color` property

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
