### PR TITLE
chore(*): disable auto approve

### DIFF
--- a/.github/workflows/auto-approve.yaml
+++ b/.github/workflows/auto-approve.yaml
@@ -6,8 +6,8 @@ permissions:
   contents: write
 
 on:
-  pull_request:
-    types: ['opened']
+  # pull_request:
+  #   types: ['opened']
 
 jobs:
   renovate-autoapprove:


### PR DESCRIPTION
# Summary

Temporarily disabling auto-approve for security reasons.

Context: github.actor dependabot or renovate can cause security vulnerabilities. Pausing this auto approval until this can be looked into.
