### PR TITLE
feat: upgrade style-dictionary to v5

### DIFF
--- a/TOKENS.md
+++ b/TOKENS.md
@@ -18,670 +18,343 @@ This document outlines the majority of the available tokens.
 <summary>Click to view the list of SCSS variables</summary>
 
 ```scss
-/* Default background color for containers (white). */
-$kui-color-background: #ffffff;
-/* Background color for danger actions or messages (red.60). */
-$kui-color-background-danger: #d60027;
-/* Strong background color for danger actions or messages (red.70). */
-$kui-color-background-danger-strong: #ad000e;
-/* Stronger background color for danger actions or messages (red.80). */
-$kui-color-background-danger-stronger: #850000;
-/* Strongest background color for danger actions or messages (red.90). */
-$kui-color-background-danger-strongest: #5c0000;
-/* Weak background color for danger actions or messages (red.40). */
-$kui-color-background-danger-weak: #ff3954;
-/* Weaker background color for danger actions or messages (red.20). */
-$kui-color-background-danger-weaker: #ffabab;
-/* Weakest background color for danger actions or messages (red.10). */
-$kui-color-background-danger-weakest: #ffe5e5;
-/* Weakest background color for decorative purposes (aqua.10). */
-$kui-color-background-decorative-aqua-weakest: #ecfcff;
-/* Background color for decorative purposes (purple.60). */
-$kui-color-background-decorative-purple: #6f28ff;
-/* Weakest background color for decorative purposes (purple.10). */
-$kui-color-background-decorative-purple-weakest: #f1f0ff;
-/* Background color for disabled elements (gray.20). */
-$kui-color-background-disabled: #e0e4ea;
-/* Background color for info elements (blue.60). */
-$kui-color-background-info: #0044f4;
-/* Strong background color for info elements (blue.70). */
-$kui-color-background-info-strong: #0030cc;
-/* Stronger background color for info elements (blue.80). */
-$kui-color-background-info-stronger: #002099;
-/* Strongest background color for info elements (blue.90). */
-$kui-color-background-info-strongest: #001466;
-/* Weak background color for info elements (blue.40). */
-$kui-color-background-info-weak: #5f9aff;
-/* Weaker background color for info elements (blue.20). */
-$kui-color-background-info-weaker: #bee2ff;
-/* Weakest background color for info elements (blue.10). */
-$kui-color-background-info-weakest: #eefaff;
-/* Inverse background color for containers (blue.100) */
-$kui-color-background-inverse: #000933;
-/* Background color for neutral elements (gray.60). */
-$kui-color-background-neutral: #6c7489;
-/* Strong background color for neutral elements (gray.70). */
-$kui-color-background-neutral-strong: #52596e;
-/* Stronger background color for neutral elements (gray.80). */
-$kui-color-background-neutral-stronger: #3a3f51;
-/* Strongest background color for neutral elements (gray.90). */
-$kui-color-background-neutral-strongest: #232633;
-/* Weak background color for neutral elements (gray.40). */
-$kui-color-background-neutral-weak: #afb7c5;
-/* Weaker background color for neutral elements (gray.20). */
-$kui-color-background-neutral-weaker: #e0e4ea;
-/* Weakest background color for neutral elements (gray.10). */
-$kui-color-background-neutral-weakest: #f9fafb;
-/* Overlay background color (rgba(blue.100, 0.6)) */
-$kui-color-background-overlay: rgba(0, 9, 51, 0.6);
-/* Background color for primary actions or messages (blue.60). */
-$kui-color-background-primary: #0044f4;
-/* Strong background color for primary actions or messages (blue.70). */
-$kui-color-background-primary-strong: #0030cc;
-/* Stronger background color for primary actions or messages (blue.80). */
-$kui-color-background-primary-stronger: #002099;
-/* Strongest background color for primary actions or messages (blue.90). */
-$kui-color-background-primary-strongest: #001466;
-/* Weak background color for primary actions or messages (blue.40). */
-$kui-color-background-primary-weak: #5f9aff;
-/* Weaker background color for primary actions or messages (blue.20). */
-$kui-color-background-primary-weaker: #bee2ff;
-/* Weakest background color for primary actions or messages (blue.10) */
-$kui-color-background-primary-weakest: #eefaff;
-/* Background color for success elements (green.60). */
-$kui-color-background-success: #007d60;
-/* Strong background color for success elements (green.70). */
-$kui-color-background-success-strong: #005944;
-/* Stronger background color for success elements (green.80). */
-$kui-color-background-success-stronger: #004737;
-/* Strongest background color for success elements (green.90). */
-$kui-color-background-success-strongest: #003629;
-/* Weak background color for success elements (green.40). */
-$kui-color-background-success-weak: #00d6a4;
-/* Weaker background color for success elements (green.20). */
-$kui-color-background-success-weaker: #b5ffee;
-/* Weakest background color for success elements (green.10). */
-$kui-color-background-success-weakest: #ecfffb;
-/* Transparent background color (transparent). */
-$kui-color-background-transparent: transparent;
-/* Background color for warning elements (yellow.60). */
-$kui-color-background-warning: #995c00;
-/* Strong background color for warning elements (yellow.70). */
-$kui-color-background-warning-strong: #804400;
-/* Stronger background color for warning elements (yellow.80). */
-$kui-color-background-warning-stronger: #662d00;
-/* Strongest background color for warning elements (yellow.90). */
-$kui-color-background-warning-strongest: #4d1b00;
-/* Weak background color for warning elements (yellow.40). */
-$kui-color-background-warning-weak: #ffc400;
-/* Weaker background color for warning elements (yellow.20). */
-$kui-color-background-warning-weaker: #fff296;
-/* Weakest background color for warning elements (yellow.10). */
-$kui-color-background-warning-weakest: #fffce0;
-/* Default border color for containers (gray.20). */
-$kui-color-border: #e0e4ea;
-/* Border color for danger actions or messages (red.60). */
-$kui-color-border-danger: #d60027;
-/* Strong border color for danger actions or messages (red.70). */
-$kui-color-border-danger-strong: #ad000e;
-/* Stronger border color for danger actions or messages (red.80). */
-$kui-color-border-danger-stronger: #850000;
-/* Strongest border color for danger actions or messages (red.90). */
-$kui-color-border-danger-strongest: #5c0000;
-/* Weak border color for danger actions or messages (red.40). */
-$kui-color-border-danger-weak: #ff3954;
-/* Weaker border color for danger actions or messages (red.20). */
-$kui-color-border-danger-weaker: #ffabab;
-/* Weakest border color for danger actions or messages (red.10). */
-$kui-color-border-danger-weakest: #ffe5e5;
-/* Border color for decorative purposes (purple.60). */
-$kui-color-border-decorative-purple: #6f28ff;
-/* Border color for disabled elements (gray.20). */
-$kui-color-border-disabled: #e0e4ea;
-/* Inverse border color (rgba(white, 0.2)). */
-$kui-color-border-inverse: rgba(255, 255, 255, 0.2);
-/* Border color for neutral elements (gray.60) */
-$kui-color-border-neutral: #6c7489;
-/* Strong border color for neutral elements (gray.70) */
-$kui-color-border-neutral-strong: #52596e;
-/* Stronger border color for neutral elements (gray.80) */
-$kui-color-border-neutral-stronger: #3a3f51;
-/* Strongest border color for neutral elements (gray.90) */
-$kui-color-border-neutral-strongest: #232633;
-/* Weak border color for neutral elements (gray.40) */
-$kui-color-border-neutral-weak: #afb7c5;
-/* Weaker border color for neutral elements (gray.20) */
-$kui-color-border-neutral-weaker: #e0e4ea;
-/* Weakest border color for neutral elements (gray.10) */
-$kui-color-border-neutral-weakest: #f9fafb;
-/* Border color for primary actions or messages (blue.60). */
-$kui-color-border-primary: #0044f4;
-/* Strong border color for primary actions or messages (blue.70). */
-$kui-color-border-primary-strong: #0030cc;
-/* Stronger border color for primary actions or messages (blue.80). */
-$kui-color-border-primary-stronger: #002099;
-/* Strongest border color for primary actions or messages (blue.90). */
-$kui-color-border-primary-strongest: #001466;
-/* Weak border color for primary actions or messages (blue.40). */
-$kui-color-border-primary-weak: #5f9aff;
-/* Weaker border color for primary actions or messages (blue.20). */
-$kui-color-border-primary-weaker: #bee2ff;
-/* Weakest border color for primary actions or messages (blue.10). */
-$kui-color-border-primary-weakest: #eefaff;
-/* Transparent border color (transparent). */
-$kui-color-border-transparent: transparent;
-/* Default text color (blue.100). */
-$kui-color-text: #000933;
-/* Text color for danger actions or messages (red.60). */
-$kui-color-text-danger: #d60027;
-/* Strong text color for danger actions or messages (red.70). */
-$kui-color-text-danger-strong: #ad000e;
-/* Stronger text color for danger actions or messages (red.80). */
-$kui-color-text-danger-stronger: #850000;
-/* Strongest text color for danger actions or messages (red.90). */
-$kui-color-text-danger-strongest: #5c0000;
-/* Weak text color for danger actions or messages (red.40). */
-$kui-color-text-danger-weak: #ff3954;
-/* Weaker text color for danger actions or messages (red.20). */
-$kui-color-text-danger-weaker: #ffabab;
-/* Weakest text color for danger actions or messages (red.10). */
-$kui-color-text-danger-weakest: #ffe5e5;
-/* Text color for decorative purposes (aqua.50). */
-$kui-color-text-decorative-aqua: #00abd2;
-/* Text color for decorative purposes (pink.60). */
-$kui-color-text-decorative-pink: #d60067;
-/* Text color for decorative purposes (purple.60). */
-$kui-color-text-decorative-purple: #6f28ff;
-/* Strong text color for decorative purposes (purple.70). */
-$kui-color-text-decorative-purple-strong: #5e00f5;
-/* Text color for disabled elements (gray.40). */
-$kui-color-text-disabled: #afb7c5;
-/* Text color for info elements (blue.60). */
-$kui-color-text-info: #0044f4;
-/* Strong text color for info elements (blue.70). */
-$kui-color-text-info-strong: #0030cc;
-/* Stronger text color for info elements (blue.80). */
-$kui-color-text-info-stronger: #002099;
-/* Strongest text color for info elements (blue.90). */
-$kui-color-text-info-strongest: #001466;
-/* Weak text color for info elements (blue.40). */
-$kui-color-text-info-weak: #5f9aff;
-/* Weaker text color for info elements (blue.20). */
-$kui-color-text-info-weaker: #bee2ff;
-/* Weakest text color for info elements (blue.10). */
-$kui-color-text-info-weakest: #eefaff;
-/* Inverse text color (white). */
-$kui-color-text-inverse: #ffffff;
-/* Text color for neutral elements (gray.60). */
-$kui-color-text-neutral: #6c7489;
-/* Strong text color for neutral elements (gray.70). */
-$kui-color-text-neutral-strong: #52596e;
-/* Stronger text color for neutral elements (gray.80). */
-$kui-color-text-neutral-stronger: #3a3f51;
-/* Strongest text color for neutral elements (gray.90). */
-$kui-color-text-neutral-strongest: #232633;
-/* Weak text color for neutral elements (gray.40). */
-$kui-color-text-neutral-weak: #afb7c5;
-/* Weaker text color for neutral elements (gray.20). */
-$kui-color-text-neutral-weaker: #e0e4ea;
-/* Weakest text color for neutral elements (gray.10). */
-$kui-color-text-neutral-weakest: #f9fafb;
-/* Text color for primary actions or messages (blue.60). */
-$kui-color-text-primary: #0044f4;
-/* Strong text color for primary actions or messages (blue.70). */
-$kui-color-text-primary-strong: #0030cc;
-/* Stronger text color for primary actions or messages (blue.80). */
-$kui-color-text-primary-stronger: #002099;
-/* Strongest text color for primary actions or messages (blue.90). */
-$kui-color-text-primary-strongest: #001466;
-/* Weak text color for primary actions or messages (blue.40). */
-$kui-color-text-primary-weak: #5f9aff;
-/* Weaker text color for primary actions or messages (blue.20). */
-$kui-color-text-primary-weaker: #bee2ff;
-/* Weakest text color for primary actions or messages (blue.10). */
-$kui-color-text-primary-weakest: #eefaff;
-/* Text color for success elements (green.60). */
-$kui-color-text-success: #007d60;
-/* Strong text color for success elements (green.70). */
-$kui-color-text-success-strong: #005944;
-/* Stronger text color for success elements (green.80). */
-$kui-color-text-success-stronger: #004737;
-/* Stronger text color for success elements (green.90). */
-$kui-color-text-success-strongest: #003629;
-/* Weak text color for success elements (green.40). */
-$kui-color-text-success-weak: #00d6a4;
-/* Weaker text color for success elements (green.20). */
-$kui-color-text-success-weaker: #b5ffee;
-/* Weakest text color for success elements (green.10). */
-$kui-color-text-success-weakest: #ecfffb;
-/* Text color for warning elements (yellow.60). */
-$kui-color-text-warning: #995c00;
-/* Strong text color for warning elements (yellow.70). */
-$kui-color-text-warning-strong: #804400;
-/* Stronger text color for warning elements (yellow.80). */
-$kui-color-text-warning-stronger: #662d00;
-/* Strongest text color for warning elements (yellow.90). */
-$kui-color-text-warning-strongest: #4d1b00;
-/* Weak text color for warning elements (yellow.40). */
-$kui-color-text-warning-weak: #ffc400;
-/* Weaker text color for warning elements (yellow.20). */
-$kui-color-text-warning-weaker: #fff296;
-/* Weakest text color for warning elements (yellow.10). */
-$kui-color-text-warning-weakest: #fffce0;
-/* Default transition timing */
-$kui-animation-duration-20: 0.2s;
-/* 0px border radius. */
-$kui-border-radius-0: 0px;
-/* 2px border radius. */
-$kui-border-radius-10: 2px;
-/* 4px border radius. */
-$kui-border-radius-20: 4px;
-/* 6px border radius. */
-$kui-border-radius-30: 6px;
-/* 8px border radius. */
-$kui-border-radius-40: 8px;
-/* 10px border radius. */
-$kui-border-radius-50: 10px;
-/* 50% border radius used to create circles. */
-$kui-border-radius-circle: 50%;
-/* 100px border radius used to create pill shapes. */
-$kui-border-radius-round: 100px;
-/* 0px border width. */
-$kui-border-width-0: 0px;
-/* 1px border width. */
-$kui-border-width-10: 1px;
-/* 2px border width. */
-$kui-border-width-20: 2px;
-/* 4px border width. */
-$kui-border-width-30: 4px;
-/* Used for larger mobile screens. Any viewport width under this value is considered mobile. */
-$kui-breakpoint-mobile: 640px;
-/* Used for tablet screens. */
-$kui-breakpoint-phablet: 768px;
-/* Used for larger tablet screens. Any viewport width less than this value will likely show a mobile layout. Any viewport width this value and greater will likely show a desktop layout. */
-$kui-breakpoint-tablet: 1024px;
-/* Used for standard desktop screens. */
-$kui-breakpoint-laptop: 1280px;
-/* Used for larger desktop screens. */
-$kui-breakpoint-desktop: 1536px;
-/* Danger color for icons. */
-$kui-icon-color-danger: #f50045;
-/* Neutral color for icons. */
-$kui-icon-color-neutral: #828a9e;
-/* Primary color for icons. */
-$kui-icon-color-primary: #306fff;
-/* Success color for icons. */
-$kui-icon-color-success: #00a17b;
-/* Warning color for icons. */
-$kui-icon-color-warning: #ffc400;
-/* 10px icon size. */
-$kui-icon-size-10: 10px;
-/* 12px icon size. */
-$kui-icon-size-20: 12px;
-/* 16px icon size. */
-$kui-icon-size-30: 16px;
-/* 20px icon size. */
-$kui-icon-size-40: 20px;
-/* 24px icon size (default). */
-$kui-icon-size-50: 24px;
-/* 32px icon size. */
-$kui-icon-size-60: 32px;
-/* 40px icon size. */
-$kui-icon-size-70: 40px;
-/* 48px icon size. */
-$kui-icon-size-80: 48px;
-/* Background color for the CONNECT method (purple.10). */
-$kui-method-color-background-connect: #f1f0ff;
-/* Background color for the DELETE method (red.10). */
-$kui-method-color-background-delete: #ffe5e5;
-/* Background color for the GET method (blue.10). */
-$kui-method-color-background-get: #eefaff;
-/* Background color for the HEAD method (gray.70). */
-$kui-method-color-background-head: #52596e;
-/* Background color for the OPTIONS method (gray.20). */
-$kui-method-color-background-options: #e0e4ea;
-/* Background color for the PATCH method (aqua.10). */
-$kui-method-color-background-patch: #ecfcff;
-/* Background color for the POST method (green.10). */
-$kui-method-color-background-post: #ecfffb;
-/* Background color for the PUT method (yellow.10). */
-$kui-method-color-background-put: #fffce0;
-/* Background color for the TRACE method (pink.10). */
-$kui-method-color-background-trace: #fff0f7;
-/* Text color for the CONNECT method (purple.60). */
-$kui-method-color-text-connect: #6f28ff;
-/* Strong text color for the CONNECT method (purple.70). */
-$kui-method-color-text-connect-strong: #5e00f5;
-/* Text color for the DELETE method (red.60). */
-$kui-method-color-text-delete: #d60027;
-/* Strong text color for the DELETE method (red.70). */
-$kui-method-color-text-delete-strong: #ad000e;
-/* Text color for the GET method (blue.60). */
-$kui-method-color-text-get: #0044f4;
-/* Strong text color for the GET method (blue.70). */
-$kui-method-color-text-get-strong: #0030cc;
-/* Text color for the HEAD method (gray.20). */
-$kui-method-color-text-head: #e0e4ea;
-/* Strong text color for the HEAD method (gray.40). */
-$kui-method-color-text-head-strong: #afb7c5;
-/* Text color for the OPTIONS method (gray.70). */
-$kui-method-color-text-options: #52596e;
-/* Strong text color for the OPTIONS method (gray.80). */
-$kui-method-color-text-options-strong: #3a3f51;
-/* Text color for the PATCH method (aqua.60). */
-$kui-method-color-text-patch: #00819d;
-/* Strong text color for the PATCH method (aqua.70). */
-$kui-method-color-text-patch-strong: #00647a;
-/* Text color for the POST method (green.60). */
-$kui-method-color-text-post: #007d60;
-/* Strong text color for the POST method (green.70). */
-$kui-method-color-text-post-strong: #005944;
-/* Text color for the PUT method (yellow.60). */
-$kui-method-color-text-put: #995c00;
-/* Strong text color for the PUT method (yellow.70). */
-$kui-method-color-text-put-strong: #804400;
-/* Text color for the TRACE method (pink.60). */
-$kui-method-color-text-trace: #d60067;
-/* Strong text color for the TRACE method (pink.70). */
-$kui-method-color-text-trace-strong: #ad0053;
-/* blue.100 */
-$kui-navigation-color-background: #000933;
-/* The background color of a selected navigation item. */
-$kui-navigation-color-background-selected: rgba(255, 255, 255, 0.12);
-/* rgba(white, 0.12) */
-$kui-navigation-color-border: rgba(255, 255, 255, 0.12);
-/* The border color for a selected child navigation item. */
-$kui-navigation-color-border-child: #00fabe;
-/* The color of the navigation section divider. */
-$kui-navigation-color-border-divider: rgba(255, 255, 255, 0.24);
-/* Navigation link and icon color. */
-$kui-navigation-color-text: #bee2ff;
-/* Navigation link and icon focus-visible color. */
-$kui-navigation-color-text-focus: #ffffff;
-/* Navigation link and icon hover color. */
-$kui-navigation-color-text-hover: #eefaff;
-/* Navigation link and icon selected color. */
-$kui-navigation-color-text-selected: #00fabe;
-/* The box-shadow for a focus-visible navigation link. */
-$kui-navigation-shadow-border: 0 0 0 1px rgba(255, 255, 255, 0.12) inset;
-/* The left box-shadow for an active child navigation link. */
-$kui-navigation-shadow-border-child: 4px 0 0 0 #00fabe inset;
-/* Navigation link focus-visible box-shadow. */
-$kui-navigation-shadow-focus: 0 0 0 1px rgba(255, 255, 255, 0.60) inset;
-/* Color representing response status code 100 (blue.20). */
-$kui-status-color-100: #bee2ff;
-/* Color representing response status code 101 (blue.30). */
-$kui-status-color-101: #8fc1ff;
-/* Color representing response status code 102 (blue.40). */
-$kui-status-color-102: #5f9aff;
-/* Color representing response status code 103 (blue.50). */
-$kui-status-color-103: #306fff;
-/* Color representing response status code 200 (green.20). */
-$kui-status-color-200: #b5ffee;
-/* Color representing response status code 201 (green.30). */
-$kui-status-color-201: #00fabe;
-/* Color representing response status code 202 (green.40). */
-$kui-status-color-202: #00d6a4;
-/* Color representing response status code 203 (green.50). */
-$kui-status-color-203: #00a17b;
-/* Color representing response status code 204 (green.60). */
-$kui-status-color-204: #007d60;
-/* Color representing response status code 205 (green.70). */
-$kui-status-color-205: #005944;
-/* Color representing response status code 206 (green.20). */
-$kui-status-color-206: #b5ffee;
-/* Color representing response status code 207 (green.30). */
-$kui-status-color-207: #00fabe;
-/* Color representing response status code 208 (green.40). */
-$kui-status-color-208: #b5ffee;
-/* Color representing response status code 226 (green.50). */
-$kui-status-color-226: #00a17b;
-/* Color representing response status code 100 (yellow.20). */
-$kui-status-color-300: #fff296;
-/* Color representing response status code 101 (yellow.30). */
-$kui-status-color-301: #ffe04b;
-/* Color representing response status code 102 (yellow.40). */
-$kui-status-color-302: #ffc400;
-/* Color representing response status code 103 (yellow.50). */
-$kui-status-color-303: #b37600;
-/* Color representing response status code 103 (yellow.60). */
-$kui-status-color-304: #995c00;
-/* Color representing response status code 103 (yellow.70). */
-$kui-status-color-305: #804400;
-/* Color representing response status code 103 (yellow.20). */
-$kui-status-color-307: #fff296;
-/* Color representing response status code 103 (yellow.30). */
-$kui-status-color-308: #ffe04b;
-/* Color representing response status code 400 (orange.20). */
-$kui-status-color-400: #FFC2B3;
-/* Color representing response status code 401 (orange.30). */
-$kui-status-color-401: #FF9877;
-/* Color representing response status code 402 (orange.40). */
-$kui-status-color-402: #FF723C;
-/* Color representing response status code 403 (orange.50). */
-$kui-status-color-403: #F75008;
-/* Color representing response status code 404 (orange.60). */
-$kui-status-color-404: #D13500;
-/* Color representing response status code 405 (orange.70). */
-$kui-status-color-405: #A31F00;
-/* Color representing response status code 406 (orange.20). */
-$kui-status-color-406: #FFC2B3;
-/* Color representing response status code 407 (orange.30). */
-$kui-status-color-407: #FF9877;
-/* Color representing response status code 408 (orange.40). */
-$kui-status-color-408: #FF723C;
-/* Color representing response status code 409 (orange.50). */
-$kui-status-color-409: #F75008;
-/* Color representing response status code 410 (orange.60). */
-$kui-status-color-410: #D13500;
-/* Color representing response status code 411 (orange.70). */
-$kui-status-color-411: #A31F00;
-/* Color representing response status code 412 (orange.20). */
-$kui-status-color-412: #FFC2B3;
-/* Color representing response status code 413 (orange.30). */
-$kui-status-color-413: #FF9877;
-/* Color representing response status code 414 (orange.40). */
-$kui-status-color-414: #FF723C;
-/* Color representing response status code 415 (orange.50). */
-$kui-status-color-415: #F75008;
-/* Color representing response status code 416 (orange.60). */
-$kui-status-color-416: #D13500;
-/* Color representing response status code 417 (orange.70). */
-$kui-status-color-417: #A31F00;
-/* Color representing response status code 418 (orange.20). */
-$kui-status-color-418: #FFC2B3;
-/* Color representing response status code 421 (orange.30). */
-$kui-status-color-421: #FF9877;
-/* Color representing response status code 422 (orange.40). */
-$kui-status-color-422: #FF723C;
-/* Color representing response status code 423 (orange.50). */
-$kui-status-color-423: #F75008;
-/* Color representing response status code 424 (orange.60). */
-$kui-status-color-424: #D13500;
-/* Color representing response status code 425 (orange.70). */
-$kui-status-color-425: #A31F00;
-/* Color representing response status code 426 (orange.20). */
-$kui-status-color-426: #FFC2B3;
-/* Color representing response status code 428 (orange.30). */
-$kui-status-color-428: #FF9877;
-/* Color representing response status code 429 (orange.40). */
-$kui-status-color-429: #FF723C;
-/* Color representing response status code 431 (orange.50). */
-$kui-status-color-431: #F75008;
-/* Color representing response status code 451 (orange.60). */
-$kui-status-color-451: #D13500;
-/* Color representing response status code 500 (red.20). */
-$kui-status-color-500: #ffabab;
-/* Color representing response status code 501 (red.30). */
-$kui-status-color-501: #ff7272;
-/* Color representing response status code 502 (red.40). */
-$kui-status-color-502: #ff3954;
-/* Color representing response status code 503 (red.50). */
-$kui-status-color-503: #f50045;
-/* Color representing response status code 504 (red.60). */
-$kui-status-color-504: #d60027;
-/* Color representing response status code 505 (red.70). */
-$kui-status-color-505: #ad000e;
-/* Color representing response status code 506 (red.20). */
-$kui-status-color-506: #ffabab;
-/* Color representing response status code 507 (red.30). */
-$kui-status-color-507: #ff7272;
-/* Color representing response status code 508 (red.40). */
-$kui-status-color-508: #ff3954;
-/* Color representing response status code 510 (red.50). */
-$kui-status-color-510: #f50045;
-/* Color representing response status code 511 (red.60). */
-$kui-status-color-511: #d60027;
-/* Color for unknown response status codes in the 100-199 range (blue.10). */
-$kui-status-color-1na: #eefaff;
-/* Color for unknown response status codes in the 200-299 range (green.10). */
-$kui-status-color-2na: #ecfffb;
-/* Color for unknown response status codes in the 300-399 range (yellow.10). */
-$kui-status-color-3na: #fffce0;
-/* Color for unknown response status codes in the 400-499 range (orange.10). */
-$kui-status-color-4na: #FFF1EF;
-/* Color for unknown response status codes in the 500-599 range (red.10). */
-$kui-status-color-5na: #ffe5e5;
-/* Color for a group of response status codes in the 100-199 range (blue.40). */
-$kui-status-color-100s: #5f9aff;
-/* Color for a group of response status codes in the 200-299 range (green.40). */
-$kui-status-color-200s: #00d6a4;
-/* Color for a group of response status codes in the 300-399 range (yellow.40). */
-$kui-status-color-300s: #ffc400;
-/* Color for a group of response status codes in the 400-499 range (orange.40). */
-$kui-status-color-400s: #FF723C;
-/* Color for a group of response status codes in the 500-599 range (red.40). */
-$kui-status-color-500s: #ff3954;
-/* Background color for http status 100 elements (blue.10). */
-$kui-status-color-background-100: #eefaff;
-/* Background color for http status 200 elements (green.10). */
-$kui-status-color-background-200: #ecfffb;
-/* Background color for http status 300 elements (yellow.10). */
-$kui-status-color-background-300: #fffce0;
-/* Background color for http status 400 elements (orange.10). */
-$kui-status-color-background-400: #FFF1EF;
-/* Background color for http status 500 elements (red.10). */
-$kui-status-color-background-500: #ffe5e5;
-/* Text color for http status 100 elements (blue.60). */
-$kui-status-color-text-100: #0044f4;
-/* Text color for http status 200 elements (green.60). */
-$kui-status-color-text-200: #007d60;
-/* Text color for http status 300 elements (yellow.60). */
-$kui-status-color-text-300: #995c00;
-/* Text color for http status 400 elements (orange.60). */
-$kui-status-color-text-400: #D13500;
-/* Text color for http status 500 elements (red.60). */
-$kui-status-color-text-500: #d60027;
-/* The standard monospace text font family. Typically used for code blocks, inline code, and copyable text. */
-$kui-font-family-code: 'JetBrains Mono', Consolas, monospace;
-/* The standard heading text font family. */
-$kui-font-family-heading: 'Inter', Roboto, Helvetica, sans-serif;
-/* The standard text font family. */
-$kui-font-family-text: 'Inter', Roboto, Helvetica, sans-serif;
-$kui-font-size-10: 10px;
-$kui-font-size-20: 12px;
-$kui-font-size-30: 14px;
-$kui-font-size-40: 16px;
-$kui-font-size-50: 18px;
-$kui-font-size-60: 20px;
-$kui-font-size-70: 24px;
-$kui-font-size-80: 32px;
-$kui-font-size-90: 40px;
-$kui-font-size-100: 48px;
-/* 700: The bold font weight. */
-$kui-font-weight-bold: 700;
-/* 500: The medium font weight. */
-$kui-font-weight-medium: 500;
-/* 400: The normal font weight. */
-$kui-font-weight-regular: 400;
-/* 600: The semibold font weight. */
-$kui-font-weight-semibold: 600;
-/* Alias for letter-spacing-normal */
-$kui-letter-spacing-0: normal;
-/* -0.12px */
-$kui-letter-spacing-minus-10: -0.12px;
-/* -0.24px */
-$kui-letter-spacing-minus-20: -0.24px;
-/* -0.32px */
-$kui-letter-spacing-minus-30: -0.32px;
-/* -0.4px */
-$kui-letter-spacing-minus-40: -0.4px;
-/* -0.48px */
-$kui-letter-spacing-minus-50: -0.48px;
-/* normal */
-$kui-letter-spacing-normal: normal;
-/* 12px */
-$kui-line-height-10: 12px;
-/* 16px */
-$kui-line-height-20: 16px;
-/* 20px */
-$kui-line-height-30: 20px;
-/* 24px */
-$kui-line-height-40: 24px;
-/* 28px */
-$kui-line-height-50: 28px;
-/* 32px */
-$kui-line-height-60: 32px;
-/* 36px */
-$kui-line-height-70: 36px;
-/* 40px */
-$kui-line-height-80: 40px;
-/* 48px */
-$kui-line-height-90: 48px;
-/* 56px */
-$kui-line-height-100: 56px;
-/* 0px 4px 20px 0px rgba(0, 0, 0, 0.08) */
-$kui-shadow: 0px 4px 20px 0px rgba(0, 0, 0, 0.08);
-/* 0px 0px 0px 1px gray.20 inset */
-$kui-shadow-border: 0px 0px 0px 1px #e0e4ea inset;
-/* 0px 0px 0px 1px red.60 inset */
-$kui-shadow-border-danger: 0px 0px 0px 1px #d60027 inset;
-/* 0px 0px 0px 1px red.70 inset */
-$kui-shadow-border-danger-strong: 0px 0px 0px 1px #ad000e inset;
-/* 0px 0px 0px 1px gray.20 inset */
-$kui-shadow-border-disabled: 0px 0px 0px 1px #e0e4ea inset;
-/* 0px 0px 0px 1px blue.60 inset */
-$kui-shadow-border-primary: 0px 0px 0px 1px #0044f4 inset;
-/* 0px 0px 0px 1px blue.90 inset */
-$kui-shadow-border-primary-strongest: 0px 0px 0px 1px #001466 inset;
-/* 0px 0px 0px 1px blue.40 inset */
-$kui-shadow-border-primary-weak: 0px 0px 0px 1px #5f9aff inset;
-/* 0px 0px 0px 4px rgba(0, 68, 244, 0.2) */
-$kui-shadow-focus: 0px 0px 0px 4px rgba(0, 68, 244, 0.2);
-/* 0px value for gaps, margin, or padding. */
-$kui-space-0: 0px;
-/* 2px value for gaps, margin, or padding. */
-$kui-space-10: 2px;
-/* 4px value for gaps, margin, or padding. */
-$kui-space-20: 4px;
-/* 6px value for gaps, margin, or padding. */
-$kui-space-30: 6px;
-/* 8px value for gaps, margin, or padding. */
-$kui-space-40: 8px;
-/* 12px value for gaps, margin, or padding. */
-$kui-space-50: 12px;
-/* 16px value for gaps, margin, or padding. */
-$kui-space-60: 16px;
-/* 20px value for gaps, margin, or padding. */
-$kui-space-70: 20px;
-/* 24px value for gaps, margin, or padding. */
-$kui-space-80: 24px;
-/* 32px value for gaps, margin, or padding. */
-$kui-space-90: 32px;
-/* 40px value for gaps, margin, or padding. */
-$kui-space-100: 40px;
-/* 48px value for gaps, margin, or padding. */
-$kui-space-110: 48px;
-/* 56px value for gaps, margin, or padding. */
-$kui-space-120: 56px;
-/* 64px value for gaps, margin, or padding. */
-$kui-space-130: 64px;
-/* 80px value for gaps, margin, or padding. */
-$kui-space-140: 80px;
-/* 96px value for gaps, margin, or padding. */
-$kui-space-150: 96px;
-/* auto */
-$kui-space-auto: auto;
+$kui-color-background: ;
+$kui-color-background-danger: ;
+$kui-color-background-danger-strong: ;
+$kui-color-background-danger-stronger: ;
+$kui-color-background-danger-strongest: ;
+$kui-color-background-danger-weak: ;
+$kui-color-background-danger-weaker: ;
+$kui-color-background-danger-weakest: ;
+$kui-color-background-decorative-aqua-weakest: ;
+$kui-color-background-decorative-purple: ;
+$kui-color-background-decorative-purple-weakest: ;
+$kui-color-background-disabled: ;
+$kui-color-background-info: ;
+$kui-color-background-info-strong: ;
+$kui-color-background-info-stronger: ;
+$kui-color-background-info-strongest: ;
+$kui-color-background-info-weak: ;
+$kui-color-background-info-weaker: ;
+$kui-color-background-info-weakest: ;
+$kui-color-background-inverse: ;
+$kui-color-background-neutral: ;
+$kui-color-background-neutral-strong: ;
+$kui-color-background-neutral-stronger: ;
+$kui-color-background-neutral-strongest: ;
+$kui-color-background-neutral-weak: ;
+$kui-color-background-neutral-weaker: ;
+$kui-color-background-neutral-weakest: ;
+$kui-color-background-overlay: ;
+$kui-color-background-primary: ;
+$kui-color-background-primary-strong: ;
+$kui-color-background-primary-stronger: ;
+$kui-color-background-primary-strongest: ;
+$kui-color-background-primary-weak: ;
+$kui-color-background-primary-weaker: ;
+$kui-color-background-primary-weakest: ;
+$kui-color-background-success: ;
+$kui-color-background-success-strong: ;
+$kui-color-background-success-stronger: ;
+$kui-color-background-success-strongest: ;
+$kui-color-background-success-weak: ;
+$kui-color-background-success-weaker: ;
+$kui-color-background-success-weakest: ;
+$kui-color-background-transparent: ;
+$kui-color-background-warning: ;
+$kui-color-background-warning-strong: ;
+$kui-color-background-warning-stronger: ;
+$kui-color-background-warning-strongest: ;
+$kui-color-background-warning-weak: ;
+$kui-color-background-warning-weaker: ;
+$kui-color-background-warning-weakest: ;
+$kui-color-border: ;
+$kui-color-border-danger: ;
+$kui-color-border-danger-strong: ;
+$kui-color-border-danger-stronger: ;
+$kui-color-border-danger-strongest: ;
+$kui-color-border-danger-weak: ;
+$kui-color-border-danger-weaker: ;
+$kui-color-border-danger-weakest: ;
+$kui-color-border-decorative-purple: ;
+$kui-color-border-disabled: ;
+$kui-color-border-inverse: ;
+$kui-color-border-neutral: ;
+$kui-color-border-neutral-strong: ;
+$kui-color-border-neutral-stronger: ;
+$kui-color-border-neutral-strongest: ;
+$kui-color-border-neutral-weak: ;
+$kui-color-border-neutral-weaker: ;
+$kui-color-border-neutral-weakest: ;
+$kui-color-border-primary: ;
+$kui-color-border-primary-strong: ;
+$kui-color-border-primary-stronger: ;
+$kui-color-border-primary-strongest: ;
+$kui-color-border-primary-weak: ;
+$kui-color-border-primary-weaker: ;
+$kui-color-border-primary-weakest: ;
+$kui-color-border-transparent: ;
+$kui-color-text: ;
+$kui-color-text-danger: ;
+$kui-color-text-danger-strong: ;
+$kui-color-text-danger-stronger: ;
+$kui-color-text-danger-strongest: ;
+$kui-color-text-danger-weak: ;
+$kui-color-text-danger-weaker: ;
+$kui-color-text-danger-weakest: ;
+$kui-color-text-decorative-aqua: ;
+$kui-color-text-decorative-pink: ;
+$kui-color-text-decorative-purple: ;
+$kui-color-text-decorative-purple-strong: ;
+$kui-color-text-disabled: ;
+$kui-color-text-info: ;
+$kui-color-text-info-strong: ;
+$kui-color-text-info-stronger: ;
+$kui-color-text-info-strongest: ;
+$kui-color-text-info-weak: ;
+$kui-color-text-info-weaker: ;
+$kui-color-text-info-weakest: ;
+$kui-color-text-inverse: ;
+$kui-color-text-neutral: ;
+$kui-color-text-neutral-strong: ;
+$kui-color-text-neutral-stronger: ;
+$kui-color-text-neutral-strongest: ;
+$kui-color-text-neutral-weak: ;
+$kui-color-text-neutral-weaker: ;
+$kui-color-text-neutral-weakest: ;
+$kui-color-text-primary: ;
+$kui-color-text-primary-strong: ;
+$kui-color-text-primary-stronger: ;
+$kui-color-text-primary-strongest: ;
+$kui-color-text-primary-weak: ;
+$kui-color-text-primary-weaker: ;
+$kui-color-text-primary-weakest: ;
+$kui-color-text-success: ;
+$kui-color-text-success-strong: ;
+$kui-color-text-success-stronger: ;
+$kui-color-text-success-strongest: ;
+$kui-color-text-success-weak: ;
+$kui-color-text-success-weaker: ;
+$kui-color-text-success-weakest: ;
+$kui-color-text-warning: ;
+$kui-color-text-warning-strong: ;
+$kui-color-text-warning-stronger: ;
+$kui-color-text-warning-strongest: ;
+$kui-color-text-warning-weak: ;
+$kui-color-text-warning-weaker: ;
+$kui-color-text-warning-weakest: ;
+$kui-animation-duration-20: ;
+$kui-border-radius-0: ;
+$kui-border-radius-10: ;
+$kui-border-radius-20: ;
+$kui-border-radius-30: ;
+$kui-border-radius-40: ;
+$kui-border-radius-50: ;
+$kui-border-radius-circle: ;
+$kui-border-radius-round: ;
+$kui-border-width-0: ;
+$kui-border-width-10: ;
+$kui-border-width-20: ;
+$kui-border-width-30: ;
+$kui-breakpoint-mobile: ;
+$kui-breakpoint-phablet: ;
+$kui-breakpoint-tablet: ;
+$kui-breakpoint-laptop: ;
+$kui-breakpoint-desktop: ;
+$kui-icon-color-danger: ;
+$kui-icon-color-neutral: ;
+$kui-icon-color-primary: ;
+$kui-icon-color-success: ;
+$kui-icon-color-warning: ;
+$kui-icon-size-10: ;
+$kui-icon-size-20: ;
+$kui-icon-size-30: ;
+$kui-icon-size-40: ;
+$kui-icon-size-50: ;
+$kui-icon-size-60: ;
+$kui-icon-size-70: ;
+$kui-icon-size-80: ;
+$kui-method-color-background-connect: ;
+$kui-method-color-background-delete: ;
+$kui-method-color-background-get: ;
+$kui-method-color-background-head: ;
+$kui-method-color-background-options: ;
+$kui-method-color-background-patch: ;
+$kui-method-color-background-post: ;
+$kui-method-color-background-put: ;
+$kui-method-color-background-trace: ;
+$kui-method-color-text-connect: ;
+$kui-method-color-text-connect-strong: ;
+$kui-method-color-text-delete: ;
+$kui-method-color-text-delete-strong: ;
+$kui-method-color-text-get: ;
+$kui-method-color-text-get-strong: ;
+$kui-method-color-text-head: ;
+$kui-method-color-text-head-strong: ;
+$kui-method-color-text-options: ;
+$kui-method-color-text-options-strong: ;
+$kui-method-color-text-patch: ;
+$kui-method-color-text-patch-strong: ;
+$kui-method-color-text-post: ;
+$kui-method-color-text-post-strong: ;
+$kui-method-color-text-put: ;
+$kui-method-color-text-put-strong: ;
+$kui-method-color-text-trace: ;
+$kui-method-color-text-trace-strong: ;
+$kui-navigation-color-background: ;
+$kui-navigation-color-background-selected: ;
+$kui-navigation-color-border: ;
+$kui-navigation-color-border-child: ;
+$kui-navigation-color-border-divider: ;
+$kui-navigation-color-text: ;
+$kui-navigation-color-text-focus: ;
+$kui-navigation-color-text-hover: ;
+$kui-navigation-color-text-selected: ;
+$kui-navigation-shadow-border: ;
+$kui-navigation-shadow-border-child: ;
+$kui-navigation-shadow-focus: ;
+$kui-status-color-100: ;
+$kui-status-color-101: ;
+$kui-status-color-102: ;
+$kui-status-color-103: ;
+$kui-status-color-200: ;
+$kui-status-color-201: ;
+$kui-status-color-202: ;
+$kui-status-color-203: ;
+$kui-status-color-204: ;
+$kui-status-color-205: ;
+$kui-status-color-206: ;
+$kui-status-color-207: ;
+$kui-status-color-208: ;
+$kui-status-color-226: ;
+$kui-status-color-300: ;
+$kui-status-color-301: ;
+$kui-status-color-302: ;
+$kui-status-color-303: ;
+$kui-status-color-304: ;
+$kui-status-color-305: ;
+$kui-status-color-307: ;
+$kui-status-color-308: ;
+$kui-status-color-400: ;
+$kui-status-color-401: ;
+$kui-status-color-402: ;
+$kui-status-color-403: ;
+$kui-status-color-404: ;
+$kui-status-color-405: ;
+$kui-status-color-406: ;
+$kui-status-color-407: ;
+$kui-status-color-408: ;
+$kui-status-color-409: ;
+$kui-status-color-410: ;
+$kui-status-color-411: ;
+$kui-status-color-412: ;
+$kui-status-color-413: ;
+$kui-status-color-414: ;
+$kui-status-color-415: ;
+$kui-status-color-416: ;
+$kui-status-color-417: ;
+$kui-status-color-418: ;
+$kui-status-color-421: ;
+$kui-status-color-422: ;
+$kui-status-color-423: ;
+$kui-status-color-424: ;
+$kui-status-color-425: ;
+$kui-status-color-426: ;
+$kui-status-color-428: ;
+$kui-status-color-429: ;
+$kui-status-color-431: ;
+$kui-status-color-451: ;
+$kui-status-color-500: ;
+$kui-status-color-501: ;
+$kui-status-color-502: ;
+$kui-status-color-503: ;
+$kui-status-color-504: ;
+$kui-status-color-505: ;
+$kui-status-color-506: ;
+$kui-status-color-507: ;
+$kui-status-color-508: ;
+$kui-status-color-510: ;
+$kui-status-color-511: ;
+$kui-status-color-1na: ;
+$kui-status-color-2na: ;
+$kui-status-color-3na: ;
+$kui-status-color-4na: ;
+$kui-status-color-5na: ;
+$kui-status-color-100s: ;
+$kui-status-color-200s: ;
+$kui-status-color-300s: ;
+$kui-status-color-400s: ;
+$kui-status-color-500s: ;
+$kui-status-color-background-100: ;
+$kui-status-color-background-200: ;
+$kui-status-color-background-300: ;
+$kui-status-color-background-400: ;
+$kui-status-color-background-500: ;
+$kui-status-color-text-100: ;
+$kui-status-color-text-200: ;
+$kui-status-color-text-300: ;
+$kui-status-color-text-400: ;
+$kui-status-color-text-500: ;
+$kui-font-family-code: ;
+$kui-font-family-heading: ;
+$kui-font-family-text: ;
+$kui-font-size-10: ;
+$kui-font-size-20: ;
+$kui-font-size-30: ;
+$kui-font-size-40: ;
+$kui-font-size-50: ;
+$kui-font-size-60: ;
+$kui-font-size-70: ;
+$kui-font-size-80: ;
+$kui-font-size-90: ;
+$kui-font-size-100: ;
+$kui-font-weight-bold: ;
+$kui-font-weight-medium: ;
+$kui-font-weight-regular: ;
+$kui-font-weight-semibold: ;
+$kui-letter-spacing-0: ;
+$kui-letter-spacing-minus-10: ;
+$kui-letter-spacing-minus-20: ;
+$kui-letter-spacing-minus-30: ;
+$kui-letter-spacing-minus-40: ;
+$kui-letter-spacing-minus-50: ;
+$kui-letter-spacing-normal: ;
+$kui-line-height-10: ;
+$kui-line-height-20: ;
+$kui-line-height-30: ;
+$kui-line-height-40: ;
+$kui-line-height-50: ;
+$kui-line-height-60: ;
+$kui-line-height-70: ;
+$kui-line-height-80: ;
+$kui-line-height-90: ;
+$kui-line-height-100: ;
+$kui-shadow: ;
+$kui-shadow-border: ;
+$kui-shadow-border-danger: ;
+$kui-shadow-border-danger-strong: ;
+$kui-shadow-border-disabled: ;
+$kui-shadow-border-primary: ;
+$kui-shadow-border-primary-strongest: ;
+$kui-shadow-border-primary-weak: ;
+$kui-shadow-focus: ;
+$kui-space-0: ;
+$kui-space-10: ;
+$kui-space-20: ;
+$kui-space-30: ;
+$kui-space-40: ;
+$kui-space-50: ;
+$kui-space-60: ;
+$kui-space-70: ;
+$kui-space-80: ;
+$kui-space-90: ;
+$kui-space-100: ;
+$kui-space-110: ;
+$kui-space-120: ;
+$kui-space-130: ;
+$kui-space-140: ;
+$kui-space-150: ;
+$kui-space-auto: ;
 ```
 
 </details>
@@ -694,670 +367,343 @@ $kui-space-auto: auto;
 
 ```scss
 $tokens-map: (
-  /* Default background color for containers (white). */
-  'kui-color-background': #ffffff;
-  /* Background color for danger actions or messages (red.60). */
-  'kui-color-background-danger': #d60027;
-  /* Strong background color for danger actions or messages (red.70). */
-  'kui-color-background-danger-strong': #ad000e;
-  /* Stronger background color for danger actions or messages (red.80). */
-  'kui-color-background-danger-stronger': #850000;
-  /* Strongest background color for danger actions or messages (red.90). */
-  'kui-color-background-danger-strongest': #5c0000;
-  /* Weak background color for danger actions or messages (red.40). */
-  'kui-color-background-danger-weak': #ff3954;
-  /* Weaker background color for danger actions or messages (red.20). */
-  'kui-color-background-danger-weaker': #ffabab;
-  /* Weakest background color for danger actions or messages (red.10). */
-  'kui-color-background-danger-weakest': #ffe5e5;
-  /* Weakest background color for decorative purposes (aqua.10). */
-  'kui-color-background-decorative-aqua-weakest': #ecfcff;
-  /* Background color for decorative purposes (purple.60). */
-  'kui-color-background-decorative-purple': #6f28ff;
-  /* Weakest background color for decorative purposes (purple.10). */
-  'kui-color-background-decorative-purple-weakest': #f1f0ff;
-  /* Background color for disabled elements (gray.20). */
-  'kui-color-background-disabled': #e0e4ea;
-  /* Background color for info elements (blue.60). */
-  'kui-color-background-info': #0044f4;
-  /* Strong background color for info elements (blue.70). */
-  'kui-color-background-info-strong': #0030cc;
-  /* Stronger background color for info elements (blue.80). */
-  'kui-color-background-info-stronger': #002099;
-  /* Strongest background color for info elements (blue.90). */
-  'kui-color-background-info-strongest': #001466;
-  /* Weak background color for info elements (blue.40). */
-  'kui-color-background-info-weak': #5f9aff;
-  /* Weaker background color for info elements (blue.20). */
-  'kui-color-background-info-weaker': #bee2ff;
-  /* Weakest background color for info elements (blue.10). */
-  'kui-color-background-info-weakest': #eefaff;
-  /* Inverse background color for containers (blue.100) */
-  'kui-color-background-inverse': #000933;
-  /* Background color for neutral elements (gray.60). */
-  'kui-color-background-neutral': #6c7489;
-  /* Strong background color for neutral elements (gray.70). */
-  'kui-color-background-neutral-strong': #52596e;
-  /* Stronger background color for neutral elements (gray.80). */
-  'kui-color-background-neutral-stronger': #3a3f51;
-  /* Strongest background color for neutral elements (gray.90). */
-  'kui-color-background-neutral-strongest': #232633;
-  /* Weak background color for neutral elements (gray.40). */
-  'kui-color-background-neutral-weak': #afb7c5;
-  /* Weaker background color for neutral elements (gray.20). */
-  'kui-color-background-neutral-weaker': #e0e4ea;
-  /* Weakest background color for neutral elements (gray.10). */
-  'kui-color-background-neutral-weakest': #f9fafb;
-  /* Overlay background color (rgba(blue.100, 0.6)) */
-  'kui-color-background-overlay': rgba(0, 9, 51, 0.6);
-  /* Background color for primary actions or messages (blue.60). */
-  'kui-color-background-primary': #0044f4;
-  /* Strong background color for primary actions or messages (blue.70). */
-  'kui-color-background-primary-strong': #0030cc;
-  /* Stronger background color for primary actions or messages (blue.80). */
-  'kui-color-background-primary-stronger': #002099;
-  /* Strongest background color for primary actions or messages (blue.90). */
-  'kui-color-background-primary-strongest': #001466;
-  /* Weak background color for primary actions or messages (blue.40). */
-  'kui-color-background-primary-weak': #5f9aff;
-  /* Weaker background color for primary actions or messages (blue.20). */
-  'kui-color-background-primary-weaker': #bee2ff;
-  /* Weakest background color for primary actions or messages (blue.10) */
-  'kui-color-background-primary-weakest': #eefaff;
-  /* Background color for success elements (green.60). */
-  'kui-color-background-success': #007d60;
-  /* Strong background color for success elements (green.70). */
-  'kui-color-background-success-strong': #005944;
-  /* Stronger background color for success elements (green.80). */
-  'kui-color-background-success-stronger': #004737;
-  /* Strongest background color for success elements (green.90). */
-  'kui-color-background-success-strongest': #003629;
-  /* Weak background color for success elements (green.40). */
-  'kui-color-background-success-weak': #00d6a4;
-  /* Weaker background color for success elements (green.20). */
-  'kui-color-background-success-weaker': #b5ffee;
-  /* Weakest background color for success elements (green.10). */
-  'kui-color-background-success-weakest': #ecfffb;
-  /* Transparent background color (transparent). */
-  'kui-color-background-transparent': transparent;
-  /* Background color for warning elements (yellow.60). */
-  'kui-color-background-warning': #995c00;
-  /* Strong background color for warning elements (yellow.70). */
-  'kui-color-background-warning-strong': #804400;
-  /* Stronger background color for warning elements (yellow.80). */
-  'kui-color-background-warning-stronger': #662d00;
-  /* Strongest background color for warning elements (yellow.90). */
-  'kui-color-background-warning-strongest': #4d1b00;
-  /* Weak background color for warning elements (yellow.40). */
-  'kui-color-background-warning-weak': #ffc400;
-  /* Weaker background color for warning elements (yellow.20). */
-  'kui-color-background-warning-weaker': #fff296;
-  /* Weakest background color for warning elements (yellow.10). */
-  'kui-color-background-warning-weakest': #fffce0;
-  /* Default border color for containers (gray.20). */
-  'kui-color-border': #e0e4ea;
-  /* Border color for danger actions or messages (red.60). */
-  'kui-color-border-danger': #d60027;
-  /* Strong border color for danger actions or messages (red.70). */
-  'kui-color-border-danger-strong': #ad000e;
-  /* Stronger border color for danger actions or messages (red.80). */
-  'kui-color-border-danger-stronger': #850000;
-  /* Strongest border color for danger actions or messages (red.90). */
-  'kui-color-border-danger-strongest': #5c0000;
-  /* Weak border color for danger actions or messages (red.40). */
-  'kui-color-border-danger-weak': #ff3954;
-  /* Weaker border color for danger actions or messages (red.20). */
-  'kui-color-border-danger-weaker': #ffabab;
-  /* Weakest border color for danger actions or messages (red.10). */
-  'kui-color-border-danger-weakest': #ffe5e5;
-  /* Border color for decorative purposes (purple.60). */
-  'kui-color-border-decorative-purple': #6f28ff;
-  /* Border color for disabled elements (gray.20). */
-  'kui-color-border-disabled': #e0e4ea;
-  /* Inverse border color (rgba(white, 0.2)). */
-  'kui-color-border-inverse': rgba(255, 255, 255, 0.2);
-  /* Border color for neutral elements (gray.60) */
-  'kui-color-border-neutral': #6c7489;
-  /* Strong border color for neutral elements (gray.70) */
-  'kui-color-border-neutral-strong': #52596e;
-  /* Stronger border color for neutral elements (gray.80) */
-  'kui-color-border-neutral-stronger': #3a3f51;
-  /* Strongest border color for neutral elements (gray.90) */
-  'kui-color-border-neutral-strongest': #232633;
-  /* Weak border color for neutral elements (gray.40) */
-  'kui-color-border-neutral-weak': #afb7c5;
-  /* Weaker border color for neutral elements (gray.20) */
-  'kui-color-border-neutral-weaker': #e0e4ea;
-  /* Weakest border color for neutral elements (gray.10) */
-  'kui-color-border-neutral-weakest': #f9fafb;
-  /* Border color for primary actions or messages (blue.60). */
-  'kui-color-border-primary': #0044f4;
-  /* Strong border color for primary actions or messages (blue.70). */
-  'kui-color-border-primary-strong': #0030cc;
-  /* Stronger border color for primary actions or messages (blue.80). */
-  'kui-color-border-primary-stronger': #002099;
-  /* Strongest border color for primary actions or messages (blue.90). */
-  'kui-color-border-primary-strongest': #001466;
-  /* Weak border color for primary actions or messages (blue.40). */
-  'kui-color-border-primary-weak': #5f9aff;
-  /* Weaker border color for primary actions or messages (blue.20). */
-  'kui-color-border-primary-weaker': #bee2ff;
-  /* Weakest border color for primary actions or messages (blue.10). */
-  'kui-color-border-primary-weakest': #eefaff;
-  /* Transparent border color (transparent). */
-  'kui-color-border-transparent': transparent;
-  /* Default text color (blue.100). */
-  'kui-color-text': #000933;
-  /* Text color for danger actions or messages (red.60). */
-  'kui-color-text-danger': #d60027;
-  /* Strong text color for danger actions or messages (red.70). */
-  'kui-color-text-danger-strong': #ad000e;
-  /* Stronger text color for danger actions or messages (red.80). */
-  'kui-color-text-danger-stronger': #850000;
-  /* Strongest text color for danger actions or messages (red.90). */
-  'kui-color-text-danger-strongest': #5c0000;
-  /* Weak text color for danger actions or messages (red.40). */
-  'kui-color-text-danger-weak': #ff3954;
-  /* Weaker text color for danger actions or messages (red.20). */
-  'kui-color-text-danger-weaker': #ffabab;
-  /* Weakest text color for danger actions or messages (red.10). */
-  'kui-color-text-danger-weakest': #ffe5e5;
-  /* Text color for decorative purposes (aqua.50). */
-  'kui-color-text-decorative-aqua': #00abd2;
-  /* Text color for decorative purposes (pink.60). */
-  'kui-color-text-decorative-pink': #d60067;
-  /* Text color for decorative purposes (purple.60). */
-  'kui-color-text-decorative-purple': #6f28ff;
-  /* Strong text color for decorative purposes (purple.70). */
-  'kui-color-text-decorative-purple-strong': #5e00f5;
-  /* Text color for disabled elements (gray.40). */
-  'kui-color-text-disabled': #afb7c5;
-  /* Text color for info elements (blue.60). */
-  'kui-color-text-info': #0044f4;
-  /* Strong text color for info elements (blue.70). */
-  'kui-color-text-info-strong': #0030cc;
-  /* Stronger text color for info elements (blue.80). */
-  'kui-color-text-info-stronger': #002099;
-  /* Strongest text color for info elements (blue.90). */
-  'kui-color-text-info-strongest': #001466;
-  /* Weak text color for info elements (blue.40). */
-  'kui-color-text-info-weak': #5f9aff;
-  /* Weaker text color for info elements (blue.20). */
-  'kui-color-text-info-weaker': #bee2ff;
-  /* Weakest text color for info elements (blue.10). */
-  'kui-color-text-info-weakest': #eefaff;
-  /* Inverse text color (white). */
-  'kui-color-text-inverse': #ffffff;
-  /* Text color for neutral elements (gray.60). */
-  'kui-color-text-neutral': #6c7489;
-  /* Strong text color for neutral elements (gray.70). */
-  'kui-color-text-neutral-strong': #52596e;
-  /* Stronger text color for neutral elements (gray.80). */
-  'kui-color-text-neutral-stronger': #3a3f51;
-  /* Strongest text color for neutral elements (gray.90). */
-  'kui-color-text-neutral-strongest': #232633;
-  /* Weak text color for neutral elements (gray.40). */
-  'kui-color-text-neutral-weak': #afb7c5;
-  /* Weaker text color for neutral elements (gray.20). */
-  'kui-color-text-neutral-weaker': #e0e4ea;
-  /* Weakest text color for neutral elements (gray.10). */
-  'kui-color-text-neutral-weakest': #f9fafb;
-  /* Text color for primary actions or messages (blue.60). */
-  'kui-color-text-primary': #0044f4;
-  /* Strong text color for primary actions or messages (blue.70). */
-  'kui-color-text-primary-strong': #0030cc;
-  /* Stronger text color for primary actions or messages (blue.80). */
-  'kui-color-text-primary-stronger': #002099;
-  /* Strongest text color for primary actions or messages (blue.90). */
-  'kui-color-text-primary-strongest': #001466;
-  /* Weak text color for primary actions or messages (blue.40). */
-  'kui-color-text-primary-weak': #5f9aff;
-  /* Weaker text color for primary actions or messages (blue.20). */
-  'kui-color-text-primary-weaker': #bee2ff;
-  /* Weakest text color for primary actions or messages (blue.10). */
-  'kui-color-text-primary-weakest': #eefaff;
-  /* Text color for success elements (green.60). */
-  'kui-color-text-success': #007d60;
-  /* Strong text color for success elements (green.70). */
-  'kui-color-text-success-strong': #005944;
-  /* Stronger text color for success elements (green.80). */
-  'kui-color-text-success-stronger': #004737;
-  /* Stronger text color for success elements (green.90). */
-  'kui-color-text-success-strongest': #003629;
-  /* Weak text color for success elements (green.40). */
-  'kui-color-text-success-weak': #00d6a4;
-  /* Weaker text color for success elements (green.20). */
-  'kui-color-text-success-weaker': #b5ffee;
-  /* Weakest text color for success elements (green.10). */
-  'kui-color-text-success-weakest': #ecfffb;
-  /* Text color for warning elements (yellow.60). */
-  'kui-color-text-warning': #995c00;
-  /* Strong text color for warning elements (yellow.70). */
-  'kui-color-text-warning-strong': #804400;
-  /* Stronger text color for warning elements (yellow.80). */
-  'kui-color-text-warning-stronger': #662d00;
-  /* Strongest text color for warning elements (yellow.90). */
-  'kui-color-text-warning-strongest': #4d1b00;
-  /* Weak text color for warning elements (yellow.40). */
-  'kui-color-text-warning-weak': #ffc400;
-  /* Weaker text color for warning elements (yellow.20). */
-  'kui-color-text-warning-weaker': #fff296;
-  /* Weakest text color for warning elements (yellow.10). */
-  'kui-color-text-warning-weakest': #fffce0;
-  /* Default transition timing */
-  'kui-animation-duration-20': 0.2s;
-  /* 0px border radius. */
-  'kui-border-radius-0': 0px;
-  /* 2px border radius. */
-  'kui-border-radius-10': 2px;
-  /* 4px border radius. */
-  'kui-border-radius-20': 4px;
-  /* 6px border radius. */
-  'kui-border-radius-30': 6px;
-  /* 8px border radius. */
-  'kui-border-radius-40': 8px;
-  /* 10px border radius. */
-  'kui-border-radius-50': 10px;
-  /* 50% border radius used to create circles. */
-  'kui-border-radius-circle': 50%;
-  /* 100px border radius used to create pill shapes. */
-  'kui-border-radius-round': 100px;
-  /* 0px border width. */
-  'kui-border-width-0': 0px;
-  /* 1px border width. */
-  'kui-border-width-10': 1px;
-  /* 2px border width. */
-  'kui-border-width-20': 2px;
-  /* 4px border width. */
-  'kui-border-width-30': 4px;
-  /* Used for larger mobile screens. Any viewport width under this value is considered mobile. */
-  'kui-breakpoint-mobile': 640px;
-  /* Used for tablet screens. */
-  'kui-breakpoint-phablet': 768px;
-  /* Used for larger tablet screens. Any viewport width less than this value will likely show a mobile layout. Any viewport width this value and greater will likely show a desktop layout. */
-  'kui-breakpoint-tablet': 1024px;
-  /* Used for standard desktop screens. */
-  'kui-breakpoint-laptop': 1280px;
-  /* Used for larger desktop screens. */
-  'kui-breakpoint-desktop': 1536px;
-  /* Danger color for icons. */
-  'kui-icon-color-danger': #f50045;
-  /* Neutral color for icons. */
-  'kui-icon-color-neutral': #828a9e;
-  /* Primary color for icons. */
-  'kui-icon-color-primary': #306fff;
-  /* Success color for icons. */
-  'kui-icon-color-success': #00a17b;
-  /* Warning color for icons. */
-  'kui-icon-color-warning': #ffc400;
-  /* 10px icon size. */
-  'kui-icon-size-10': 10px;
-  /* 12px icon size. */
-  'kui-icon-size-20': 12px;
-  /* 16px icon size. */
-  'kui-icon-size-30': 16px;
-  /* 20px icon size. */
-  'kui-icon-size-40': 20px;
-  /* 24px icon size (default). */
-  'kui-icon-size-50': 24px;
-  /* 32px icon size. */
-  'kui-icon-size-60': 32px;
-  /* 40px icon size. */
-  'kui-icon-size-70': 40px;
-  /* 48px icon size. */
-  'kui-icon-size-80': 48px;
-  /* Background color for the CONNECT method (purple.10). */
-  'kui-method-color-background-connect': #f1f0ff;
-  /* Background color for the DELETE method (red.10). */
-  'kui-method-color-background-delete': #ffe5e5;
-  /* Background color for the GET method (blue.10). */
-  'kui-method-color-background-get': #eefaff;
-  /* Background color for the HEAD method (gray.70). */
-  'kui-method-color-background-head': #52596e;
-  /* Background color for the OPTIONS method (gray.20). */
-  'kui-method-color-background-options': #e0e4ea;
-  /* Background color for the PATCH method (aqua.10). */
-  'kui-method-color-background-patch': #ecfcff;
-  /* Background color for the POST method (green.10). */
-  'kui-method-color-background-post': #ecfffb;
-  /* Background color for the PUT method (yellow.10). */
-  'kui-method-color-background-put': #fffce0;
-  /* Background color for the TRACE method (pink.10). */
-  'kui-method-color-background-trace': #fff0f7;
-  /* Text color for the CONNECT method (purple.60). */
-  'kui-method-color-text-connect': #6f28ff;
-  /* Strong text color for the CONNECT method (purple.70). */
-  'kui-method-color-text-connect-strong': #5e00f5;
-  /* Text color for the DELETE method (red.60). */
-  'kui-method-color-text-delete': #d60027;
-  /* Strong text color for the DELETE method (red.70). */
-  'kui-method-color-text-delete-strong': #ad000e;
-  /* Text color for the GET method (blue.60). */
-  'kui-method-color-text-get': #0044f4;
-  /* Strong text color for the GET method (blue.70). */
-  'kui-method-color-text-get-strong': #0030cc;
-  /* Text color for the HEAD method (gray.20). */
-  'kui-method-color-text-head': #e0e4ea;
-  /* Strong text color for the HEAD method (gray.40). */
-  'kui-method-color-text-head-strong': #afb7c5;
-  /* Text color for the OPTIONS method (gray.70). */
-  'kui-method-color-text-options': #52596e;
-  /* Strong text color for the OPTIONS method (gray.80). */
-  'kui-method-color-text-options-strong': #3a3f51;
-  /* Text color for the PATCH method (aqua.60). */
-  'kui-method-color-text-patch': #00819d;
-  /* Strong text color for the PATCH method (aqua.70). */
-  'kui-method-color-text-patch-strong': #00647a;
-  /* Text color for the POST method (green.60). */
-  'kui-method-color-text-post': #007d60;
-  /* Strong text color for the POST method (green.70). */
-  'kui-method-color-text-post-strong': #005944;
-  /* Text color for the PUT method (yellow.60). */
-  'kui-method-color-text-put': #995c00;
-  /* Strong text color for the PUT method (yellow.70). */
-  'kui-method-color-text-put-strong': #804400;
-  /* Text color for the TRACE method (pink.60). */
-  'kui-method-color-text-trace': #d60067;
-  /* Strong text color for the TRACE method (pink.70). */
-  'kui-method-color-text-trace-strong': #ad0053;
-  /* blue.100 */
-  'kui-navigation-color-background': #000933;
-  /* The background color of a selected navigation item. */
-  'kui-navigation-color-background-selected': rgba(255, 255, 255, 0.12);
-  /* rgba(white, 0.12) */
-  'kui-navigation-color-border': rgba(255, 255, 255, 0.12);
-  /* The border color for a selected child navigation item. */
-  'kui-navigation-color-border-child': #00fabe;
-  /* The color of the navigation section divider. */
-  'kui-navigation-color-border-divider': rgba(255, 255, 255, 0.24);
-  /* Navigation link and icon color. */
-  'kui-navigation-color-text': #bee2ff;
-  /* Navigation link and icon focus-visible color. */
-  'kui-navigation-color-text-focus': #ffffff;
-  /* Navigation link and icon hover color. */
-  'kui-navigation-color-text-hover': #eefaff;
-  /* Navigation link and icon selected color. */
-  'kui-navigation-color-text-selected': #00fabe;
-  /* The box-shadow for a focus-visible navigation link. */
-  'kui-navigation-shadow-border': 0 0 0 1px rgba(255, 255, 255, 0.12) inset;
-  /* The left box-shadow for an active child navigation link. */
-  'kui-navigation-shadow-border-child': 4px 0 0 0 #00fabe inset;
-  /* Navigation link focus-visible box-shadow. */
-  'kui-navigation-shadow-focus': 0 0 0 1px rgba(255, 255, 255, 0.60) inset;
-  /* Color representing response status code 100 (blue.20). */
-  'kui-status-color-100': #bee2ff;
-  /* Color representing response status code 101 (blue.30). */
-  'kui-status-color-101': #8fc1ff;
-  /* Color representing response status code 102 (blue.40). */
-  'kui-status-color-102': #5f9aff;
-  /* Color representing response status code 103 (blue.50). */
-  'kui-status-color-103': #306fff;
-  /* Color representing response status code 200 (green.20). */
-  'kui-status-color-200': #b5ffee;
-  /* Color representing response status code 201 (green.30). */
-  'kui-status-color-201': #00fabe;
-  /* Color representing response status code 202 (green.40). */
-  'kui-status-color-202': #00d6a4;
-  /* Color representing response status code 203 (green.50). */
-  'kui-status-color-203': #00a17b;
-  /* Color representing response status code 204 (green.60). */
-  'kui-status-color-204': #007d60;
-  /* Color representing response status code 205 (green.70). */
-  'kui-status-color-205': #005944;
-  /* Color representing response status code 206 (green.20). */
-  'kui-status-color-206': #b5ffee;
-  /* Color representing response status code 207 (green.30). */
-  'kui-status-color-207': #00fabe;
-  /* Color representing response status code 208 (green.40). */
-  'kui-status-color-208': #b5ffee;
-  /* Color representing response status code 226 (green.50). */
-  'kui-status-color-226': #00a17b;
-  /* Color representing response status code 100 (yellow.20). */
-  'kui-status-color-300': #fff296;
-  /* Color representing response status code 101 (yellow.30). */
-  'kui-status-color-301': #ffe04b;
-  /* Color representing response status code 102 (yellow.40). */
-  'kui-status-color-302': #ffc400;
-  /* Color representing response status code 103 (yellow.50). */
-  'kui-status-color-303': #b37600;
-  /* Color representing response status code 103 (yellow.60). */
-  'kui-status-color-304': #995c00;
-  /* Color representing response status code 103 (yellow.70). */
-  'kui-status-color-305': #804400;
-  /* Color representing response status code 103 (yellow.20). */
-  'kui-status-color-307': #fff296;
-  /* Color representing response status code 103 (yellow.30). */
-  'kui-status-color-308': #ffe04b;
-  /* Color representing response status code 400 (orange.20). */
-  'kui-status-color-400': #FFC2B3;
-  /* Color representing response status code 401 (orange.30). */
-  'kui-status-color-401': #FF9877;
-  /* Color representing response status code 402 (orange.40). */
-  'kui-status-color-402': #FF723C;
-  /* Color representing response status code 403 (orange.50). */
-  'kui-status-color-403': #F75008;
-  /* Color representing response status code 404 (orange.60). */
-  'kui-status-color-404': #D13500;
-  /* Color representing response status code 405 (orange.70). */
-  'kui-status-color-405': #A31F00;
-  /* Color representing response status code 406 (orange.20). */
-  'kui-status-color-406': #FFC2B3;
-  /* Color representing response status code 407 (orange.30). */
-  'kui-status-color-407': #FF9877;
-  /* Color representing response status code 408 (orange.40). */
-  'kui-status-color-408': #FF723C;
-  /* Color representing response status code 409 (orange.50). */
-  'kui-status-color-409': #F75008;
-  /* Color representing response status code 410 (orange.60). */
-  'kui-status-color-410': #D13500;
-  /* Color representing response status code 411 (orange.70). */
-  'kui-status-color-411': #A31F00;
-  /* Color representing response status code 412 (orange.20). */
-  'kui-status-color-412': #FFC2B3;
-  /* Color representing response status code 413 (orange.30). */
-  'kui-status-color-413': #FF9877;
-  /* Color representing response status code 414 (orange.40). */
-  'kui-status-color-414': #FF723C;
-  /* Color representing response status code 415 (orange.50). */
-  'kui-status-color-415': #F75008;
-  /* Color representing response status code 416 (orange.60). */
-  'kui-status-color-416': #D13500;
-  /* Color representing response status code 417 (orange.70). */
-  'kui-status-color-417': #A31F00;
-  /* Color representing response status code 418 (orange.20). */
-  'kui-status-color-418': #FFC2B3;
-  /* Color representing response status code 421 (orange.30). */
-  'kui-status-color-421': #FF9877;
-  /* Color representing response status code 422 (orange.40). */
-  'kui-status-color-422': #FF723C;
-  /* Color representing response status code 423 (orange.50). */
-  'kui-status-color-423': #F75008;
-  /* Color representing response status code 424 (orange.60). */
-  'kui-status-color-424': #D13500;
-  /* Color representing response status code 425 (orange.70). */
-  'kui-status-color-425': #A31F00;
-  /* Color representing response status code 426 (orange.20). */
-  'kui-status-color-426': #FFC2B3;
-  /* Color representing response status code 428 (orange.30). */
-  'kui-status-color-428': #FF9877;
-  /* Color representing response status code 429 (orange.40). */
-  'kui-status-color-429': #FF723C;
-  /* Color representing response status code 431 (orange.50). */
-  'kui-status-color-431': #F75008;
-  /* Color representing response status code 451 (orange.60). */
-  'kui-status-color-451': #D13500;
-  /* Color representing response status code 500 (red.20). */
-  'kui-status-color-500': #ffabab;
-  /* Color representing response status code 501 (red.30). */
-  'kui-status-color-501': #ff7272;
-  /* Color representing response status code 502 (red.40). */
-  'kui-status-color-502': #ff3954;
-  /* Color representing response status code 503 (red.50). */
-  'kui-status-color-503': #f50045;
-  /* Color representing response status code 504 (red.60). */
-  'kui-status-color-504': #d60027;
-  /* Color representing response status code 505 (red.70). */
-  'kui-status-color-505': #ad000e;
-  /* Color representing response status code 506 (red.20). */
-  'kui-status-color-506': #ffabab;
-  /* Color representing response status code 507 (red.30). */
-  'kui-status-color-507': #ff7272;
-  /* Color representing response status code 508 (red.40). */
-  'kui-status-color-508': #ff3954;
-  /* Color representing response status code 510 (red.50). */
-  'kui-status-color-510': #f50045;
-  /* Color representing response status code 511 (red.60). */
-  'kui-status-color-511': #d60027;
-  /* Color for unknown response status codes in the 100-199 range (blue.10). */
-  'kui-status-color-1na': #eefaff;
-  /* Color for unknown response status codes in the 200-299 range (green.10). */
-  'kui-status-color-2na': #ecfffb;
-  /* Color for unknown response status codes in the 300-399 range (yellow.10). */
-  'kui-status-color-3na': #fffce0;
-  /* Color for unknown response status codes in the 400-499 range (orange.10). */
-  'kui-status-color-4na': #FFF1EF;
-  /* Color for unknown response status codes in the 500-599 range (red.10). */
-  'kui-status-color-5na': #ffe5e5;
-  /* Color for a group of response status codes in the 100-199 range (blue.40). */
-  'kui-status-color-100s': #5f9aff;
-  /* Color for a group of response status codes in the 200-299 range (green.40). */
-  'kui-status-color-200s': #00d6a4;
-  /* Color for a group of response status codes in the 300-399 range (yellow.40). */
-  'kui-status-color-300s': #ffc400;
-  /* Color for a group of response status codes in the 400-499 range (orange.40). */
-  'kui-status-color-400s': #FF723C;
-  /* Color for a group of response status codes in the 500-599 range (red.40). */
-  'kui-status-color-500s': #ff3954;
-  /* Background color for http status 100 elements (blue.10). */
-  'kui-status-color-background-100': #eefaff;
-  /* Background color for http status 200 elements (green.10). */
-  'kui-status-color-background-200': #ecfffb;
-  /* Background color for http status 300 elements (yellow.10). */
-  'kui-status-color-background-300': #fffce0;
-  /* Background color for http status 400 elements (orange.10). */
-  'kui-status-color-background-400': #FFF1EF;
-  /* Background color for http status 500 elements (red.10). */
-  'kui-status-color-background-500': #ffe5e5;
-  /* Text color for http status 100 elements (blue.60). */
-  'kui-status-color-text-100': #0044f4;
-  /* Text color for http status 200 elements (green.60). */
-  'kui-status-color-text-200': #007d60;
-  /* Text color for http status 300 elements (yellow.60). */
-  'kui-status-color-text-300': #995c00;
-  /* Text color for http status 400 elements (orange.60). */
-  'kui-status-color-text-400': #D13500;
-  /* Text color for http status 500 elements (red.60). */
-  'kui-status-color-text-500': #d60027;
-  /* The standard monospace text font family. Typically used for code blocks, inline code, and copyable text. */
-  'kui-font-family-code': 'JetBrains Mono', Consolas, monospace;
-  /* The standard heading text font family. */
-  'kui-font-family-heading': 'Inter', Roboto, Helvetica, sans-serif;
-  /* The standard text font family. */
-  'kui-font-family-text': 'Inter', Roboto, Helvetica, sans-serif;
-  'kui-font-size-10': 10px;
-  'kui-font-size-20': 12px;
-  'kui-font-size-30': 14px;
-  'kui-font-size-40': 16px;
-  'kui-font-size-50': 18px;
-  'kui-font-size-60': 20px;
-  'kui-font-size-70': 24px;
-  'kui-font-size-80': 32px;
-  'kui-font-size-90': 40px;
-  'kui-font-size-100': 48px;
-  /* 700: The bold font weight. */
-  'kui-font-weight-bold': 700;
-  /* 500: The medium font weight. */
-  'kui-font-weight-medium': 500;
-  /* 400: The normal font weight. */
-  'kui-font-weight-regular': 400;
-  /* 600: The semibold font weight. */
-  'kui-font-weight-semibold': 600;
-  /* Alias for letter-spacing-normal */
-  'kui-letter-spacing-0': normal;
-  /* -0.12px */
-  'kui-letter-spacing-minus-10': -0.12px;
-  /* -0.24px */
-  'kui-letter-spacing-minus-20': -0.24px;
-  /* -0.32px */
-  'kui-letter-spacing-minus-30': -0.32px;
-  /* -0.4px */
-  'kui-letter-spacing-minus-40': -0.4px;
-  /* -0.48px */
-  'kui-letter-spacing-minus-50': -0.48px;
-  /* normal */
-  'kui-letter-spacing-normal': normal;
-  /* 12px */
-  'kui-line-height-10': 12px;
-  /* 16px */
-  'kui-line-height-20': 16px;
-  /* 20px */
-  'kui-line-height-30': 20px;
-  /* 24px */
-  'kui-line-height-40': 24px;
-  /* 28px */
-  'kui-line-height-50': 28px;
-  /* 32px */
-  'kui-line-height-60': 32px;
-  /* 36px */
-  'kui-line-height-70': 36px;
-  /* 40px */
-  'kui-line-height-80': 40px;
-  /* 48px */
-  'kui-line-height-90': 48px;
-  /* 56px */
-  'kui-line-height-100': 56px;
-  /* 0px 4px 20px 0px rgba(0, 0, 0, 0.08) */
-  'kui-shadow': 0px 4px 20px 0px rgba(0, 0, 0, 0.08);
-  /* 0px 0px 0px 1px gray.20 inset */
-  'kui-shadow-border': 0px 0px 0px 1px #e0e4ea inset;
-  /* 0px 0px 0px 1px red.60 inset */
-  'kui-shadow-border-danger': 0px 0px 0px 1px #d60027 inset;
-  /* 0px 0px 0px 1px red.70 inset */
-  'kui-shadow-border-danger-strong': 0px 0px 0px 1px #ad000e inset;
-  /* 0px 0px 0px 1px gray.20 inset */
-  'kui-shadow-border-disabled': 0px 0px 0px 1px #e0e4ea inset;
-  /* 0px 0px 0px 1px blue.60 inset */
-  'kui-shadow-border-primary': 0px 0px 0px 1px #0044f4 inset;
-  /* 0px 0px 0px 1px blue.90 inset */
-  'kui-shadow-border-primary-strongest': 0px 0px 0px 1px #001466 inset;
-  /* 0px 0px 0px 1px blue.40 inset */
-  'kui-shadow-border-primary-weak': 0px 0px 0px 1px #5f9aff inset;
-  /* 0px 0px 0px 4px rgba(0, 68, 244, 0.2) */
-  'kui-shadow-focus': 0px 0px 0px 4px rgba(0, 68, 244, 0.2);
-  /* 0px value for gaps, margin, or padding. */
-  'kui-space-0': 0px;
-  /* 2px value for gaps, margin, or padding. */
-  'kui-space-10': 2px;
-  /* 4px value for gaps, margin, or padding. */
-  'kui-space-20': 4px;
-  /* 6px value for gaps, margin, or padding. */
-  'kui-space-30': 6px;
-  /* 8px value for gaps, margin, or padding. */
-  'kui-space-40': 8px;
-  /* 12px value for gaps, margin, or padding. */
-  'kui-space-50': 12px;
-  /* 16px value for gaps, margin, or padding. */
-  'kui-space-60': 16px;
-  /* 20px value for gaps, margin, or padding. */
-  'kui-space-70': 20px;
-  /* 24px value for gaps, margin, or padding. */
-  'kui-space-80': 24px;
-  /* 32px value for gaps, margin, or padding. */
-  'kui-space-90': 32px;
-  /* 40px value for gaps, margin, or padding. */
-  'kui-space-100': 40px;
-  /* 48px value for gaps, margin, or padding. */
-  'kui-space-110': 48px;
-  /* 56px value for gaps, margin, or padding. */
-  'kui-space-120': 56px;
-  /* 64px value for gaps, margin, or padding. */
-  'kui-space-130': 64px;
-  /* 80px value for gaps, margin, or padding. */
-  'kui-space-140': 80px;
-  /* 96px value for gaps, margin, or padding. */
-  'kui-space-150': 96px;
-  /* auto */
-  'kui-space-auto': auto;
+  'kui-color-background': ;
+  'kui-color-background-danger': ;
+  'kui-color-background-danger-strong': ;
+  'kui-color-background-danger-stronger': ;
+  'kui-color-background-danger-strongest': ;
+  'kui-color-background-danger-weak': ;
+  'kui-color-background-danger-weaker': ;
+  'kui-color-background-danger-weakest': ;
+  'kui-color-background-decorative-aqua-weakest': ;
+  'kui-color-background-decorative-purple': ;
+  'kui-color-background-decorative-purple-weakest': ;
+  'kui-color-background-disabled': ;
+  'kui-color-background-info': ;
+  'kui-color-background-info-strong': ;
+  'kui-color-background-info-stronger': ;
+  'kui-color-background-info-strongest': ;
+  'kui-color-background-info-weak': ;
+  'kui-color-background-info-weaker': ;
+  'kui-color-background-info-weakest': ;
+  'kui-color-background-inverse': ;
+  'kui-color-background-neutral': ;
+  'kui-color-background-neutral-strong': ;
+  'kui-color-background-neutral-stronger': ;
+  'kui-color-background-neutral-strongest': ;
+  'kui-color-background-neutral-weak': ;
+  'kui-color-background-neutral-weaker': ;
+  'kui-color-background-neutral-weakest': ;
+  'kui-color-background-overlay': ;
+  'kui-color-background-primary': ;
+  'kui-color-background-primary-strong': ;
+  'kui-color-background-primary-stronger': ;
+  'kui-color-background-primary-strongest': ;
+  'kui-color-background-primary-weak': ;
+  'kui-color-background-primary-weaker': ;
+  'kui-color-background-primary-weakest': ;
+  'kui-color-background-success': ;
+  'kui-color-background-success-strong': ;
+  'kui-color-background-success-stronger': ;
+  'kui-color-background-success-strongest': ;
+  'kui-color-background-success-weak': ;
+  'kui-color-background-success-weaker': ;
+  'kui-color-background-success-weakest': ;
+  'kui-color-background-transparent': ;
+  'kui-color-background-warning': ;
+  'kui-color-background-warning-strong': ;
+  'kui-color-background-warning-stronger': ;
+  'kui-color-background-warning-strongest': ;
+  'kui-color-background-warning-weak': ;
+  'kui-color-background-warning-weaker': ;
+  'kui-color-background-warning-weakest': ;
+  'kui-color-border': ;
+  'kui-color-border-danger': ;
+  'kui-color-border-danger-strong': ;
+  'kui-color-border-danger-stronger': ;
+  'kui-color-border-danger-strongest': ;
+  'kui-color-border-danger-weak': ;
+  'kui-color-border-danger-weaker': ;
+  'kui-color-border-danger-weakest': ;
+  'kui-color-border-decorative-purple': ;
+  'kui-color-border-disabled': ;
+  'kui-color-border-inverse': ;
+  'kui-color-border-neutral': ;
+  'kui-color-border-neutral-strong': ;
+  'kui-color-border-neutral-stronger': ;
+  'kui-color-border-neutral-strongest': ;
+  'kui-color-border-neutral-weak': ;
+  'kui-color-border-neutral-weaker': ;
+  'kui-color-border-neutral-weakest': ;
+  'kui-color-border-primary': ;
+  'kui-color-border-primary-strong': ;
+  'kui-color-border-primary-stronger': ;
+  'kui-color-border-primary-strongest': ;
+  'kui-color-border-primary-weak': ;
+  'kui-color-border-primary-weaker': ;
+  'kui-color-border-primary-weakest': ;
+  'kui-color-border-transparent': ;
+  'kui-color-text': ;
+  'kui-color-text-danger': ;
+  'kui-color-text-danger-strong': ;
+  'kui-color-text-danger-stronger': ;
+  'kui-color-text-danger-strongest': ;
+  'kui-color-text-danger-weak': ;
+  'kui-color-text-danger-weaker': ;
+  'kui-color-text-danger-weakest': ;
+  'kui-color-text-decorative-aqua': ;
+  'kui-color-text-decorative-pink': ;
+  'kui-color-text-decorative-purple': ;
+  'kui-color-text-decorative-purple-strong': ;
+  'kui-color-text-disabled': ;
+  'kui-color-text-info': ;
+  'kui-color-text-info-strong': ;
+  'kui-color-text-info-stronger': ;
+  'kui-color-text-info-strongest': ;
+  'kui-color-text-info-weak': ;
+  'kui-color-text-info-weaker': ;
+  'kui-color-text-info-weakest': ;
+  'kui-color-text-inverse': ;
+  'kui-color-text-neutral': ;
+  'kui-color-text-neutral-strong': ;
+  'kui-color-text-neutral-stronger': ;
+  'kui-color-text-neutral-strongest': ;
+  'kui-color-text-neutral-weak': ;
+  'kui-color-text-neutral-weaker': ;
+  'kui-color-text-neutral-weakest': ;
+  'kui-color-text-primary': ;
+  'kui-color-text-primary-strong': ;
+  'kui-color-text-primary-stronger': ;
+  'kui-color-text-primary-strongest': ;
+  'kui-color-text-primary-weak': ;
+  'kui-color-text-primary-weaker': ;
+  'kui-color-text-primary-weakest': ;
+  'kui-color-text-success': ;
+  'kui-color-text-success-strong': ;
+  'kui-color-text-success-stronger': ;
+  'kui-color-text-success-strongest': ;
+  'kui-color-text-success-weak': ;
+  'kui-color-text-success-weaker': ;
+  'kui-color-text-success-weakest': ;
+  'kui-color-text-warning': ;
+  'kui-color-text-warning-strong': ;
+  'kui-color-text-warning-stronger': ;
+  'kui-color-text-warning-strongest': ;
+  'kui-color-text-warning-weak': ;
+  'kui-color-text-warning-weaker': ;
+  'kui-color-text-warning-weakest': ;
+  'kui-animation-duration-20': ;
+  'kui-border-radius-0': ;
+  'kui-border-radius-10': ;
+  'kui-border-radius-20': ;
+  'kui-border-radius-30': ;
+  'kui-border-radius-40': ;
+  'kui-border-radius-50': ;
+  'kui-border-radius-circle': ;
+  'kui-border-radius-round': ;
+  'kui-border-width-0': ;
+  'kui-border-width-10': ;
+  'kui-border-width-20': ;
+  'kui-border-width-30': ;
+  'kui-breakpoint-mobile': ;
+  'kui-breakpoint-phablet': ;
+  'kui-breakpoint-tablet': ;
+  'kui-breakpoint-laptop': ;
+  'kui-breakpoint-desktop': ;
+  'kui-icon-color-danger': ;
+  'kui-icon-color-neutral': ;
+  'kui-icon-color-primary': ;
+  'kui-icon-color-success': ;
+  'kui-icon-color-warning': ;
+  'kui-icon-size-10': ;
+  'kui-icon-size-20': ;
+  'kui-icon-size-30': ;
+  'kui-icon-size-40': ;
+  'kui-icon-size-50': ;
+  'kui-icon-size-60': ;
+  'kui-icon-size-70': ;
+  'kui-icon-size-80': ;
+  'kui-method-color-background-connect': ;
+  'kui-method-color-background-delete': ;
+  'kui-method-color-background-get': ;
+  'kui-method-color-background-head': ;
+  'kui-method-color-background-options': ;
+  'kui-method-color-background-patch': ;
+  'kui-method-color-background-post': ;
+  'kui-method-color-background-put': ;
+  'kui-method-color-background-trace': ;
+  'kui-method-color-text-connect': ;
+  'kui-method-color-text-connect-strong': ;
+  'kui-method-color-text-delete': ;
+  'kui-method-color-text-delete-strong': ;
+  'kui-method-color-text-get': ;
+  'kui-method-color-text-get-strong': ;
+  'kui-method-color-text-head': ;
+  'kui-method-color-text-head-strong': ;
+  'kui-method-color-text-options': ;
+  'kui-method-color-text-options-strong': ;
+  'kui-method-color-text-patch': ;
+  'kui-method-color-text-patch-strong': ;
+  'kui-method-color-text-post': ;
+  'kui-method-color-text-post-strong': ;
+  'kui-method-color-text-put': ;
+  'kui-method-color-text-put-strong': ;
+  'kui-method-color-text-trace': ;
+  'kui-method-color-text-trace-strong': ;
+  'kui-navigation-color-background': ;
+  'kui-navigation-color-background-selected': ;
+  'kui-navigation-color-border': ;
+  'kui-navigation-color-border-child': ;
+  'kui-navigation-color-border-divider': ;
+  'kui-navigation-color-text': ;
+  'kui-navigation-color-text-focus': ;
+  'kui-navigation-color-text-hover': ;
+  'kui-navigation-color-text-selected': ;
+  'kui-navigation-shadow-border': ;
+  'kui-navigation-shadow-border-child': ;
+  'kui-navigation-shadow-focus': ;
+  'kui-status-color-100': ;
+  'kui-status-color-101': ;
+  'kui-status-color-102': ;
+  'kui-status-color-103': ;
+  'kui-status-color-200': ;
+  'kui-status-color-201': ;
+  'kui-status-color-202': ;
+  'kui-status-color-203': ;
+  'kui-status-color-204': ;
+  'kui-status-color-205': ;
+  'kui-status-color-206': ;
+  'kui-status-color-207': ;
+  'kui-status-color-208': ;
+  'kui-status-color-226': ;
+  'kui-status-color-300': ;
+  'kui-status-color-301': ;
+  'kui-status-color-302': ;
+  'kui-status-color-303': ;
+  'kui-status-color-304': ;
+  'kui-status-color-305': ;
+  'kui-status-color-307': ;
+  'kui-status-color-308': ;
+  'kui-status-color-400': ;
+  'kui-status-color-401': ;
+  'kui-status-color-402': ;
+  'kui-status-color-403': ;
+  'kui-status-color-404': ;
+  'kui-status-color-405': ;
+  'kui-status-color-406': ;
+  'kui-status-color-407': ;
+  'kui-status-color-408': ;
+  'kui-status-color-409': ;
+  'kui-status-color-410': ;
+  'kui-status-color-411': ;
+  'kui-status-color-412': ;
+  'kui-status-color-413': ;
+  'kui-status-color-414': ;
+  'kui-status-color-415': ;
+  'kui-status-color-416': ;
+  'kui-status-color-417': ;
+  'kui-status-color-418': ;
+  'kui-status-color-421': ;
+  'kui-status-color-422': ;
+  'kui-status-color-423': ;
+  'kui-status-color-424': ;
+  'kui-status-color-425': ;
+  'kui-status-color-426': ;
+  'kui-status-color-428': ;
+  'kui-status-color-429': ;
+  'kui-status-color-431': ;
+  'kui-status-color-451': ;
+  'kui-status-color-500': ;
+  'kui-status-color-501': ;
+  'kui-status-color-502': ;
+  'kui-status-color-503': ;
+  'kui-status-color-504': ;
+  'kui-status-color-505': ;
+  'kui-status-color-506': ;
+  'kui-status-color-507': ;
+  'kui-status-color-508': ;
+  'kui-status-color-510': ;
+  'kui-status-color-511': ;
+  'kui-status-color-1na': ;
+  'kui-status-color-2na': ;
+  'kui-status-color-3na': ;
+  'kui-status-color-4na': ;
+  'kui-status-color-5na': ;
+  'kui-status-color-100s': ;
+  'kui-status-color-200s': ;
+  'kui-status-color-300s': ;
+  'kui-status-color-400s': ;
+  'kui-status-color-500s': ;
+  'kui-status-color-background-100': ;
+  'kui-status-color-background-200': ;
+  'kui-status-color-background-300': ;
+  'kui-status-color-background-400': ;
+  'kui-status-color-background-500': ;
+  'kui-status-color-text-100': ;
+  'kui-status-color-text-200': ;
+  'kui-status-color-text-300': ;
+  'kui-status-color-text-400': ;
+  'kui-status-color-text-500': ;
+  'kui-font-family-code': ;
+  'kui-font-family-heading': ;
+  'kui-font-family-text': ;
+  'kui-font-size-10': ;
+  'kui-font-size-20': ;
+  'kui-font-size-30': ;
+  'kui-font-size-40': ;
+  'kui-font-size-50': ;
+  'kui-font-size-60': ;
+  'kui-font-size-70': ;
+  'kui-font-size-80': ;
+  'kui-font-size-90': ;
+  'kui-font-size-100': ;
+  'kui-font-weight-bold': ;
+  'kui-font-weight-medium': ;
+  'kui-font-weight-regular': ;
+  'kui-font-weight-semibold': ;
+  'kui-letter-spacing-0': ;
+  'kui-letter-spacing-minus-10': ;
+  'kui-letter-spacing-minus-20': ;
+  'kui-letter-spacing-minus-30': ;
+  'kui-letter-spacing-minus-40': ;
+  'kui-letter-spacing-minus-50': ;
+  'kui-letter-spacing-normal': ;
+  'kui-line-height-10': ;
+  'kui-line-height-20': ;
+  'kui-line-height-30': ;
+  'kui-line-height-40': ;
+  'kui-line-height-50': ;
+  'kui-line-height-60': ;
+  'kui-line-height-70': ;
+  'kui-line-height-80': ;
+  'kui-line-height-90': ;
+  'kui-line-height-100': ;
+  'kui-shadow': ;
+  'kui-shadow-border': ;
+  'kui-shadow-border-danger': ;
+  'kui-shadow-border-danger-strong': ;
+  'kui-shadow-border-disabled': ;
+  'kui-shadow-border-primary': ;
+  'kui-shadow-border-primary-strongest': ;
+  'kui-shadow-border-primary-weak': ;
+  'kui-shadow-focus': ;
+  'kui-space-0': ;
+  'kui-space-10': ;
+  'kui-space-20': ;
+  'kui-space-30': ;
+  'kui-space-40': ;
+  'kui-space-50': ;
+  'kui-space-60': ;
+  'kui-space-70': ;
+  'kui-space-80': ;
+  'kui-space-90': ;
+  'kui-space-100': ;
+  'kui-space-110': ;
+  'kui-space-120': ;
+  'kui-space-130': ;
+  'kui-space-140': ;
+  'kui-space-150': ;
+  'kui-space-auto': ;
 );
 ```
 
@@ -1372,670 +718,343 @@ $tokens-map: (
 <summary>Click to view the list of LESS variables</summary>
 
 ```less
-/* Default background color for containers (white). */
-@kui-color-background: #ffffff;
-/* Background color for danger actions or messages (red.60). */
-@kui-color-background-danger: #d60027;
-/* Strong background color for danger actions or messages (red.70). */
-@kui-color-background-danger-strong: #ad000e;
-/* Stronger background color for danger actions or messages (red.80). */
-@kui-color-background-danger-stronger: #850000;
-/* Strongest background color for danger actions or messages (red.90). */
-@kui-color-background-danger-strongest: #5c0000;
-/* Weak background color for danger actions or messages (red.40). */
-@kui-color-background-danger-weak: #ff3954;
-/* Weaker background color for danger actions or messages (red.20). */
-@kui-color-background-danger-weaker: #ffabab;
-/* Weakest background color for danger actions or messages (red.10). */
-@kui-color-background-danger-weakest: #ffe5e5;
-/* Weakest background color for decorative purposes (aqua.10). */
-@kui-color-background-decorative-aqua-weakest: #ecfcff;
-/* Background color for decorative purposes (purple.60). */
-@kui-color-background-decorative-purple: #6f28ff;
-/* Weakest background color for decorative purposes (purple.10). */
-@kui-color-background-decorative-purple-weakest: #f1f0ff;
-/* Background color for disabled elements (gray.20). */
-@kui-color-background-disabled: #e0e4ea;
-/* Background color for info elements (blue.60). */
-@kui-color-background-info: #0044f4;
-/* Strong background color for info elements (blue.70). */
-@kui-color-background-info-strong: #0030cc;
-/* Stronger background color for info elements (blue.80). */
-@kui-color-background-info-stronger: #002099;
-/* Strongest background color for info elements (blue.90). */
-@kui-color-background-info-strongest: #001466;
-/* Weak background color for info elements (blue.40). */
-@kui-color-background-info-weak: #5f9aff;
-/* Weaker background color for info elements (blue.20). */
-@kui-color-background-info-weaker: #bee2ff;
-/* Weakest background color for info elements (blue.10). */
-@kui-color-background-info-weakest: #eefaff;
-/* Inverse background color for containers (blue.100) */
-@kui-color-background-inverse: #000933;
-/* Background color for neutral elements (gray.60). */
-@kui-color-background-neutral: #6c7489;
-/* Strong background color for neutral elements (gray.70). */
-@kui-color-background-neutral-strong: #52596e;
-/* Stronger background color for neutral elements (gray.80). */
-@kui-color-background-neutral-stronger: #3a3f51;
-/* Strongest background color for neutral elements (gray.90). */
-@kui-color-background-neutral-strongest: #232633;
-/* Weak background color for neutral elements (gray.40). */
-@kui-color-background-neutral-weak: #afb7c5;
-/* Weaker background color for neutral elements (gray.20). */
-@kui-color-background-neutral-weaker: #e0e4ea;
-/* Weakest background color for neutral elements (gray.10). */
-@kui-color-background-neutral-weakest: #f9fafb;
-/* Overlay background color (rgba(blue.100, 0.6)) */
-@kui-color-background-overlay: rgba(0, 9, 51, 0.6);
-/* Background color for primary actions or messages (blue.60). */
-@kui-color-background-primary: #0044f4;
-/* Strong background color for primary actions or messages (blue.70). */
-@kui-color-background-primary-strong: #0030cc;
-/* Stronger background color for primary actions or messages (blue.80). */
-@kui-color-background-primary-stronger: #002099;
-/* Strongest background color for primary actions or messages (blue.90). */
-@kui-color-background-primary-strongest: #001466;
-/* Weak background color for primary actions or messages (blue.40). */
-@kui-color-background-primary-weak: #5f9aff;
-/* Weaker background color for primary actions or messages (blue.20). */
-@kui-color-background-primary-weaker: #bee2ff;
-/* Weakest background color for primary actions or messages (blue.10) */
-@kui-color-background-primary-weakest: #eefaff;
-/* Background color for success elements (green.60). */
-@kui-color-background-success: #007d60;
-/* Strong background color for success elements (green.70). */
-@kui-color-background-success-strong: #005944;
-/* Stronger background color for success elements (green.80). */
-@kui-color-background-success-stronger: #004737;
-/* Strongest background color for success elements (green.90). */
-@kui-color-background-success-strongest: #003629;
-/* Weak background color for success elements (green.40). */
-@kui-color-background-success-weak: #00d6a4;
-/* Weaker background color for success elements (green.20). */
-@kui-color-background-success-weaker: #b5ffee;
-/* Weakest background color for success elements (green.10). */
-@kui-color-background-success-weakest: #ecfffb;
-/* Transparent background color (transparent). */
-@kui-color-background-transparent: transparent;
-/* Background color for warning elements (yellow.60). */
-@kui-color-background-warning: #995c00;
-/* Strong background color for warning elements (yellow.70). */
-@kui-color-background-warning-strong: #804400;
-/* Stronger background color for warning elements (yellow.80). */
-@kui-color-background-warning-stronger: #662d00;
-/* Strongest background color for warning elements (yellow.90). */
-@kui-color-background-warning-strongest: #4d1b00;
-/* Weak background color for warning elements (yellow.40). */
-@kui-color-background-warning-weak: #ffc400;
-/* Weaker background color for warning elements (yellow.20). */
-@kui-color-background-warning-weaker: #fff296;
-/* Weakest background color for warning elements (yellow.10). */
-@kui-color-background-warning-weakest: #fffce0;
-/* Default border color for containers (gray.20). */
-@kui-color-border: #e0e4ea;
-/* Border color for danger actions or messages (red.60). */
-@kui-color-border-danger: #d60027;
-/* Strong border color for danger actions or messages (red.70). */
-@kui-color-border-danger-strong: #ad000e;
-/* Stronger border color for danger actions or messages (red.80). */
-@kui-color-border-danger-stronger: #850000;
-/* Strongest border color for danger actions or messages (red.90). */
-@kui-color-border-danger-strongest: #5c0000;
-/* Weak border color for danger actions or messages (red.40). */
-@kui-color-border-danger-weak: #ff3954;
-/* Weaker border color for danger actions or messages (red.20). */
-@kui-color-border-danger-weaker: #ffabab;
-/* Weakest border color for danger actions or messages (red.10). */
-@kui-color-border-danger-weakest: #ffe5e5;
-/* Border color for decorative purposes (purple.60). */
-@kui-color-border-decorative-purple: #6f28ff;
-/* Border color for disabled elements (gray.20). */
-@kui-color-border-disabled: #e0e4ea;
-/* Inverse border color (rgba(white, 0.2)). */
-@kui-color-border-inverse: rgba(255, 255, 255, 0.2);
-/* Border color for neutral elements (gray.60) */
-@kui-color-border-neutral: #6c7489;
-/* Strong border color for neutral elements (gray.70) */
-@kui-color-border-neutral-strong: #52596e;
-/* Stronger border color for neutral elements (gray.80) */
-@kui-color-border-neutral-stronger: #3a3f51;
-/* Strongest border color for neutral elements (gray.90) */
-@kui-color-border-neutral-strongest: #232633;
-/* Weak border color for neutral elements (gray.40) */
-@kui-color-border-neutral-weak: #afb7c5;
-/* Weaker border color for neutral elements (gray.20) */
-@kui-color-border-neutral-weaker: #e0e4ea;
-/* Weakest border color for neutral elements (gray.10) */
-@kui-color-border-neutral-weakest: #f9fafb;
-/* Border color for primary actions or messages (blue.60). */
-@kui-color-border-primary: #0044f4;
-/* Strong border color for primary actions or messages (blue.70). */
-@kui-color-border-primary-strong: #0030cc;
-/* Stronger border color for primary actions or messages (blue.80). */
-@kui-color-border-primary-stronger: #002099;
-/* Strongest border color for primary actions or messages (blue.90). */
-@kui-color-border-primary-strongest: #001466;
-/* Weak border color for primary actions or messages (blue.40). */
-@kui-color-border-primary-weak: #5f9aff;
-/* Weaker border color for primary actions or messages (blue.20). */
-@kui-color-border-primary-weaker: #bee2ff;
-/* Weakest border color for primary actions or messages (blue.10). */
-@kui-color-border-primary-weakest: #eefaff;
-/* Transparent border color (transparent). */
-@kui-color-border-transparent: transparent;
-/* Default text color (blue.100). */
-@kui-color-text: #000933;
-/* Text color for danger actions or messages (red.60). */
-@kui-color-text-danger: #d60027;
-/* Strong text color for danger actions or messages (red.70). */
-@kui-color-text-danger-strong: #ad000e;
-/* Stronger text color for danger actions or messages (red.80). */
-@kui-color-text-danger-stronger: #850000;
-/* Strongest text color for danger actions or messages (red.90). */
-@kui-color-text-danger-strongest: #5c0000;
-/* Weak text color for danger actions or messages (red.40). */
-@kui-color-text-danger-weak: #ff3954;
-/* Weaker text color for danger actions or messages (red.20). */
-@kui-color-text-danger-weaker: #ffabab;
-/* Weakest text color for danger actions or messages (red.10). */
-@kui-color-text-danger-weakest: #ffe5e5;
-/* Text color for decorative purposes (aqua.50). */
-@kui-color-text-decorative-aqua: #00abd2;
-/* Text color for decorative purposes (pink.60). */
-@kui-color-text-decorative-pink: #d60067;
-/* Text color for decorative purposes (purple.60). */
-@kui-color-text-decorative-purple: #6f28ff;
-/* Strong text color for decorative purposes (purple.70). */
-@kui-color-text-decorative-purple-strong: #5e00f5;
-/* Text color for disabled elements (gray.40). */
-@kui-color-text-disabled: #afb7c5;
-/* Text color for info elements (blue.60). */
-@kui-color-text-info: #0044f4;
-/* Strong text color for info elements (blue.70). */
-@kui-color-text-info-strong: #0030cc;
-/* Stronger text color for info elements (blue.80). */
-@kui-color-text-info-stronger: #002099;
-/* Strongest text color for info elements (blue.90). */
-@kui-color-text-info-strongest: #001466;
-/* Weak text color for info elements (blue.40). */
-@kui-color-text-info-weak: #5f9aff;
-/* Weaker text color for info elements (blue.20). */
-@kui-color-text-info-weaker: #bee2ff;
-/* Weakest text color for info elements (blue.10). */
-@kui-color-text-info-weakest: #eefaff;
-/* Inverse text color (white). */
-@kui-color-text-inverse: #ffffff;
-/* Text color for neutral elements (gray.60). */
-@kui-color-text-neutral: #6c7489;
-/* Strong text color for neutral elements (gray.70). */
-@kui-color-text-neutral-strong: #52596e;
-/* Stronger text color for neutral elements (gray.80). */
-@kui-color-text-neutral-stronger: #3a3f51;
-/* Strongest text color for neutral elements (gray.90). */
-@kui-color-text-neutral-strongest: #232633;
-/* Weak text color for neutral elements (gray.40). */
-@kui-color-text-neutral-weak: #afb7c5;
-/* Weaker text color for neutral elements (gray.20). */
-@kui-color-text-neutral-weaker: #e0e4ea;
-/* Weakest text color for neutral elements (gray.10). */
-@kui-color-text-neutral-weakest: #f9fafb;
-/* Text color for primary actions or messages (blue.60). */
-@kui-color-text-primary: #0044f4;
-/* Strong text color for primary actions or messages (blue.70). */
-@kui-color-text-primary-strong: #0030cc;
-/* Stronger text color for primary actions or messages (blue.80). */
-@kui-color-text-primary-stronger: #002099;
-/* Strongest text color for primary actions or messages (blue.90). */
-@kui-color-text-primary-strongest: #001466;
-/* Weak text color for primary actions or messages (blue.40). */
-@kui-color-text-primary-weak: #5f9aff;
-/* Weaker text color for primary actions or messages (blue.20). */
-@kui-color-text-primary-weaker: #bee2ff;
-/* Weakest text color for primary actions or messages (blue.10). */
-@kui-color-text-primary-weakest: #eefaff;
-/* Text color for success elements (green.60). */
-@kui-color-text-success: #007d60;
-/* Strong text color for success elements (green.70). */
-@kui-color-text-success-strong: #005944;
-/* Stronger text color for success elements (green.80). */
-@kui-color-text-success-stronger: #004737;
-/* Stronger text color for success elements (green.90). */
-@kui-color-text-success-strongest: #003629;
-/* Weak text color for success elements (green.40). */
-@kui-color-text-success-weak: #00d6a4;
-/* Weaker text color for success elements (green.20). */
-@kui-color-text-success-weaker: #b5ffee;
-/* Weakest text color for success elements (green.10). */
-@kui-color-text-success-weakest: #ecfffb;
-/* Text color for warning elements (yellow.60). */
-@kui-color-text-warning: #995c00;
-/* Strong text color for warning elements (yellow.70). */
-@kui-color-text-warning-strong: #804400;
-/* Stronger text color for warning elements (yellow.80). */
-@kui-color-text-warning-stronger: #662d00;
-/* Strongest text color for warning elements (yellow.90). */
-@kui-color-text-warning-strongest: #4d1b00;
-/* Weak text color for warning elements (yellow.40). */
-@kui-color-text-warning-weak: #ffc400;
-/* Weaker text color for warning elements (yellow.20). */
-@kui-color-text-warning-weaker: #fff296;
-/* Weakest text color for warning elements (yellow.10). */
-@kui-color-text-warning-weakest: #fffce0;
-/* Default transition timing */
-@kui-animation-duration-20: 0.2s;
-/* 0px border radius. */
-@kui-border-radius-0: 0px;
-/* 2px border radius. */
-@kui-border-radius-10: 2px;
-/* 4px border radius. */
-@kui-border-radius-20: 4px;
-/* 6px border radius. */
-@kui-border-radius-30: 6px;
-/* 8px border radius. */
-@kui-border-radius-40: 8px;
-/* 10px border radius. */
-@kui-border-radius-50: 10px;
-/* 50% border radius used to create circles. */
-@kui-border-radius-circle: 50%;
-/* 100px border radius used to create pill shapes. */
-@kui-border-radius-round: 100px;
-/* 0px border width. */
-@kui-border-width-0: 0px;
-/* 1px border width. */
-@kui-border-width-10: 1px;
-/* 2px border width. */
-@kui-border-width-20: 2px;
-/* 4px border width. */
-@kui-border-width-30: 4px;
-/* Used for larger mobile screens. Any viewport width under this value is considered mobile. */
-@kui-breakpoint-mobile: 640px;
-/* Used for tablet screens. */
-@kui-breakpoint-phablet: 768px;
-/* Used for larger tablet screens. Any viewport width less than this value will likely show a mobile layout. Any viewport width this value and greater will likely show a desktop layout. */
-@kui-breakpoint-tablet: 1024px;
-/* Used for standard desktop screens. */
-@kui-breakpoint-laptop: 1280px;
-/* Used for larger desktop screens. */
-@kui-breakpoint-desktop: 1536px;
-/* Danger color for icons. */
-@kui-icon-color-danger: #f50045;
-/* Neutral color for icons. */
-@kui-icon-color-neutral: #828a9e;
-/* Primary color for icons. */
-@kui-icon-color-primary: #306fff;
-/* Success color for icons. */
-@kui-icon-color-success: #00a17b;
-/* Warning color for icons. */
-@kui-icon-color-warning: #ffc400;
-/* 10px icon size. */
-@kui-icon-size-10: 10px;
-/* 12px icon size. */
-@kui-icon-size-20: 12px;
-/* 16px icon size. */
-@kui-icon-size-30: 16px;
-/* 20px icon size. */
-@kui-icon-size-40: 20px;
-/* 24px icon size (default). */
-@kui-icon-size-50: 24px;
-/* 32px icon size. */
-@kui-icon-size-60: 32px;
-/* 40px icon size. */
-@kui-icon-size-70: 40px;
-/* 48px icon size. */
-@kui-icon-size-80: 48px;
-/* Background color for the CONNECT method (purple.10). */
-@kui-method-color-background-connect: #f1f0ff;
-/* Background color for the DELETE method (red.10). */
-@kui-method-color-background-delete: #ffe5e5;
-/* Background color for the GET method (blue.10). */
-@kui-method-color-background-get: #eefaff;
-/* Background color for the HEAD method (gray.70). */
-@kui-method-color-background-head: #52596e;
-/* Background color for the OPTIONS method (gray.20). */
-@kui-method-color-background-options: #e0e4ea;
-/* Background color for the PATCH method (aqua.10). */
-@kui-method-color-background-patch: #ecfcff;
-/* Background color for the POST method (green.10). */
-@kui-method-color-background-post: #ecfffb;
-/* Background color for the PUT method (yellow.10). */
-@kui-method-color-background-put: #fffce0;
-/* Background color for the TRACE method (pink.10). */
-@kui-method-color-background-trace: #fff0f7;
-/* Text color for the CONNECT method (purple.60). */
-@kui-method-color-text-connect: #6f28ff;
-/* Strong text color for the CONNECT method (purple.70). */
-@kui-method-color-text-connect-strong: #5e00f5;
-/* Text color for the DELETE method (red.60). */
-@kui-method-color-text-delete: #d60027;
-/* Strong text color for the DELETE method (red.70). */
-@kui-method-color-text-delete-strong: #ad000e;
-/* Text color for the GET method (blue.60). */
-@kui-method-color-text-get: #0044f4;
-/* Strong text color for the GET method (blue.70). */
-@kui-method-color-text-get-strong: #0030cc;
-/* Text color for the HEAD method (gray.20). */
-@kui-method-color-text-head: #e0e4ea;
-/* Strong text color for the HEAD method (gray.40). */
-@kui-method-color-text-head-strong: #afb7c5;
-/* Text color for the OPTIONS method (gray.70). */
-@kui-method-color-text-options: #52596e;
-/* Strong text color for the OPTIONS method (gray.80). */
-@kui-method-color-text-options-strong: #3a3f51;
-/* Text color for the PATCH method (aqua.60). */
-@kui-method-color-text-patch: #00819d;
-/* Strong text color for the PATCH method (aqua.70). */
-@kui-method-color-text-patch-strong: #00647a;
-/* Text color for the POST method (green.60). */
-@kui-method-color-text-post: #007d60;
-/* Strong text color for the POST method (green.70). */
-@kui-method-color-text-post-strong: #005944;
-/* Text color for the PUT method (yellow.60). */
-@kui-method-color-text-put: #995c00;
-/* Strong text color for the PUT method (yellow.70). */
-@kui-method-color-text-put-strong: #804400;
-/* Text color for the TRACE method (pink.60). */
-@kui-method-color-text-trace: #d60067;
-/* Strong text color for the TRACE method (pink.70). */
-@kui-method-color-text-trace-strong: #ad0053;
-/* blue.100 */
-@kui-navigation-color-background: #000933;
-/* The background color of a selected navigation item. */
-@kui-navigation-color-background-selected: rgba(255, 255, 255, 0.12);
-/* rgba(white, 0.12) */
-@kui-navigation-color-border: rgba(255, 255, 255, 0.12);
-/* The border color for a selected child navigation item. */
-@kui-navigation-color-border-child: #00fabe;
-/* The color of the navigation section divider. */
-@kui-navigation-color-border-divider: rgba(255, 255, 255, 0.24);
-/* Navigation link and icon color. */
-@kui-navigation-color-text: #bee2ff;
-/* Navigation link and icon focus-visible color. */
-@kui-navigation-color-text-focus: #ffffff;
-/* Navigation link and icon hover color. */
-@kui-navigation-color-text-hover: #eefaff;
-/* Navigation link and icon selected color. */
-@kui-navigation-color-text-selected: #00fabe;
-/* The box-shadow for a focus-visible navigation link. */
-@kui-navigation-shadow-border: 0 0 0 1px rgba(255, 255, 255, 0.12) inset;
-/* The left box-shadow for an active child navigation link. */
-@kui-navigation-shadow-border-child: 4px 0 0 0 #00fabe inset;
-/* Navigation link focus-visible box-shadow. */
-@kui-navigation-shadow-focus: 0 0 0 1px rgba(255, 255, 255, 0.60) inset;
-/* Color representing response status code 100 (blue.20). */
-@kui-status-color-100: #bee2ff;
-/* Color representing response status code 101 (blue.30). */
-@kui-status-color-101: #8fc1ff;
-/* Color representing response status code 102 (blue.40). */
-@kui-status-color-102: #5f9aff;
-/* Color representing response status code 103 (blue.50). */
-@kui-status-color-103: #306fff;
-/* Color representing response status code 200 (green.20). */
-@kui-status-color-200: #b5ffee;
-/* Color representing response status code 201 (green.30). */
-@kui-status-color-201: #00fabe;
-/* Color representing response status code 202 (green.40). */
-@kui-status-color-202: #00d6a4;
-/* Color representing response status code 203 (green.50). */
-@kui-status-color-203: #00a17b;
-/* Color representing response status code 204 (green.60). */
-@kui-status-color-204: #007d60;
-/* Color representing response status code 205 (green.70). */
-@kui-status-color-205: #005944;
-/* Color representing response status code 206 (green.20). */
-@kui-status-color-206: #b5ffee;
-/* Color representing response status code 207 (green.30). */
-@kui-status-color-207: #00fabe;
-/* Color representing response status code 208 (green.40). */
-@kui-status-color-208: #b5ffee;
-/* Color representing response status code 226 (green.50). */
-@kui-status-color-226: #00a17b;
-/* Color representing response status code 100 (yellow.20). */
-@kui-status-color-300: #fff296;
-/* Color representing response status code 101 (yellow.30). */
-@kui-status-color-301: #ffe04b;
-/* Color representing response status code 102 (yellow.40). */
-@kui-status-color-302: #ffc400;
-/* Color representing response status code 103 (yellow.50). */
-@kui-status-color-303: #b37600;
-/* Color representing response status code 103 (yellow.60). */
-@kui-status-color-304: #995c00;
-/* Color representing response status code 103 (yellow.70). */
-@kui-status-color-305: #804400;
-/* Color representing response status code 103 (yellow.20). */
-@kui-status-color-307: #fff296;
-/* Color representing response status code 103 (yellow.30). */
-@kui-status-color-308: #ffe04b;
-/* Color representing response status code 400 (orange.20). */
-@kui-status-color-400: #FFC2B3;
-/* Color representing response status code 401 (orange.30). */
-@kui-status-color-401: #FF9877;
-/* Color representing response status code 402 (orange.40). */
-@kui-status-color-402: #FF723C;
-/* Color representing response status code 403 (orange.50). */
-@kui-status-color-403: #F75008;
-/* Color representing response status code 404 (orange.60). */
-@kui-status-color-404: #D13500;
-/* Color representing response status code 405 (orange.70). */
-@kui-status-color-405: #A31F00;
-/* Color representing response status code 406 (orange.20). */
-@kui-status-color-406: #FFC2B3;
-/* Color representing response status code 407 (orange.30). */
-@kui-status-color-407: #FF9877;
-/* Color representing response status code 408 (orange.40). */
-@kui-status-color-408: #FF723C;
-/* Color representing response status code 409 (orange.50). */
-@kui-status-color-409: #F75008;
-/* Color representing response status code 410 (orange.60). */
-@kui-status-color-410: #D13500;
-/* Color representing response status code 411 (orange.70). */
-@kui-status-color-411: #A31F00;
-/* Color representing response status code 412 (orange.20). */
-@kui-status-color-412: #FFC2B3;
-/* Color representing response status code 413 (orange.30). */
-@kui-status-color-413: #FF9877;
-/* Color representing response status code 414 (orange.40). */
-@kui-status-color-414: #FF723C;
-/* Color representing response status code 415 (orange.50). */
-@kui-status-color-415: #F75008;
-/* Color representing response status code 416 (orange.60). */
-@kui-status-color-416: #D13500;
-/* Color representing response status code 417 (orange.70). */
-@kui-status-color-417: #A31F00;
-/* Color representing response status code 418 (orange.20). */
-@kui-status-color-418: #FFC2B3;
-/* Color representing response status code 421 (orange.30). */
-@kui-status-color-421: #FF9877;
-/* Color representing response status code 422 (orange.40). */
-@kui-status-color-422: #FF723C;
-/* Color representing response status code 423 (orange.50). */
-@kui-status-color-423: #F75008;
-/* Color representing response status code 424 (orange.60). */
-@kui-status-color-424: #D13500;
-/* Color representing response status code 425 (orange.70). */
-@kui-status-color-425: #A31F00;
-/* Color representing response status code 426 (orange.20). */
-@kui-status-color-426: #FFC2B3;
-/* Color representing response status code 428 (orange.30). */
-@kui-status-color-428: #FF9877;
-/* Color representing response status code 429 (orange.40). */
-@kui-status-color-429: #FF723C;
-/* Color representing response status code 431 (orange.50). */
-@kui-status-color-431: #F75008;
-/* Color representing response status code 451 (orange.60). */
-@kui-status-color-451: #D13500;
-/* Color representing response status code 500 (red.20). */
-@kui-status-color-500: #ffabab;
-/* Color representing response status code 501 (red.30). */
-@kui-status-color-501: #ff7272;
-/* Color representing response status code 502 (red.40). */
-@kui-status-color-502: #ff3954;
-/* Color representing response status code 503 (red.50). */
-@kui-status-color-503: #f50045;
-/* Color representing response status code 504 (red.60). */
-@kui-status-color-504: #d60027;
-/* Color representing response status code 505 (red.70). */
-@kui-status-color-505: #ad000e;
-/* Color representing response status code 506 (red.20). */
-@kui-status-color-506: #ffabab;
-/* Color representing response status code 507 (red.30). */
-@kui-status-color-507: #ff7272;
-/* Color representing response status code 508 (red.40). */
-@kui-status-color-508: #ff3954;
-/* Color representing response status code 510 (red.50). */
-@kui-status-color-510: #f50045;
-/* Color representing response status code 511 (red.60). */
-@kui-status-color-511: #d60027;
-/* Color for unknown response status codes in the 100-199 range (blue.10). */
-@kui-status-color-1na: #eefaff;
-/* Color for unknown response status codes in the 200-299 range (green.10). */
-@kui-status-color-2na: #ecfffb;
-/* Color for unknown response status codes in the 300-399 range (yellow.10). */
-@kui-status-color-3na: #fffce0;
-/* Color for unknown response status codes in the 400-499 range (orange.10). */
-@kui-status-color-4na: #FFF1EF;
-/* Color for unknown response status codes in the 500-599 range (red.10). */
-@kui-status-color-5na: #ffe5e5;
-/* Color for a group of response status codes in the 100-199 range (blue.40). */
-@kui-status-color-100s: #5f9aff;
-/* Color for a group of response status codes in the 200-299 range (green.40). */
-@kui-status-color-200s: #00d6a4;
-/* Color for a group of response status codes in the 300-399 range (yellow.40). */
-@kui-status-color-300s: #ffc400;
-/* Color for a group of response status codes in the 400-499 range (orange.40). */
-@kui-status-color-400s: #FF723C;
-/* Color for a group of response status codes in the 500-599 range (red.40). */
-@kui-status-color-500s: #ff3954;
-/* Background color for http status 100 elements (blue.10). */
-@kui-status-color-background-100: #eefaff;
-/* Background color for http status 200 elements (green.10). */
-@kui-status-color-background-200: #ecfffb;
-/* Background color for http status 300 elements (yellow.10). */
-@kui-status-color-background-300: #fffce0;
-/* Background color for http status 400 elements (orange.10). */
-@kui-status-color-background-400: #FFF1EF;
-/* Background color for http status 500 elements (red.10). */
-@kui-status-color-background-500: #ffe5e5;
-/* Text color for http status 100 elements (blue.60). */
-@kui-status-color-text-100: #0044f4;
-/* Text color for http status 200 elements (green.60). */
-@kui-status-color-text-200: #007d60;
-/* Text color for http status 300 elements (yellow.60). */
-@kui-status-color-text-300: #995c00;
-/* Text color for http status 400 elements (orange.60). */
-@kui-status-color-text-400: #D13500;
-/* Text color for http status 500 elements (red.60). */
-@kui-status-color-text-500: #d60027;
-/* The standard monospace text font family. Typically used for code blocks, inline code, and copyable text. */
-@kui-font-family-code: 'JetBrains Mono', Consolas, monospace;
-/* The standard heading text font family. */
-@kui-font-family-heading: 'Inter', Roboto, Helvetica, sans-serif;
-/* The standard text font family. */
-@kui-font-family-text: 'Inter', Roboto, Helvetica, sans-serif;
-@kui-font-size-10: 10px;
-@kui-font-size-20: 12px;
-@kui-font-size-30: 14px;
-@kui-font-size-40: 16px;
-@kui-font-size-50: 18px;
-@kui-font-size-60: 20px;
-@kui-font-size-70: 24px;
-@kui-font-size-80: 32px;
-@kui-font-size-90: 40px;
-@kui-font-size-100: 48px;
-/* 700: The bold font weight. */
-@kui-font-weight-bold: 700;
-/* 500: The medium font weight. */
-@kui-font-weight-medium: 500;
-/* 400: The normal font weight. */
-@kui-font-weight-regular: 400;
-/* 600: The semibold font weight. */
-@kui-font-weight-semibold: 600;
-/* Alias for letter-spacing-normal */
-@kui-letter-spacing-0: normal;
-/* -0.12px */
-@kui-letter-spacing-minus-10: -0.12px;
-/* -0.24px */
-@kui-letter-spacing-minus-20: -0.24px;
-/* -0.32px */
-@kui-letter-spacing-minus-30: -0.32px;
-/* -0.4px */
-@kui-letter-spacing-minus-40: -0.4px;
-/* -0.48px */
-@kui-letter-spacing-minus-50: -0.48px;
-/* normal */
-@kui-letter-spacing-normal: normal;
-/* 12px */
-@kui-line-height-10: 12px;
-/* 16px */
-@kui-line-height-20: 16px;
-/* 20px */
-@kui-line-height-30: 20px;
-/* 24px */
-@kui-line-height-40: 24px;
-/* 28px */
-@kui-line-height-50: 28px;
-/* 32px */
-@kui-line-height-60: 32px;
-/* 36px */
-@kui-line-height-70: 36px;
-/* 40px */
-@kui-line-height-80: 40px;
-/* 48px */
-@kui-line-height-90: 48px;
-/* 56px */
-@kui-line-height-100: 56px;
-/* 0px 4px 20px 0px rgba(0, 0, 0, 0.08) */
-@kui-shadow: 0px 4px 20px 0px rgba(0, 0, 0, 0.08);
-/* 0px 0px 0px 1px gray.20 inset */
-@kui-shadow-border: 0px 0px 0px 1px #e0e4ea inset;
-/* 0px 0px 0px 1px red.60 inset */
-@kui-shadow-border-danger: 0px 0px 0px 1px #d60027 inset;
-/* 0px 0px 0px 1px red.70 inset */
-@kui-shadow-border-danger-strong: 0px 0px 0px 1px #ad000e inset;
-/* 0px 0px 0px 1px gray.20 inset */
-@kui-shadow-border-disabled: 0px 0px 0px 1px #e0e4ea inset;
-/* 0px 0px 0px 1px blue.60 inset */
-@kui-shadow-border-primary: 0px 0px 0px 1px #0044f4 inset;
-/* 0px 0px 0px 1px blue.90 inset */
-@kui-shadow-border-primary-strongest: 0px 0px 0px 1px #001466 inset;
-/* 0px 0px 0px 1px blue.40 inset */
-@kui-shadow-border-primary-weak: 0px 0px 0px 1px #5f9aff inset;
-/* 0px 0px 0px 4px rgba(0, 68, 244, 0.2) */
-@kui-shadow-focus: 0px 0px 0px 4px rgba(0, 68, 244, 0.2);
-/* 0px value for gaps, margin, or padding. */
-@kui-space-0: 0px;
-/* 2px value for gaps, margin, or padding. */
-@kui-space-10: 2px;
-/* 4px value for gaps, margin, or padding. */
-@kui-space-20: 4px;
-/* 6px value for gaps, margin, or padding. */
-@kui-space-30: 6px;
-/* 8px value for gaps, margin, or padding. */
-@kui-space-40: 8px;
-/* 12px value for gaps, margin, or padding. */
-@kui-space-50: 12px;
-/* 16px value for gaps, margin, or padding. */
-@kui-space-60: 16px;
-/* 20px value for gaps, margin, or padding. */
-@kui-space-70: 20px;
-/* 24px value for gaps, margin, or padding. */
-@kui-space-80: 24px;
-/* 32px value for gaps, margin, or padding. */
-@kui-space-90: 32px;
-/* 40px value for gaps, margin, or padding. */
-@kui-space-100: 40px;
-/* 48px value for gaps, margin, or padding. */
-@kui-space-110: 48px;
-/* 56px value for gaps, margin, or padding. */
-@kui-space-120: 56px;
-/* 64px value for gaps, margin, or padding. */
-@kui-space-130: 64px;
-/* 80px value for gaps, margin, or padding. */
-@kui-space-140: 80px;
-/* 96px value for gaps, margin, or padding. */
-@kui-space-150: 96px;
-/* auto */
-@kui-space-auto: auto;
+@kui-color-background: ;
+@kui-color-background-danger: ;
+@kui-color-background-danger-strong: ;
+@kui-color-background-danger-stronger: ;
+@kui-color-background-danger-strongest: ;
+@kui-color-background-danger-weak: ;
+@kui-color-background-danger-weaker: ;
+@kui-color-background-danger-weakest: ;
+@kui-color-background-decorative-aqua-weakest: ;
+@kui-color-background-decorative-purple: ;
+@kui-color-background-decorative-purple-weakest: ;
+@kui-color-background-disabled: ;
+@kui-color-background-info: ;
+@kui-color-background-info-strong: ;
+@kui-color-background-info-stronger: ;
+@kui-color-background-info-strongest: ;
+@kui-color-background-info-weak: ;
+@kui-color-background-info-weaker: ;
+@kui-color-background-info-weakest: ;
+@kui-color-background-inverse: ;
+@kui-color-background-neutral: ;
+@kui-color-background-neutral-strong: ;
+@kui-color-background-neutral-stronger: ;
+@kui-color-background-neutral-strongest: ;
+@kui-color-background-neutral-weak: ;
+@kui-color-background-neutral-weaker: ;
+@kui-color-background-neutral-weakest: ;
+@kui-color-background-overlay: ;
+@kui-color-background-primary: ;
+@kui-color-background-primary-strong: ;
+@kui-color-background-primary-stronger: ;
+@kui-color-background-primary-strongest: ;
+@kui-color-background-primary-weak: ;
+@kui-color-background-primary-weaker: ;
+@kui-color-background-primary-weakest: ;
+@kui-color-background-success: ;
+@kui-color-background-success-strong: ;
+@kui-color-background-success-stronger: ;
+@kui-color-background-success-strongest: ;
+@kui-color-background-success-weak: ;
+@kui-color-background-success-weaker: ;
+@kui-color-background-success-weakest: ;
+@kui-color-background-transparent: ;
+@kui-color-background-warning: ;
+@kui-color-background-warning-strong: ;
+@kui-color-background-warning-stronger: ;
+@kui-color-background-warning-strongest: ;
+@kui-color-background-warning-weak: ;
+@kui-color-background-warning-weaker: ;
+@kui-color-background-warning-weakest: ;
+@kui-color-border: ;
+@kui-color-border-danger: ;
+@kui-color-border-danger-strong: ;
+@kui-color-border-danger-stronger: ;
+@kui-color-border-danger-strongest: ;
+@kui-color-border-danger-weak: ;
+@kui-color-border-danger-weaker: ;
+@kui-color-border-danger-weakest: ;
+@kui-color-border-decorative-purple: ;
+@kui-color-border-disabled: ;
+@kui-color-border-inverse: ;
+@kui-color-border-neutral: ;
+@kui-color-border-neutral-strong: ;
+@kui-color-border-neutral-stronger: ;
+@kui-color-border-neutral-strongest: ;
+@kui-color-border-neutral-weak: ;
+@kui-color-border-neutral-weaker: ;
+@kui-color-border-neutral-weakest: ;
+@kui-color-border-primary: ;
+@kui-color-border-primary-strong: ;
+@kui-color-border-primary-stronger: ;
+@kui-color-border-primary-strongest: ;
+@kui-color-border-primary-weak: ;
+@kui-color-border-primary-weaker: ;
+@kui-color-border-primary-weakest: ;
+@kui-color-border-transparent: ;
+@kui-color-text: ;
+@kui-color-text-danger: ;
+@kui-color-text-danger-strong: ;
+@kui-color-text-danger-stronger: ;
+@kui-color-text-danger-strongest: ;
+@kui-color-text-danger-weak: ;
+@kui-color-text-danger-weaker: ;
+@kui-color-text-danger-weakest: ;
+@kui-color-text-decorative-aqua: ;
+@kui-color-text-decorative-pink: ;
+@kui-color-text-decorative-purple: ;
+@kui-color-text-decorative-purple-strong: ;
+@kui-color-text-disabled: ;
+@kui-color-text-info: ;
+@kui-color-text-info-strong: ;
+@kui-color-text-info-stronger: ;
+@kui-color-text-info-strongest: ;
+@kui-color-text-info-weak: ;
+@kui-color-text-info-weaker: ;
+@kui-color-text-info-weakest: ;
+@kui-color-text-inverse: ;
+@kui-color-text-neutral: ;
+@kui-color-text-neutral-strong: ;
+@kui-color-text-neutral-stronger: ;
+@kui-color-text-neutral-strongest: ;
+@kui-color-text-neutral-weak: ;
+@kui-color-text-neutral-weaker: ;
+@kui-color-text-neutral-weakest: ;
+@kui-color-text-primary: ;
+@kui-color-text-primary-strong: ;
+@kui-color-text-primary-stronger: ;
+@kui-color-text-primary-strongest: ;
+@kui-color-text-primary-weak: ;
+@kui-color-text-primary-weaker: ;
+@kui-color-text-primary-weakest: ;
+@kui-color-text-success: ;
+@kui-color-text-success-strong: ;
+@kui-color-text-success-stronger: ;
+@kui-color-text-success-strongest: ;
+@kui-color-text-success-weak: ;
+@kui-color-text-success-weaker: ;
+@kui-color-text-success-weakest: ;
+@kui-color-text-warning: ;
+@kui-color-text-warning-strong: ;
+@kui-color-text-warning-stronger: ;
+@kui-color-text-warning-strongest: ;
+@kui-color-text-warning-weak: ;
+@kui-color-text-warning-weaker: ;
+@kui-color-text-warning-weakest: ;
+@kui-animation-duration-20: ;
+@kui-border-radius-0: ;
+@kui-border-radius-10: ;
+@kui-border-radius-20: ;
+@kui-border-radius-30: ;
+@kui-border-radius-40: ;
+@kui-border-radius-50: ;
+@kui-border-radius-circle: ;
+@kui-border-radius-round: ;
+@kui-border-width-0: ;
+@kui-border-width-10: ;
+@kui-border-width-20: ;
+@kui-border-width-30: ;
+@kui-breakpoint-mobile: ;
+@kui-breakpoint-phablet: ;
+@kui-breakpoint-tablet: ;
+@kui-breakpoint-laptop: ;
+@kui-breakpoint-desktop: ;
+@kui-icon-color-danger: ;
+@kui-icon-color-neutral: ;
+@kui-icon-color-primary: ;
+@kui-icon-color-success: ;
+@kui-icon-color-warning: ;
+@kui-icon-size-10: ;
+@kui-icon-size-20: ;
+@kui-icon-size-30: ;
+@kui-icon-size-40: ;
+@kui-icon-size-50: ;
+@kui-icon-size-60: ;
+@kui-icon-size-70: ;
+@kui-icon-size-80: ;
+@kui-method-color-background-connect: ;
+@kui-method-color-background-delete: ;
+@kui-method-color-background-get: ;
+@kui-method-color-background-head: ;
+@kui-method-color-background-options: ;
+@kui-method-color-background-patch: ;
+@kui-method-color-background-post: ;
+@kui-method-color-background-put: ;
+@kui-method-color-background-trace: ;
+@kui-method-color-text-connect: ;
+@kui-method-color-text-connect-strong: ;
+@kui-method-color-text-delete: ;
+@kui-method-color-text-delete-strong: ;
+@kui-method-color-text-get: ;
+@kui-method-color-text-get-strong: ;
+@kui-method-color-text-head: ;
+@kui-method-color-text-head-strong: ;
+@kui-method-color-text-options: ;
+@kui-method-color-text-options-strong: ;
+@kui-method-color-text-patch: ;
+@kui-method-color-text-patch-strong: ;
+@kui-method-color-text-post: ;
+@kui-method-color-text-post-strong: ;
+@kui-method-color-text-put: ;
+@kui-method-color-text-put-strong: ;
+@kui-method-color-text-trace: ;
+@kui-method-color-text-trace-strong: ;
+@kui-navigation-color-background: ;
+@kui-navigation-color-background-selected: ;
+@kui-navigation-color-border: ;
+@kui-navigation-color-border-child: ;
+@kui-navigation-color-border-divider: ;
+@kui-navigation-color-text: ;
+@kui-navigation-color-text-focus: ;
+@kui-navigation-color-text-hover: ;
+@kui-navigation-color-text-selected: ;
+@kui-navigation-shadow-border: ;
+@kui-navigation-shadow-border-child: ;
+@kui-navigation-shadow-focus: ;
+@kui-status-color-100: ;
+@kui-status-color-101: ;
+@kui-status-color-102: ;
+@kui-status-color-103: ;
+@kui-status-color-200: ;
+@kui-status-color-201: ;
+@kui-status-color-202: ;
+@kui-status-color-203: ;
+@kui-status-color-204: ;
+@kui-status-color-205: ;
+@kui-status-color-206: ;
+@kui-status-color-207: ;
+@kui-status-color-208: ;
+@kui-status-color-226: ;
+@kui-status-color-300: ;
+@kui-status-color-301: ;
+@kui-status-color-302: ;
+@kui-status-color-303: ;
+@kui-status-color-304: ;
+@kui-status-color-305: ;
+@kui-status-color-307: ;
+@kui-status-color-308: ;
+@kui-status-color-400: ;
+@kui-status-color-401: ;
+@kui-status-color-402: ;
+@kui-status-color-403: ;
+@kui-status-color-404: ;
+@kui-status-color-405: ;
+@kui-status-color-406: ;
+@kui-status-color-407: ;
+@kui-status-color-408: ;
+@kui-status-color-409: ;
+@kui-status-color-410: ;
+@kui-status-color-411: ;
+@kui-status-color-412: ;
+@kui-status-color-413: ;
+@kui-status-color-414: ;
+@kui-status-color-415: ;
+@kui-status-color-416: ;
+@kui-status-color-417: ;
+@kui-status-color-418: ;
+@kui-status-color-421: ;
+@kui-status-color-422: ;
+@kui-status-color-423: ;
+@kui-status-color-424: ;
+@kui-status-color-425: ;
+@kui-status-color-426: ;
+@kui-status-color-428: ;
+@kui-status-color-429: ;
+@kui-status-color-431: ;
+@kui-status-color-451: ;
+@kui-status-color-500: ;
+@kui-status-color-501: ;
+@kui-status-color-502: ;
+@kui-status-color-503: ;
+@kui-status-color-504: ;
+@kui-status-color-505: ;
+@kui-status-color-506: ;
+@kui-status-color-507: ;
+@kui-status-color-508: ;
+@kui-status-color-510: ;
+@kui-status-color-511: ;
+@kui-status-color-1na: ;
+@kui-status-color-2na: ;
+@kui-status-color-3na: ;
+@kui-status-color-4na: ;
+@kui-status-color-5na: ;
+@kui-status-color-100s: ;
+@kui-status-color-200s: ;
+@kui-status-color-300s: ;
+@kui-status-color-400s: ;
+@kui-status-color-500s: ;
+@kui-status-color-background-100: ;
+@kui-status-color-background-200: ;
+@kui-status-color-background-300: ;
+@kui-status-color-background-400: ;
+@kui-status-color-background-500: ;
+@kui-status-color-text-100: ;
+@kui-status-color-text-200: ;
+@kui-status-color-text-300: ;
+@kui-status-color-text-400: ;
+@kui-status-color-text-500: ;
+@kui-font-family-code: ;
+@kui-font-family-heading: ;
+@kui-font-family-text: ;
+@kui-font-size-10: ;
+@kui-font-size-20: ;
+@kui-font-size-30: ;
+@kui-font-size-40: ;
+@kui-font-size-50: ;
+@kui-font-size-60: ;
+@kui-font-size-70: ;
+@kui-font-size-80: ;
+@kui-font-size-90: ;
+@kui-font-size-100: ;
+@kui-font-weight-bold: ;
+@kui-font-weight-medium: ;
+@kui-font-weight-regular: ;
+@kui-font-weight-semibold: ;
+@kui-letter-spacing-0: ;
+@kui-letter-spacing-minus-10: ;
+@kui-letter-spacing-minus-20: ;
+@kui-letter-spacing-minus-30: ;
+@kui-letter-spacing-minus-40: ;
+@kui-letter-spacing-minus-50: ;
+@kui-letter-spacing-normal: ;
+@kui-line-height-10: ;
+@kui-line-height-20: ;
+@kui-line-height-30: ;
+@kui-line-height-40: ;
+@kui-line-height-50: ;
+@kui-line-height-60: ;
+@kui-line-height-70: ;
+@kui-line-height-80: ;
+@kui-line-height-90: ;
+@kui-line-height-100: ;
+@kui-shadow: ;
+@kui-shadow-border: ;
+@kui-shadow-border-danger: ;
+@kui-shadow-border-danger-strong: ;
+@kui-shadow-border-disabled: ;
+@kui-shadow-border-primary: ;
+@kui-shadow-border-primary-strongest: ;
+@kui-shadow-border-primary-weak: ;
+@kui-shadow-focus: ;
+@kui-space-0: ;
+@kui-space-10: ;
+@kui-space-20: ;
+@kui-space-30: ;
+@kui-space-40: ;
+@kui-space-50: ;
+@kui-space-60: ;
+@kui-space-70: ;
+@kui-space-80: ;
+@kui-space-90: ;
+@kui-space-100: ;
+@kui-space-110: ;
+@kui-space-120: ;
+@kui-space-130: ;
+@kui-space-140: ;
+@kui-space-150: ;
+@kui-space-auto: ;
 ```
 
 </details>
@@ -2051,670 +1070,343 @@ You may scope your CSS custom property overrides inside the `:root` selector as 
 <summary>Click to view the list of CSS custom properties</summary>
 
 ```scss
-/* Default background color for containers (white). */
---kui-color-background: #ffffff;
-/* Background color for danger actions or messages (red.60). */
---kui-color-background-danger: #d60027;
-/* Strong background color for danger actions or messages (red.70). */
---kui-color-background-danger-strong: #ad000e;
-/* Stronger background color for danger actions or messages (red.80). */
---kui-color-background-danger-stronger: #850000;
-/* Strongest background color for danger actions or messages (red.90). */
---kui-color-background-danger-strongest: #5c0000;
-/* Weak background color for danger actions or messages (red.40). */
---kui-color-background-danger-weak: #ff3954;
-/* Weaker background color for danger actions or messages (red.20). */
---kui-color-background-danger-weaker: #ffabab;
-/* Weakest background color for danger actions or messages (red.10). */
---kui-color-background-danger-weakest: #ffe5e5;
-/* Weakest background color for decorative purposes (aqua.10). */
---kui-color-background-decorative-aqua-weakest: #ecfcff;
-/* Background color for decorative purposes (purple.60). */
---kui-color-background-decorative-purple: #6f28ff;
-/* Weakest background color for decorative purposes (purple.10). */
---kui-color-background-decorative-purple-weakest: #f1f0ff;
-/* Background color for disabled elements (gray.20). */
---kui-color-background-disabled: #e0e4ea;
-/* Background color for info elements (blue.60). */
---kui-color-background-info: #0044f4;
-/* Strong background color for info elements (blue.70). */
---kui-color-background-info-strong: #0030cc;
-/* Stronger background color for info elements (blue.80). */
---kui-color-background-info-stronger: #002099;
-/* Strongest background color for info elements (blue.90). */
---kui-color-background-info-strongest: #001466;
-/* Weak background color for info elements (blue.40). */
---kui-color-background-info-weak: #5f9aff;
-/* Weaker background color for info elements (blue.20). */
---kui-color-background-info-weaker: #bee2ff;
-/* Weakest background color for info elements (blue.10). */
---kui-color-background-info-weakest: #eefaff;
-/* Inverse background color for containers (blue.100) */
---kui-color-background-inverse: #000933;
-/* Background color for neutral elements (gray.60). */
---kui-color-background-neutral: #6c7489;
-/* Strong background color for neutral elements (gray.70). */
---kui-color-background-neutral-strong: #52596e;
-/* Stronger background color for neutral elements (gray.80). */
---kui-color-background-neutral-stronger: #3a3f51;
-/* Strongest background color for neutral elements (gray.90). */
---kui-color-background-neutral-strongest: #232633;
-/* Weak background color for neutral elements (gray.40). */
---kui-color-background-neutral-weak: #afb7c5;
-/* Weaker background color for neutral elements (gray.20). */
---kui-color-background-neutral-weaker: #e0e4ea;
-/* Weakest background color for neutral elements (gray.10). */
---kui-color-background-neutral-weakest: #f9fafb;
-/* Overlay background color (rgba(blue.100, 0.6)) */
---kui-color-background-overlay: rgba(0, 9, 51, 0.6);
-/* Background color for primary actions or messages (blue.60). */
---kui-color-background-primary: #0044f4;
-/* Strong background color for primary actions or messages (blue.70). */
---kui-color-background-primary-strong: #0030cc;
-/* Stronger background color for primary actions or messages (blue.80). */
---kui-color-background-primary-stronger: #002099;
-/* Strongest background color for primary actions or messages (blue.90). */
---kui-color-background-primary-strongest: #001466;
-/* Weak background color for primary actions or messages (blue.40). */
---kui-color-background-primary-weak: #5f9aff;
-/* Weaker background color for primary actions or messages (blue.20). */
---kui-color-background-primary-weaker: #bee2ff;
-/* Weakest background color for primary actions or messages (blue.10) */
---kui-color-background-primary-weakest: #eefaff;
-/* Background color for success elements (green.60). */
---kui-color-background-success: #007d60;
-/* Strong background color for success elements (green.70). */
---kui-color-background-success-strong: #005944;
-/* Stronger background color for success elements (green.80). */
---kui-color-background-success-stronger: #004737;
-/* Strongest background color for success elements (green.90). */
---kui-color-background-success-strongest: #003629;
-/* Weak background color for success elements (green.40). */
---kui-color-background-success-weak: #00d6a4;
-/* Weaker background color for success elements (green.20). */
---kui-color-background-success-weaker: #b5ffee;
-/* Weakest background color for success elements (green.10). */
---kui-color-background-success-weakest: #ecfffb;
-/* Transparent background color (transparent). */
---kui-color-background-transparent: transparent;
-/* Background color for warning elements (yellow.60). */
---kui-color-background-warning: #995c00;
-/* Strong background color for warning elements (yellow.70). */
---kui-color-background-warning-strong: #804400;
-/* Stronger background color for warning elements (yellow.80). */
---kui-color-background-warning-stronger: #662d00;
-/* Strongest background color for warning elements (yellow.90). */
---kui-color-background-warning-strongest: #4d1b00;
-/* Weak background color for warning elements (yellow.40). */
---kui-color-background-warning-weak: #ffc400;
-/* Weaker background color for warning elements (yellow.20). */
---kui-color-background-warning-weaker: #fff296;
-/* Weakest background color for warning elements (yellow.10). */
---kui-color-background-warning-weakest: #fffce0;
-/* Default border color for containers (gray.20). */
---kui-color-border: #e0e4ea;
-/* Border color for danger actions or messages (red.60). */
---kui-color-border-danger: #d60027;
-/* Strong border color for danger actions or messages (red.70). */
---kui-color-border-danger-strong: #ad000e;
-/* Stronger border color for danger actions or messages (red.80). */
---kui-color-border-danger-stronger: #850000;
-/* Strongest border color for danger actions or messages (red.90). */
---kui-color-border-danger-strongest: #5c0000;
-/* Weak border color for danger actions or messages (red.40). */
---kui-color-border-danger-weak: #ff3954;
-/* Weaker border color for danger actions or messages (red.20). */
---kui-color-border-danger-weaker: #ffabab;
-/* Weakest border color for danger actions or messages (red.10). */
---kui-color-border-danger-weakest: #ffe5e5;
-/* Border color for decorative purposes (purple.60). */
---kui-color-border-decorative-purple: #6f28ff;
-/* Border color for disabled elements (gray.20). */
---kui-color-border-disabled: #e0e4ea;
-/* Inverse border color (rgba(white, 0.2)). */
---kui-color-border-inverse: rgba(255, 255, 255, 0.2);
-/* Border color for neutral elements (gray.60) */
---kui-color-border-neutral: #6c7489;
-/* Strong border color for neutral elements (gray.70) */
---kui-color-border-neutral-strong: #52596e;
-/* Stronger border color for neutral elements (gray.80) */
---kui-color-border-neutral-stronger: #3a3f51;
-/* Strongest border color for neutral elements (gray.90) */
---kui-color-border-neutral-strongest: #232633;
-/* Weak border color for neutral elements (gray.40) */
---kui-color-border-neutral-weak: #afb7c5;
-/* Weaker border color for neutral elements (gray.20) */
---kui-color-border-neutral-weaker: #e0e4ea;
-/* Weakest border color for neutral elements (gray.10) */
---kui-color-border-neutral-weakest: #f9fafb;
-/* Border color for primary actions or messages (blue.60). */
---kui-color-border-primary: #0044f4;
-/* Strong border color for primary actions or messages (blue.70). */
---kui-color-border-primary-strong: #0030cc;
-/* Stronger border color for primary actions or messages (blue.80). */
---kui-color-border-primary-stronger: #002099;
-/* Strongest border color for primary actions or messages (blue.90). */
---kui-color-border-primary-strongest: #001466;
-/* Weak border color for primary actions or messages (blue.40). */
---kui-color-border-primary-weak: #5f9aff;
-/* Weaker border color for primary actions or messages (blue.20). */
---kui-color-border-primary-weaker: #bee2ff;
-/* Weakest border color for primary actions or messages (blue.10). */
---kui-color-border-primary-weakest: #eefaff;
-/* Transparent border color (transparent). */
---kui-color-border-transparent: transparent;
-/* Default text color (blue.100). */
---kui-color-text: #000933;
-/* Text color for danger actions or messages (red.60). */
---kui-color-text-danger: #d60027;
-/* Strong text color for danger actions or messages (red.70). */
---kui-color-text-danger-strong: #ad000e;
-/* Stronger text color for danger actions or messages (red.80). */
---kui-color-text-danger-stronger: #850000;
-/* Strongest text color for danger actions or messages (red.90). */
---kui-color-text-danger-strongest: #5c0000;
-/* Weak text color for danger actions or messages (red.40). */
---kui-color-text-danger-weak: #ff3954;
-/* Weaker text color for danger actions or messages (red.20). */
---kui-color-text-danger-weaker: #ffabab;
-/* Weakest text color for danger actions or messages (red.10). */
---kui-color-text-danger-weakest: #ffe5e5;
-/* Text color for decorative purposes (aqua.50). */
---kui-color-text-decorative-aqua: #00abd2;
-/* Text color for decorative purposes (pink.60). */
---kui-color-text-decorative-pink: #d60067;
-/* Text color for decorative purposes (purple.60). */
---kui-color-text-decorative-purple: #6f28ff;
-/* Strong text color for decorative purposes (purple.70). */
---kui-color-text-decorative-purple-strong: #5e00f5;
-/* Text color for disabled elements (gray.40). */
---kui-color-text-disabled: #afb7c5;
-/* Text color for info elements (blue.60). */
---kui-color-text-info: #0044f4;
-/* Strong text color for info elements (blue.70). */
---kui-color-text-info-strong: #0030cc;
-/* Stronger text color for info elements (blue.80). */
---kui-color-text-info-stronger: #002099;
-/* Strongest text color for info elements (blue.90). */
---kui-color-text-info-strongest: #001466;
-/* Weak text color for info elements (blue.40). */
---kui-color-text-info-weak: #5f9aff;
-/* Weaker text color for info elements (blue.20). */
---kui-color-text-info-weaker: #bee2ff;
-/* Weakest text color for info elements (blue.10). */
---kui-color-text-info-weakest: #eefaff;
-/* Inverse text color (white). */
---kui-color-text-inverse: #ffffff;
-/* Text color for neutral elements (gray.60). */
---kui-color-text-neutral: #6c7489;
-/* Strong text color for neutral elements (gray.70). */
---kui-color-text-neutral-strong: #52596e;
-/* Stronger text color for neutral elements (gray.80). */
---kui-color-text-neutral-stronger: #3a3f51;
-/* Strongest text color for neutral elements (gray.90). */
---kui-color-text-neutral-strongest: #232633;
-/* Weak text color for neutral elements (gray.40). */
---kui-color-text-neutral-weak: #afb7c5;
-/* Weaker text color for neutral elements (gray.20). */
---kui-color-text-neutral-weaker: #e0e4ea;
-/* Weakest text color for neutral elements (gray.10). */
---kui-color-text-neutral-weakest: #f9fafb;
-/* Text color for primary actions or messages (blue.60). */
---kui-color-text-primary: #0044f4;
-/* Strong text color for primary actions or messages (blue.70). */
---kui-color-text-primary-strong: #0030cc;
-/* Stronger text color for primary actions or messages (blue.80). */
---kui-color-text-primary-stronger: #002099;
-/* Strongest text color for primary actions or messages (blue.90). */
---kui-color-text-primary-strongest: #001466;
-/* Weak text color for primary actions or messages (blue.40). */
---kui-color-text-primary-weak: #5f9aff;
-/* Weaker text color for primary actions or messages (blue.20). */
---kui-color-text-primary-weaker: #bee2ff;
-/* Weakest text color for primary actions or messages (blue.10). */
---kui-color-text-primary-weakest: #eefaff;
-/* Text color for success elements (green.60). */
---kui-color-text-success: #007d60;
-/* Strong text color for success elements (green.70). */
---kui-color-text-success-strong: #005944;
-/* Stronger text color for success elements (green.80). */
---kui-color-text-success-stronger: #004737;
-/* Stronger text color for success elements (green.90). */
---kui-color-text-success-strongest: #003629;
-/* Weak text color for success elements (green.40). */
---kui-color-text-success-weak: #00d6a4;
-/* Weaker text color for success elements (green.20). */
---kui-color-text-success-weaker: #b5ffee;
-/* Weakest text color for success elements (green.10). */
---kui-color-text-success-weakest: #ecfffb;
-/* Text color for warning elements (yellow.60). */
---kui-color-text-warning: #995c00;
-/* Strong text color for warning elements (yellow.70). */
---kui-color-text-warning-strong: #804400;
-/* Stronger text color for warning elements (yellow.80). */
---kui-color-text-warning-stronger: #662d00;
-/* Strongest text color for warning elements (yellow.90). */
---kui-color-text-warning-strongest: #4d1b00;
-/* Weak text color for warning elements (yellow.40). */
---kui-color-text-warning-weak: #ffc400;
-/* Weaker text color for warning elements (yellow.20). */
---kui-color-text-warning-weaker: #fff296;
-/* Weakest text color for warning elements (yellow.10). */
---kui-color-text-warning-weakest: #fffce0;
-/* Default transition timing */
---kui-animation-duration-20: 0.2s;
-/* 0px border radius. */
---kui-border-radius-0: 0px;
-/* 2px border radius. */
---kui-border-radius-10: 2px;
-/* 4px border radius. */
---kui-border-radius-20: 4px;
-/* 6px border radius. */
---kui-border-radius-30: 6px;
-/* 8px border radius. */
---kui-border-radius-40: 8px;
-/* 10px border radius. */
---kui-border-radius-50: 10px;
-/* 50% border radius used to create circles. */
---kui-border-radius-circle: 50%;
-/* 100px border radius used to create pill shapes. */
---kui-border-radius-round: 100px;
-/* 0px border width. */
---kui-border-width-0: 0px;
-/* 1px border width. */
---kui-border-width-10: 1px;
-/* 2px border width. */
---kui-border-width-20: 2px;
-/* 4px border width. */
---kui-border-width-30: 4px;
-/* Used for larger mobile screens. Any viewport width under this value is considered mobile. */
---kui-breakpoint-mobile: 640px;
-/* Used for tablet screens. */
---kui-breakpoint-phablet: 768px;
-/* Used for larger tablet screens. Any viewport width less than this value will likely show a mobile layout. Any viewport width this value and greater will likely show a desktop layout. */
---kui-breakpoint-tablet: 1024px;
-/* Used for standard desktop screens. */
---kui-breakpoint-laptop: 1280px;
-/* Used for larger desktop screens. */
---kui-breakpoint-desktop: 1536px;
-/* Danger color for icons. */
---kui-icon-color-danger: #f50045;
-/* Neutral color for icons. */
---kui-icon-color-neutral: #828a9e;
-/* Primary color for icons. */
---kui-icon-color-primary: #306fff;
-/* Success color for icons. */
---kui-icon-color-success: #00a17b;
-/* Warning color for icons. */
---kui-icon-color-warning: #ffc400;
-/* 10px icon size. */
---kui-icon-size-10: 10px;
-/* 12px icon size. */
---kui-icon-size-20: 12px;
-/* 16px icon size. */
---kui-icon-size-30: 16px;
-/* 20px icon size. */
---kui-icon-size-40: 20px;
-/* 24px icon size (default). */
---kui-icon-size-50: 24px;
-/* 32px icon size. */
---kui-icon-size-60: 32px;
-/* 40px icon size. */
---kui-icon-size-70: 40px;
-/* 48px icon size. */
---kui-icon-size-80: 48px;
-/* Background color for the CONNECT method (purple.10). */
---kui-method-color-background-connect: #f1f0ff;
-/* Background color for the DELETE method (red.10). */
---kui-method-color-background-delete: #ffe5e5;
-/* Background color for the GET method (blue.10). */
---kui-method-color-background-get: #eefaff;
-/* Background color for the HEAD method (gray.70). */
---kui-method-color-background-head: #52596e;
-/* Background color for the OPTIONS method (gray.20). */
---kui-method-color-background-options: #e0e4ea;
-/* Background color for the PATCH method (aqua.10). */
---kui-method-color-background-patch: #ecfcff;
-/* Background color for the POST method (green.10). */
---kui-method-color-background-post: #ecfffb;
-/* Background color for the PUT method (yellow.10). */
---kui-method-color-background-put: #fffce0;
-/* Background color for the TRACE method (pink.10). */
---kui-method-color-background-trace: #fff0f7;
-/* Text color for the CONNECT method (purple.60). */
---kui-method-color-text-connect: #6f28ff;
-/* Strong text color for the CONNECT method (purple.70). */
---kui-method-color-text-connect-strong: #5e00f5;
-/* Text color for the DELETE method (red.60). */
---kui-method-color-text-delete: #d60027;
-/* Strong text color for the DELETE method (red.70). */
---kui-method-color-text-delete-strong: #ad000e;
-/* Text color for the GET method (blue.60). */
---kui-method-color-text-get: #0044f4;
-/* Strong text color for the GET method (blue.70). */
---kui-method-color-text-get-strong: #0030cc;
-/* Text color for the HEAD method (gray.20). */
---kui-method-color-text-head: #e0e4ea;
-/* Strong text color for the HEAD method (gray.40). */
---kui-method-color-text-head-strong: #afb7c5;
-/* Text color for the OPTIONS method (gray.70). */
---kui-method-color-text-options: #52596e;
-/* Strong text color for the OPTIONS method (gray.80). */
---kui-method-color-text-options-strong: #3a3f51;
-/* Text color for the PATCH method (aqua.60). */
---kui-method-color-text-patch: #00819d;
-/* Strong text color for the PATCH method (aqua.70). */
---kui-method-color-text-patch-strong: #00647a;
-/* Text color for the POST method (green.60). */
---kui-method-color-text-post: #007d60;
-/* Strong text color for the POST method (green.70). */
---kui-method-color-text-post-strong: #005944;
-/* Text color for the PUT method (yellow.60). */
---kui-method-color-text-put: #995c00;
-/* Strong text color for the PUT method (yellow.70). */
---kui-method-color-text-put-strong: #804400;
-/* Text color for the TRACE method (pink.60). */
---kui-method-color-text-trace: #d60067;
-/* Strong text color for the TRACE method (pink.70). */
---kui-method-color-text-trace-strong: #ad0053;
-/* blue.100 */
---kui-navigation-color-background: #000933;
-/* The background color of a selected navigation item. */
---kui-navigation-color-background-selected: rgba(255, 255, 255, 0.12);
-/* rgba(white, 0.12) */
---kui-navigation-color-border: rgba(255, 255, 255, 0.12);
-/* The border color for a selected child navigation item. */
---kui-navigation-color-border-child: #00fabe;
-/* The color of the navigation section divider. */
---kui-navigation-color-border-divider: rgba(255, 255, 255, 0.24);
-/* Navigation link and icon color. */
---kui-navigation-color-text: #bee2ff;
-/* Navigation link and icon focus-visible color. */
---kui-navigation-color-text-focus: #ffffff;
-/* Navigation link and icon hover color. */
---kui-navigation-color-text-hover: #eefaff;
-/* Navigation link and icon selected color. */
---kui-navigation-color-text-selected: #00fabe;
-/* The box-shadow for a focus-visible navigation link. */
---kui-navigation-shadow-border: 0 0 0 1px rgba(255, 255, 255, 0.12) inset;
-/* The left box-shadow for an active child navigation link. */
---kui-navigation-shadow-border-child: 4px 0 0 0 #00fabe inset;
-/* Navigation link focus-visible box-shadow. */
---kui-navigation-shadow-focus: 0 0 0 1px rgba(255, 255, 255, 0.60) inset;
-/* Color representing response status code 100 (blue.20). */
---kui-status-color-100: #bee2ff;
-/* Color representing response status code 101 (blue.30). */
---kui-status-color-101: #8fc1ff;
-/* Color representing response status code 102 (blue.40). */
---kui-status-color-102: #5f9aff;
-/* Color representing response status code 103 (blue.50). */
---kui-status-color-103: #306fff;
-/* Color representing response status code 200 (green.20). */
---kui-status-color-200: #b5ffee;
-/* Color representing response status code 201 (green.30). */
---kui-status-color-201: #00fabe;
-/* Color representing response status code 202 (green.40). */
---kui-status-color-202: #00d6a4;
-/* Color representing response status code 203 (green.50). */
---kui-status-color-203: #00a17b;
-/* Color representing response status code 204 (green.60). */
---kui-status-color-204: #007d60;
-/* Color representing response status code 205 (green.70). */
---kui-status-color-205: #005944;
-/* Color representing response status code 206 (green.20). */
---kui-status-color-206: #b5ffee;
-/* Color representing response status code 207 (green.30). */
---kui-status-color-207: #00fabe;
-/* Color representing response status code 208 (green.40). */
---kui-status-color-208: #b5ffee;
-/* Color representing response status code 226 (green.50). */
---kui-status-color-226: #00a17b;
-/* Color representing response status code 100 (yellow.20). */
---kui-status-color-300: #fff296;
-/* Color representing response status code 101 (yellow.30). */
---kui-status-color-301: #ffe04b;
-/* Color representing response status code 102 (yellow.40). */
---kui-status-color-302: #ffc400;
-/* Color representing response status code 103 (yellow.50). */
---kui-status-color-303: #b37600;
-/* Color representing response status code 103 (yellow.60). */
---kui-status-color-304: #995c00;
-/* Color representing response status code 103 (yellow.70). */
---kui-status-color-305: #804400;
-/* Color representing response status code 103 (yellow.20). */
---kui-status-color-307: #fff296;
-/* Color representing response status code 103 (yellow.30). */
---kui-status-color-308: #ffe04b;
-/* Color representing response status code 400 (orange.20). */
---kui-status-color-400: #FFC2B3;
-/* Color representing response status code 401 (orange.30). */
---kui-status-color-401: #FF9877;
-/* Color representing response status code 402 (orange.40). */
---kui-status-color-402: #FF723C;
-/* Color representing response status code 403 (orange.50). */
---kui-status-color-403: #F75008;
-/* Color representing response status code 404 (orange.60). */
---kui-status-color-404: #D13500;
-/* Color representing response status code 405 (orange.70). */
---kui-status-color-405: #A31F00;
-/* Color representing response status code 406 (orange.20). */
---kui-status-color-406: #FFC2B3;
-/* Color representing response status code 407 (orange.30). */
---kui-status-color-407: #FF9877;
-/* Color representing response status code 408 (orange.40). */
---kui-status-color-408: #FF723C;
-/* Color representing response status code 409 (orange.50). */
---kui-status-color-409: #F75008;
-/* Color representing response status code 410 (orange.60). */
---kui-status-color-410: #D13500;
-/* Color representing response status code 411 (orange.70). */
---kui-status-color-411: #A31F00;
-/* Color representing response status code 412 (orange.20). */
---kui-status-color-412: #FFC2B3;
-/* Color representing response status code 413 (orange.30). */
---kui-status-color-413: #FF9877;
-/* Color representing response status code 414 (orange.40). */
---kui-status-color-414: #FF723C;
-/* Color representing response status code 415 (orange.50). */
---kui-status-color-415: #F75008;
-/* Color representing response status code 416 (orange.60). */
---kui-status-color-416: #D13500;
-/* Color representing response status code 417 (orange.70). */
---kui-status-color-417: #A31F00;
-/* Color representing response status code 418 (orange.20). */
---kui-status-color-418: #FFC2B3;
-/* Color representing response status code 421 (orange.30). */
---kui-status-color-421: #FF9877;
-/* Color representing response status code 422 (orange.40). */
---kui-status-color-422: #FF723C;
-/* Color representing response status code 423 (orange.50). */
---kui-status-color-423: #F75008;
-/* Color representing response status code 424 (orange.60). */
---kui-status-color-424: #D13500;
-/* Color representing response status code 425 (orange.70). */
---kui-status-color-425: #A31F00;
-/* Color representing response status code 426 (orange.20). */
---kui-status-color-426: #FFC2B3;
-/* Color representing response status code 428 (orange.30). */
---kui-status-color-428: #FF9877;
-/* Color representing response status code 429 (orange.40). */
---kui-status-color-429: #FF723C;
-/* Color representing response status code 431 (orange.50). */
---kui-status-color-431: #F75008;
-/* Color representing response status code 451 (orange.60). */
---kui-status-color-451: #D13500;
-/* Color representing response status code 500 (red.20). */
---kui-status-color-500: #ffabab;
-/* Color representing response status code 501 (red.30). */
---kui-status-color-501: #ff7272;
-/* Color representing response status code 502 (red.40). */
---kui-status-color-502: #ff3954;
-/* Color representing response status code 503 (red.50). */
---kui-status-color-503: #f50045;
-/* Color representing response status code 504 (red.60). */
---kui-status-color-504: #d60027;
-/* Color representing response status code 505 (red.70). */
---kui-status-color-505: #ad000e;
-/* Color representing response status code 506 (red.20). */
---kui-status-color-506: #ffabab;
-/* Color representing response status code 507 (red.30). */
---kui-status-color-507: #ff7272;
-/* Color representing response status code 508 (red.40). */
---kui-status-color-508: #ff3954;
-/* Color representing response status code 510 (red.50). */
---kui-status-color-510: #f50045;
-/* Color representing response status code 511 (red.60). */
---kui-status-color-511: #d60027;
-/* Color for unknown response status codes in the 100-199 range (blue.10). */
---kui-status-color-1na: #eefaff;
-/* Color for unknown response status codes in the 200-299 range (green.10). */
---kui-status-color-2na: #ecfffb;
-/* Color for unknown response status codes in the 300-399 range (yellow.10). */
---kui-status-color-3na: #fffce0;
-/* Color for unknown response status codes in the 400-499 range (orange.10). */
---kui-status-color-4na: #FFF1EF;
-/* Color for unknown response status codes in the 500-599 range (red.10). */
---kui-status-color-5na: #ffe5e5;
-/* Color for a group of response status codes in the 100-199 range (blue.40). */
---kui-status-color-100s: #5f9aff;
-/* Color for a group of response status codes in the 200-299 range (green.40). */
---kui-status-color-200s: #00d6a4;
-/* Color for a group of response status codes in the 300-399 range (yellow.40). */
---kui-status-color-300s: #ffc400;
-/* Color for a group of response status codes in the 400-499 range (orange.40). */
---kui-status-color-400s: #FF723C;
-/* Color for a group of response status codes in the 500-599 range (red.40). */
---kui-status-color-500s: #ff3954;
-/* Background color for http status 100 elements (blue.10). */
---kui-status-color-background-100: #eefaff;
-/* Background color for http status 200 elements (green.10). */
---kui-status-color-background-200: #ecfffb;
-/* Background color for http status 300 elements (yellow.10). */
---kui-status-color-background-300: #fffce0;
-/* Background color for http status 400 elements (orange.10). */
---kui-status-color-background-400: #FFF1EF;
-/* Background color for http status 500 elements (red.10). */
---kui-status-color-background-500: #ffe5e5;
-/* Text color for http status 100 elements (blue.60). */
---kui-status-color-text-100: #0044f4;
-/* Text color for http status 200 elements (green.60). */
---kui-status-color-text-200: #007d60;
-/* Text color for http status 300 elements (yellow.60). */
---kui-status-color-text-300: #995c00;
-/* Text color for http status 400 elements (orange.60). */
---kui-status-color-text-400: #D13500;
-/* Text color for http status 500 elements (red.60). */
---kui-status-color-text-500: #d60027;
-/* The standard monospace text font family. Typically used for code blocks, inline code, and copyable text. */
---kui-font-family-code: 'JetBrains Mono', Consolas, monospace;
-/* The standard heading text font family. */
---kui-font-family-heading: 'Inter', Roboto, Helvetica, sans-serif;
-/* The standard text font family. */
---kui-font-family-text: 'Inter', Roboto, Helvetica, sans-serif;
---kui-font-size-10: 10px;
---kui-font-size-20: 12px;
---kui-font-size-30: 14px;
---kui-font-size-40: 16px;
---kui-font-size-50: 18px;
---kui-font-size-60: 20px;
---kui-font-size-70: 24px;
---kui-font-size-80: 32px;
---kui-font-size-90: 40px;
---kui-font-size-100: 48px;
-/* 700: The bold font weight. */
---kui-font-weight-bold: 700;
-/* 500: The medium font weight. */
---kui-font-weight-medium: 500;
-/* 400: The normal font weight. */
---kui-font-weight-regular: 400;
-/* 600: The semibold font weight. */
---kui-font-weight-semibold: 600;
-/* Alias for letter-spacing-normal */
---kui-letter-spacing-0: normal;
-/* -0.12px */
---kui-letter-spacing-minus-10: -0.12px;
-/* -0.24px */
---kui-letter-spacing-minus-20: -0.24px;
-/* -0.32px */
---kui-letter-spacing-minus-30: -0.32px;
-/* -0.4px */
---kui-letter-spacing-minus-40: -0.4px;
-/* -0.48px */
---kui-letter-spacing-minus-50: -0.48px;
-/* normal */
---kui-letter-spacing-normal: normal;
-/* 12px */
---kui-line-height-10: 12px;
-/* 16px */
---kui-line-height-20: 16px;
-/* 20px */
---kui-line-height-30: 20px;
-/* 24px */
---kui-line-height-40: 24px;
-/* 28px */
---kui-line-height-50: 28px;
-/* 32px */
---kui-line-height-60: 32px;
-/* 36px */
---kui-line-height-70: 36px;
-/* 40px */
---kui-line-height-80: 40px;
-/* 48px */
---kui-line-height-90: 48px;
-/* 56px */
---kui-line-height-100: 56px;
-/* 0px 4px 20px 0px rgba(0, 0, 0, 0.08) */
---kui-shadow: 0px 4px 20px 0px rgba(0, 0, 0, 0.08);
-/* 0px 0px 0px 1px gray.20 inset */
---kui-shadow-border: 0px 0px 0px 1px #e0e4ea inset;
-/* 0px 0px 0px 1px red.60 inset */
---kui-shadow-border-danger: 0px 0px 0px 1px #d60027 inset;
-/* 0px 0px 0px 1px red.70 inset */
---kui-shadow-border-danger-strong: 0px 0px 0px 1px #ad000e inset;
-/* 0px 0px 0px 1px gray.20 inset */
---kui-shadow-border-disabled: 0px 0px 0px 1px #e0e4ea inset;
-/* 0px 0px 0px 1px blue.60 inset */
---kui-shadow-border-primary: 0px 0px 0px 1px #0044f4 inset;
-/* 0px 0px 0px 1px blue.90 inset */
---kui-shadow-border-primary-strongest: 0px 0px 0px 1px #001466 inset;
-/* 0px 0px 0px 1px blue.40 inset */
---kui-shadow-border-primary-weak: 0px 0px 0px 1px #5f9aff inset;
-/* 0px 0px 0px 4px rgba(0, 68, 244, 0.2) */
---kui-shadow-focus: 0px 0px 0px 4px rgba(0, 68, 244, 0.2);
-/* 0px value for gaps, margin, or padding. */
---kui-space-0: 0px;
-/* 2px value for gaps, margin, or padding. */
---kui-space-10: 2px;
-/* 4px value for gaps, margin, or padding. */
---kui-space-20: 4px;
-/* 6px value for gaps, margin, or padding. */
---kui-space-30: 6px;
-/* 8px value for gaps, margin, or padding. */
---kui-space-40: 8px;
-/* 12px value for gaps, margin, or padding. */
---kui-space-50: 12px;
-/* 16px value for gaps, margin, or padding. */
---kui-space-60: 16px;
-/* 20px value for gaps, margin, or padding. */
---kui-space-70: 20px;
-/* 24px value for gaps, margin, or padding. */
---kui-space-80: 24px;
-/* 32px value for gaps, margin, or padding. */
---kui-space-90: 32px;
-/* 40px value for gaps, margin, or padding. */
---kui-space-100: 40px;
-/* 48px value for gaps, margin, or padding. */
---kui-space-110: 48px;
-/* 56px value for gaps, margin, or padding. */
---kui-space-120: 56px;
-/* 64px value for gaps, margin, or padding. */
---kui-space-130: 64px;
-/* 80px value for gaps, margin, or padding. */
---kui-space-140: 80px;
-/* 96px value for gaps, margin, or padding. */
---kui-space-150: 96px;
-/* auto */
---kui-space-auto: auto;
+--kui-color-background: ;
+--kui-color-background-danger: ;
+--kui-color-background-danger-strong: ;
+--kui-color-background-danger-stronger: ;
+--kui-color-background-danger-strongest: ;
+--kui-color-background-danger-weak: ;
+--kui-color-background-danger-weaker: ;
+--kui-color-background-danger-weakest: ;
+--kui-color-background-decorative-aqua-weakest: ;
+--kui-color-background-decorative-purple: ;
+--kui-color-background-decorative-purple-weakest: ;
+--kui-color-background-disabled: ;
+--kui-color-background-info: ;
+--kui-color-background-info-strong: ;
+--kui-color-background-info-stronger: ;
+--kui-color-background-info-strongest: ;
+--kui-color-background-info-weak: ;
+--kui-color-background-info-weaker: ;
+--kui-color-background-info-weakest: ;
+--kui-color-background-inverse: ;
+--kui-color-background-neutral: ;
+--kui-color-background-neutral-strong: ;
+--kui-color-background-neutral-stronger: ;
+--kui-color-background-neutral-strongest: ;
+--kui-color-background-neutral-weak: ;
+--kui-color-background-neutral-weaker: ;
+--kui-color-background-neutral-weakest: ;
+--kui-color-background-overlay: ;
+--kui-color-background-primary: ;
+--kui-color-background-primary-strong: ;
+--kui-color-background-primary-stronger: ;
+--kui-color-background-primary-strongest: ;
+--kui-color-background-primary-weak: ;
+--kui-color-background-primary-weaker: ;
+--kui-color-background-primary-weakest: ;
+--kui-color-background-success: ;
+--kui-color-background-success-strong: ;
+--kui-color-background-success-stronger: ;
+--kui-color-background-success-strongest: ;
+--kui-color-background-success-weak: ;
+--kui-color-background-success-weaker: ;
+--kui-color-background-success-weakest: ;
+--kui-color-background-transparent: ;
+--kui-color-background-warning: ;
+--kui-color-background-warning-strong: ;
+--kui-color-background-warning-stronger: ;
+--kui-color-background-warning-strongest: ;
+--kui-color-background-warning-weak: ;
+--kui-color-background-warning-weaker: ;
+--kui-color-background-warning-weakest: ;
+--kui-color-border: ;
+--kui-color-border-danger: ;
+--kui-color-border-danger-strong: ;
+--kui-color-border-danger-stronger: ;
+--kui-color-border-danger-strongest: ;
+--kui-color-border-danger-weak: ;
+--kui-color-border-danger-weaker: ;
+--kui-color-border-danger-weakest: ;
+--kui-color-border-decorative-purple: ;
+--kui-color-border-disabled: ;
+--kui-color-border-inverse: ;
+--kui-color-border-neutral: ;
+--kui-color-border-neutral-strong: ;
+--kui-color-border-neutral-stronger: ;
+--kui-color-border-neutral-strongest: ;
+--kui-color-border-neutral-weak: ;
+--kui-color-border-neutral-weaker: ;
+--kui-color-border-neutral-weakest: ;
+--kui-color-border-primary: ;
+--kui-color-border-primary-strong: ;
+--kui-color-border-primary-stronger: ;
+--kui-color-border-primary-strongest: ;
+--kui-color-border-primary-weak: ;
+--kui-color-border-primary-weaker: ;
+--kui-color-border-primary-weakest: ;
+--kui-color-border-transparent: ;
+--kui-color-text: ;
+--kui-color-text-danger: ;
+--kui-color-text-danger-strong: ;
+--kui-color-text-danger-stronger: ;
+--kui-color-text-danger-strongest: ;
+--kui-color-text-danger-weak: ;
+--kui-color-text-danger-weaker: ;
+--kui-color-text-danger-weakest: ;
+--kui-color-text-decorative-aqua: ;
+--kui-color-text-decorative-pink: ;
+--kui-color-text-decorative-purple: ;
+--kui-color-text-decorative-purple-strong: ;
+--kui-color-text-disabled: ;
+--kui-color-text-info: ;
+--kui-color-text-info-strong: ;
+--kui-color-text-info-stronger: ;
+--kui-color-text-info-strongest: ;
+--kui-color-text-info-weak: ;
+--kui-color-text-info-weaker: ;
+--kui-color-text-info-weakest: ;
+--kui-color-text-inverse: ;
+--kui-color-text-neutral: ;
+--kui-color-text-neutral-strong: ;
+--kui-color-text-neutral-stronger: ;
+--kui-color-text-neutral-strongest: ;
+--kui-color-text-neutral-weak: ;
+--kui-color-text-neutral-weaker: ;
+--kui-color-text-neutral-weakest: ;
+--kui-color-text-primary: ;
+--kui-color-text-primary-strong: ;
+--kui-color-text-primary-stronger: ;
+--kui-color-text-primary-strongest: ;
+--kui-color-text-primary-weak: ;
+--kui-color-text-primary-weaker: ;
+--kui-color-text-primary-weakest: ;
+--kui-color-text-success: ;
+--kui-color-text-success-strong: ;
+--kui-color-text-success-stronger: ;
+--kui-color-text-success-strongest: ;
+--kui-color-text-success-weak: ;
+--kui-color-text-success-weaker: ;
+--kui-color-text-success-weakest: ;
+--kui-color-text-warning: ;
+--kui-color-text-warning-strong: ;
+--kui-color-text-warning-stronger: ;
+--kui-color-text-warning-strongest: ;
+--kui-color-text-warning-weak: ;
+--kui-color-text-warning-weaker: ;
+--kui-color-text-warning-weakest: ;
+--kui-animation-duration-20: ;
+--kui-border-radius-0: ;
+--kui-border-radius-10: ;
+--kui-border-radius-20: ;
+--kui-border-radius-30: ;
+--kui-border-radius-40: ;
+--kui-border-radius-50: ;
+--kui-border-radius-circle: ;
+--kui-border-radius-round: ;
+--kui-border-width-0: ;
+--kui-border-width-10: ;
+--kui-border-width-20: ;
+--kui-border-width-30: ;
+--kui-breakpoint-mobile: ;
+--kui-breakpoint-phablet: ;
+--kui-breakpoint-tablet: ;
+--kui-breakpoint-laptop: ;
+--kui-breakpoint-desktop: ;
+--kui-icon-color-danger: ;
+--kui-icon-color-neutral: ;
+--kui-icon-color-primary: ;
+--kui-icon-color-success: ;
+--kui-icon-color-warning: ;
+--kui-icon-size-10: ;
+--kui-icon-size-20: ;
+--kui-icon-size-30: ;
+--kui-icon-size-40: ;
+--kui-icon-size-50: ;
+--kui-icon-size-60: ;
+--kui-icon-size-70: ;
+--kui-icon-size-80: ;
+--kui-method-color-background-connect: ;
+--kui-method-color-background-delete: ;
+--kui-method-color-background-get: ;
+--kui-method-color-background-head: ;
+--kui-method-color-background-options: ;
+--kui-method-color-background-patch: ;
+--kui-method-color-background-post: ;
+--kui-method-color-background-put: ;
+--kui-method-color-background-trace: ;
+--kui-method-color-text-connect: ;
+--kui-method-color-text-connect-strong: ;
+--kui-method-color-text-delete: ;
+--kui-method-color-text-delete-strong: ;
+--kui-method-color-text-get: ;
+--kui-method-color-text-get-strong: ;
+--kui-method-color-text-head: ;
+--kui-method-color-text-head-strong: ;
+--kui-method-color-text-options: ;
+--kui-method-color-text-options-strong: ;
+--kui-method-color-text-patch: ;
+--kui-method-color-text-patch-strong: ;
+--kui-method-color-text-post: ;
+--kui-method-color-text-post-strong: ;
+--kui-method-color-text-put: ;
+--kui-method-color-text-put-strong: ;
+--kui-method-color-text-trace: ;
+--kui-method-color-text-trace-strong: ;
+--kui-navigation-color-background: ;
+--kui-navigation-color-background-selected: ;
+--kui-navigation-color-border: ;
+--kui-navigation-color-border-child: ;
+--kui-navigation-color-border-divider: ;
+--kui-navigation-color-text: ;
+--kui-navigation-color-text-focus: ;
+--kui-navigation-color-text-hover: ;
+--kui-navigation-color-text-selected: ;
+--kui-navigation-shadow-border: ;
+--kui-navigation-shadow-border-child: ;
+--kui-navigation-shadow-focus: ;
+--kui-status-color-100: ;
+--kui-status-color-101: ;
+--kui-status-color-102: ;
+--kui-status-color-103: ;
+--kui-status-color-200: ;
+--kui-status-color-201: ;
+--kui-status-color-202: ;
+--kui-status-color-203: ;
+--kui-status-color-204: ;
+--kui-status-color-205: ;
+--kui-status-color-206: ;
+--kui-status-color-207: ;
+--kui-status-color-208: ;
+--kui-status-color-226: ;
+--kui-status-color-300: ;
+--kui-status-color-301: ;
+--kui-status-color-302: ;
+--kui-status-color-303: ;
+--kui-status-color-304: ;
+--kui-status-color-305: ;
+--kui-status-color-307: ;
+--kui-status-color-308: ;
+--kui-status-color-400: ;
+--kui-status-color-401: ;
+--kui-status-color-402: ;
+--kui-status-color-403: ;
+--kui-status-color-404: ;
+--kui-status-color-405: ;
+--kui-status-color-406: ;
+--kui-status-color-407: ;
+--kui-status-color-408: ;
+--kui-status-color-409: ;
+--kui-status-color-410: ;
+--kui-status-color-411: ;
+--kui-status-color-412: ;
+--kui-status-color-413: ;
+--kui-status-color-414: ;
+--kui-status-color-415: ;
+--kui-status-color-416: ;
+--kui-status-color-417: ;
+--kui-status-color-418: ;
+--kui-status-color-421: ;
+--kui-status-color-422: ;
+--kui-status-color-423: ;
+--kui-status-color-424: ;
+--kui-status-color-425: ;
+--kui-status-color-426: ;
+--kui-status-color-428: ;
+--kui-status-color-429: ;
+--kui-status-color-431: ;
+--kui-status-color-451: ;
+--kui-status-color-500: ;
+--kui-status-color-501: ;
+--kui-status-color-502: ;
+--kui-status-color-503: ;
+--kui-status-color-504: ;
+--kui-status-color-505: ;
+--kui-status-color-506: ;
+--kui-status-color-507: ;
+--kui-status-color-508: ;
+--kui-status-color-510: ;
+--kui-status-color-511: ;
+--kui-status-color-1na: ;
+--kui-status-color-2na: ;
+--kui-status-color-3na: ;
+--kui-status-color-4na: ;
+--kui-status-color-5na: ;
+--kui-status-color-100s: ;
+--kui-status-color-200s: ;
+--kui-status-color-300s: ;
+--kui-status-color-400s: ;
+--kui-status-color-500s: ;
+--kui-status-color-background-100: ;
+--kui-status-color-background-200: ;
+--kui-status-color-background-300: ;
+--kui-status-color-background-400: ;
+--kui-status-color-background-500: ;
+--kui-status-color-text-100: ;
+--kui-status-color-text-200: ;
+--kui-status-color-text-300: ;
+--kui-status-color-text-400: ;
+--kui-status-color-text-500: ;
+--kui-font-family-code: ;
+--kui-font-family-heading: ;
+--kui-font-family-text: ;
+--kui-font-size-10: ;
+--kui-font-size-20: ;
+--kui-font-size-30: ;
+--kui-font-size-40: ;
+--kui-font-size-50: ;
+--kui-font-size-60: ;
+--kui-font-size-70: ;
+--kui-font-size-80: ;
+--kui-font-size-90: ;
+--kui-font-size-100: ;
+--kui-font-weight-bold: ;
+--kui-font-weight-medium: ;
+--kui-font-weight-regular: ;
+--kui-font-weight-semibold: ;
+--kui-letter-spacing-0: ;
+--kui-letter-spacing-minus-10: ;
+--kui-letter-spacing-minus-20: ;
+--kui-letter-spacing-minus-30: ;
+--kui-letter-spacing-minus-40: ;
+--kui-letter-spacing-minus-50: ;
+--kui-letter-spacing-normal: ;
+--kui-line-height-10: ;
+--kui-line-height-20: ;
+--kui-line-height-30: ;
+--kui-line-height-40: ;
+--kui-line-height-50: ;
+--kui-line-height-60: ;
+--kui-line-height-70: ;
+--kui-line-height-80: ;
+--kui-line-height-90: ;
+--kui-line-height-100: ;
+--kui-shadow: ;
+--kui-shadow-border: ;
+--kui-shadow-border-danger: ;
+--kui-shadow-border-danger-strong: ;
+--kui-shadow-border-disabled: ;
+--kui-shadow-border-primary: ;
+--kui-shadow-border-primary-strongest: ;
+--kui-shadow-border-primary-weak: ;
+--kui-shadow-focus: ;
+--kui-space-0: ;
+--kui-space-10: ;
+--kui-space-20: ;
+--kui-space-30: ;
+--kui-space-40: ;
+--kui-space-50: ;
+--kui-space-60: ;
+--kui-space-70: ;
+--kui-space-80: ;
+--kui-space-90: ;
+--kui-space-100: ;
+--kui-space-110: ;
+--kui-space-120: ;
+--kui-space-130: ;
+--kui-space-140: ;
+--kui-space-150: ;
+--kui-space-auto: ;
 ```
 
 </details>
@@ -2728,670 +1420,343 @@ You may scope your CSS custom property overrides inside the `:root` selector as 
 <summary>Click to view the list of JavaScript variables</summary>
 
 ```javascript
-/* Default background color for containers (white). */
-export const KUI_COLOR_BACKGROUND = "#ffffff";
-/* Background color for danger actions or messages (red.60). */
-export const KUI_COLOR_BACKGROUND_DANGER = "#d60027";
-/* Strong background color for danger actions or messages (red.70). */
-export const KUI_COLOR_BACKGROUND_DANGER_STRONG = "#ad000e";
-/* Stronger background color for danger actions or messages (red.80). */
-export const KUI_COLOR_BACKGROUND_DANGER_STRONGER = "#850000";
-/* Strongest background color for danger actions or messages (red.90). */
-export const KUI_COLOR_BACKGROUND_DANGER_STRONGEST = "#5c0000";
-/* Weak background color for danger actions or messages (red.40). */
-export const KUI_COLOR_BACKGROUND_DANGER_WEAK = "#ff3954";
-/* Weaker background color for danger actions or messages (red.20). */
-export const KUI_COLOR_BACKGROUND_DANGER_WEAKER = "#ffabab";
-/* Weakest background color for danger actions or messages (red.10). */
-export const KUI_COLOR_BACKGROUND_DANGER_WEAKEST = "#ffe5e5";
-/* Weakest background color for decorative purposes (aqua.10). */
-export const KUI_COLOR_BACKGROUND_DECORATIVE_AQUA_WEAKEST = "#ecfcff";
-/* Background color for decorative purposes (purple.60). */
-export const KUI_COLOR_BACKGROUND_DECORATIVE_PURPLE = "#6f28ff";
-/* Weakest background color for decorative purposes (purple.10). */
-export const KUI_COLOR_BACKGROUND_DECORATIVE_PURPLE_WEAKEST = "#f1f0ff";
-/* Background color for disabled elements (gray.20). */
-export const KUI_COLOR_BACKGROUND_DISABLED = "#e0e4ea";
-/* Background color for info elements (blue.60). */
-export const KUI_COLOR_BACKGROUND_INFO = "#0044f4";
-/* Strong background color for info elements (blue.70). */
-export const KUI_COLOR_BACKGROUND_INFO_STRONG = "#0030cc";
-/* Stronger background color for info elements (blue.80). */
-export const KUI_COLOR_BACKGROUND_INFO_STRONGER = "#002099";
-/* Strongest background color for info elements (blue.90). */
-export const KUI_COLOR_BACKGROUND_INFO_STRONGEST = "#001466";
-/* Weak background color for info elements (blue.40). */
-export const KUI_COLOR_BACKGROUND_INFO_WEAK = "#5f9aff";
-/* Weaker background color for info elements (blue.20). */
-export const KUI_COLOR_BACKGROUND_INFO_WEAKER = "#bee2ff";
-/* Weakest background color for info elements (blue.10). */
-export const KUI_COLOR_BACKGROUND_INFO_WEAKEST = "#eefaff";
-/* Inverse background color for containers (blue.100) */
-export const KUI_COLOR_BACKGROUND_INVERSE = "#000933";
-/* Background color for neutral elements (gray.60). */
-export const KUI_COLOR_BACKGROUND_NEUTRAL = "#6c7489";
-/* Strong background color for neutral elements (gray.70). */
-export const KUI_COLOR_BACKGROUND_NEUTRAL_STRONG = "#52596e";
-/* Stronger background color for neutral elements (gray.80). */
-export const KUI_COLOR_BACKGROUND_NEUTRAL_STRONGER = "#3a3f51";
-/* Strongest background color for neutral elements (gray.90). */
-export const KUI_COLOR_BACKGROUND_NEUTRAL_STRONGEST = "#232633";
-/* Weak background color for neutral elements (gray.40). */
-export const KUI_COLOR_BACKGROUND_NEUTRAL_WEAK = "#afb7c5";
-/* Weaker background color for neutral elements (gray.20). */
-export const KUI_COLOR_BACKGROUND_NEUTRAL_WEAKER = "#e0e4ea";
-/* Weakest background color for neutral elements (gray.10). */
-export const KUI_COLOR_BACKGROUND_NEUTRAL_WEAKEST = "#f9fafb";
-/* Overlay background color (rgba(blue.100, 0.6)) */
-export const KUI_COLOR_BACKGROUND_OVERLAY = "rgba(0, 9, 51, 0.6)";
-/* Background color for primary actions or messages (blue.60). */
-export const KUI_COLOR_BACKGROUND_PRIMARY = "#0044f4";
-/* Strong background color for primary actions or messages (blue.70). */
-export const KUI_COLOR_BACKGROUND_PRIMARY_STRONG = "#0030cc";
-/* Stronger background color for primary actions or messages (blue.80). */
-export const KUI_COLOR_BACKGROUND_PRIMARY_STRONGER = "#002099";
-/* Strongest background color for primary actions or messages (blue.90). */
-export const KUI_COLOR_BACKGROUND_PRIMARY_STRONGEST = "#001466";
-/* Weak background color for primary actions or messages (blue.40). */
-export const KUI_COLOR_BACKGROUND_PRIMARY_WEAK = "#5f9aff";
-/* Weaker background color for primary actions or messages (blue.20). */
-export const KUI_COLOR_BACKGROUND_PRIMARY_WEAKER = "#bee2ff";
-/* Weakest background color for primary actions or messages (blue.10) */
-export const KUI_COLOR_BACKGROUND_PRIMARY_WEAKEST = "#eefaff";
-/* Background color for success elements (green.60). */
-export const KUI_COLOR_BACKGROUND_SUCCESS = "#007d60";
-/* Strong background color for success elements (green.70). */
-export const KUI_COLOR_BACKGROUND_SUCCESS_STRONG = "#005944";
-/* Stronger background color for success elements (green.80). */
-export const KUI_COLOR_BACKGROUND_SUCCESS_STRONGER = "#004737";
-/* Strongest background color for success elements (green.90). */
-export const KUI_COLOR_BACKGROUND_SUCCESS_STRONGEST = "#003629";
-/* Weak background color for success elements (green.40). */
-export const KUI_COLOR_BACKGROUND_SUCCESS_WEAK = "#00d6a4";
-/* Weaker background color for success elements (green.20). */
-export const KUI_COLOR_BACKGROUND_SUCCESS_WEAKER = "#b5ffee";
-/* Weakest background color for success elements (green.10). */
-export const KUI_COLOR_BACKGROUND_SUCCESS_WEAKEST = "#ecfffb";
-/* Transparent background color (transparent). */
-export const KUI_COLOR_BACKGROUND_TRANSPARENT = "transparent";
-/* Background color for warning elements (yellow.60). */
-export const KUI_COLOR_BACKGROUND_WARNING = "#995c00";
-/* Strong background color for warning elements (yellow.70). */
-export const KUI_COLOR_BACKGROUND_WARNING_STRONG = "#804400";
-/* Stronger background color for warning elements (yellow.80). */
-export const KUI_COLOR_BACKGROUND_WARNING_STRONGER = "#662d00";
-/* Strongest background color for warning elements (yellow.90). */
-export const KUI_COLOR_BACKGROUND_WARNING_STRONGEST = "#4d1b00";
-/* Weak background color for warning elements (yellow.40). */
-export const KUI_COLOR_BACKGROUND_WARNING_WEAK = "#ffc400";
-/* Weaker background color for warning elements (yellow.20). */
-export const KUI_COLOR_BACKGROUND_WARNING_WEAKER = "#fff296";
-/* Weakest background color for warning elements (yellow.10). */
-export const KUI_COLOR_BACKGROUND_WARNING_WEAKEST = "#fffce0";
-/* Default border color for containers (gray.20). */
-export const KUI_COLOR_BORDER = "#e0e4ea";
-/* Border color for danger actions or messages (red.60). */
-export const KUI_COLOR_BORDER_DANGER = "#d60027";
-/* Strong border color for danger actions or messages (red.70). */
-export const KUI_COLOR_BORDER_DANGER_STRONG = "#ad000e";
-/* Stronger border color for danger actions or messages (red.80). */
-export const KUI_COLOR_BORDER_DANGER_STRONGER = "#850000";
-/* Strongest border color for danger actions or messages (red.90). */
-export const KUI_COLOR_BORDER_DANGER_STRONGEST = "#5c0000";
-/* Weak border color for danger actions or messages (red.40). */
-export const KUI_COLOR_BORDER_DANGER_WEAK = "#ff3954";
-/* Weaker border color for danger actions or messages (red.20). */
-export const KUI_COLOR_BORDER_DANGER_WEAKER = "#ffabab";
-/* Weakest border color for danger actions or messages (red.10). */
-export const KUI_COLOR_BORDER_DANGER_WEAKEST = "#ffe5e5";
-/* Border color for decorative purposes (purple.60). */
-export const KUI_COLOR_BORDER_DECORATIVE_PURPLE = "#6f28ff";
-/* Border color for disabled elements (gray.20). */
-export const KUI_COLOR_BORDER_DISABLED = "#e0e4ea";
-/* Inverse border color (rgba(white, 0.2)). */
-export const KUI_COLOR_BORDER_INVERSE = "rgba(255, 255, 255, 0.2)";
-/* Border color for neutral elements (gray.60) */
-export const KUI_COLOR_BORDER_NEUTRAL = "#6c7489";
-/* Strong border color for neutral elements (gray.70) */
-export const KUI_COLOR_BORDER_NEUTRAL_STRONG = "#52596e";
-/* Stronger border color for neutral elements (gray.80) */
-export const KUI_COLOR_BORDER_NEUTRAL_STRONGER = "#3a3f51";
-/* Strongest border color for neutral elements (gray.90) */
-export const KUI_COLOR_BORDER_NEUTRAL_STRONGEST = "#232633";
-/* Weak border color for neutral elements (gray.40) */
-export const KUI_COLOR_BORDER_NEUTRAL_WEAK = "#afb7c5";
-/* Weaker border color for neutral elements (gray.20) */
-export const KUI_COLOR_BORDER_NEUTRAL_WEAKER = "#e0e4ea";
-/* Weakest border color for neutral elements (gray.10) */
-export const KUI_COLOR_BORDER_NEUTRAL_WEAKEST = "#f9fafb";
-/* Border color for primary actions or messages (blue.60). */
-export const KUI_COLOR_BORDER_PRIMARY = "#0044f4";
-/* Strong border color for primary actions or messages (blue.70). */
-export const KUI_COLOR_BORDER_PRIMARY_STRONG = "#0030cc";
-/* Stronger border color for primary actions or messages (blue.80). */
-export const KUI_COLOR_BORDER_PRIMARY_STRONGER = "#002099";
-/* Strongest border color for primary actions or messages (blue.90). */
-export const KUI_COLOR_BORDER_PRIMARY_STRONGEST = "#001466";
-/* Weak border color for primary actions or messages (blue.40). */
-export const KUI_COLOR_BORDER_PRIMARY_WEAK = "#5f9aff";
-/* Weaker border color for primary actions or messages (blue.20). */
-export const KUI_COLOR_BORDER_PRIMARY_WEAKER = "#bee2ff";
-/* Weakest border color for primary actions or messages (blue.10). */
-export const KUI_COLOR_BORDER_PRIMARY_WEAKEST = "#eefaff";
-/* Transparent border color (transparent). */
-export const KUI_COLOR_BORDER_TRANSPARENT = "transparent";
-/* Default text color (blue.100). */
-export const KUI_COLOR_TEXT = "#000933";
-/* Text color for danger actions or messages (red.60). */
-export const KUI_COLOR_TEXT_DANGER = "#d60027";
-/* Strong text color for danger actions or messages (red.70). */
-export const KUI_COLOR_TEXT_DANGER_STRONG = "#ad000e";
-/* Stronger text color for danger actions or messages (red.80). */
-export const KUI_COLOR_TEXT_DANGER_STRONGER = "#850000";
-/* Strongest text color for danger actions or messages (red.90). */
-export const KUI_COLOR_TEXT_DANGER_STRONGEST = "#5c0000";
-/* Weak text color for danger actions or messages (red.40). */
-export const KUI_COLOR_TEXT_DANGER_WEAK = "#ff3954";
-/* Weaker text color for danger actions or messages (red.20). */
-export const KUI_COLOR_TEXT_DANGER_WEAKER = "#ffabab";
-/* Weakest text color for danger actions or messages (red.10). */
-export const KUI_COLOR_TEXT_DANGER_WEAKEST = "#ffe5e5";
-/* Text color for decorative purposes (aqua.50). */
-export const KUI_COLOR_TEXT_DECORATIVE_AQUA = "#00abd2";
-/* Text color for decorative purposes (pink.60). */
-export const KUI_COLOR_TEXT_DECORATIVE_PINK = "#d60067";
-/* Text color for decorative purposes (purple.60). */
-export const KUI_COLOR_TEXT_DECORATIVE_PURPLE = "#6f28ff";
-/* Strong text color for decorative purposes (purple.70). */
-export const KUI_COLOR_TEXT_DECORATIVE_PURPLE_STRONG = "#5e00f5";
-/* Text color for disabled elements (gray.40). */
-export const KUI_COLOR_TEXT_DISABLED = "#afb7c5";
-/* Text color for info elements (blue.60). */
-export const KUI_COLOR_TEXT_INFO = "#0044f4";
-/* Strong text color for info elements (blue.70). */
-export const KUI_COLOR_TEXT_INFO_STRONG = "#0030cc";
-/* Stronger text color for info elements (blue.80). */
-export const KUI_COLOR_TEXT_INFO_STRONGER = "#002099";
-/* Strongest text color for info elements (blue.90). */
-export const KUI_COLOR_TEXT_INFO_STRONGEST = "#001466";
-/* Weak text color for info elements (blue.40). */
-export const KUI_COLOR_TEXT_INFO_WEAK = "#5f9aff";
-/* Weaker text color for info elements (blue.20). */
-export const KUI_COLOR_TEXT_INFO_WEAKER = "#bee2ff";
-/* Weakest text color for info elements (blue.10). */
-export const KUI_COLOR_TEXT_INFO_WEAKEST = "#eefaff";
-/* Inverse text color (white). */
-export const KUI_COLOR_TEXT_INVERSE = "#ffffff";
-/* Text color for neutral elements (gray.60). */
-export const KUI_COLOR_TEXT_NEUTRAL = "#6c7489";
-/* Strong text color for neutral elements (gray.70). */
-export const KUI_COLOR_TEXT_NEUTRAL_STRONG = "#52596e";
-/* Stronger text color for neutral elements (gray.80). */
-export const KUI_COLOR_TEXT_NEUTRAL_STRONGER = "#3a3f51";
-/* Strongest text color for neutral elements (gray.90). */
-export const KUI_COLOR_TEXT_NEUTRAL_STRONGEST = "#232633";
-/* Weak text color for neutral elements (gray.40). */
-export const KUI_COLOR_TEXT_NEUTRAL_WEAK = "#afb7c5";
-/* Weaker text color for neutral elements (gray.20). */
-export const KUI_COLOR_TEXT_NEUTRAL_WEAKER = "#e0e4ea";
-/* Weakest text color for neutral elements (gray.10). */
-export const KUI_COLOR_TEXT_NEUTRAL_WEAKEST = "#f9fafb";
-/* Text color for primary actions or messages (blue.60). */
-export const KUI_COLOR_TEXT_PRIMARY = "#0044f4";
-/* Strong text color for primary actions or messages (blue.70). */
-export const KUI_COLOR_TEXT_PRIMARY_STRONG = "#0030cc";
-/* Stronger text color for primary actions or messages (blue.80). */
-export const KUI_COLOR_TEXT_PRIMARY_STRONGER = "#002099";
-/* Strongest text color for primary actions or messages (blue.90). */
-export const KUI_COLOR_TEXT_PRIMARY_STRONGEST = "#001466";
-/* Weak text color for primary actions or messages (blue.40). */
-export const KUI_COLOR_TEXT_PRIMARY_WEAK = "#5f9aff";
-/* Weaker text color for primary actions or messages (blue.20). */
-export const KUI_COLOR_TEXT_PRIMARY_WEAKER = "#bee2ff";
-/* Weakest text color for primary actions or messages (blue.10). */
-export const KUI_COLOR_TEXT_PRIMARY_WEAKEST = "#eefaff";
-/* Text color for success elements (green.60). */
-export const KUI_COLOR_TEXT_SUCCESS = "#007d60";
-/* Strong text color for success elements (green.70). */
-export const KUI_COLOR_TEXT_SUCCESS_STRONG = "#005944";
-/* Stronger text color for success elements (green.80). */
-export const KUI_COLOR_TEXT_SUCCESS_STRONGER = "#004737";
-/* Stronger text color for success elements (green.90). */
-export const KUI_COLOR_TEXT_SUCCESS_STRONGEST = "#003629";
-/* Weak text color for success elements (green.40). */
-export const KUI_COLOR_TEXT_SUCCESS_WEAK = "#00d6a4";
-/* Weaker text color for success elements (green.20). */
-export const KUI_COLOR_TEXT_SUCCESS_WEAKER = "#b5ffee";
-/* Weakest text color for success elements (green.10). */
-export const KUI_COLOR_TEXT_SUCCESS_WEAKEST = "#ecfffb";
-/* Text color for warning elements (yellow.60). */
-export const KUI_COLOR_TEXT_WARNING = "#995c00";
-/* Strong text color for warning elements (yellow.70). */
-export const KUI_COLOR_TEXT_WARNING_STRONG = "#804400";
-/* Stronger text color for warning elements (yellow.80). */
-export const KUI_COLOR_TEXT_WARNING_STRONGER = "#662d00";
-/* Strongest text color for warning elements (yellow.90). */
-export const KUI_COLOR_TEXT_WARNING_STRONGEST = "#4d1b00";
-/* Weak text color for warning elements (yellow.40). */
-export const KUI_COLOR_TEXT_WARNING_WEAK = "#ffc400";
-/* Weaker text color for warning elements (yellow.20). */
-export const KUI_COLOR_TEXT_WARNING_WEAKER = "#fff296";
-/* Weakest text color for warning elements (yellow.10). */
-export const KUI_COLOR_TEXT_WARNING_WEAKEST = "#fffce0";
-/* Default transition timing */
-export const KUI_ANIMATION_DURATION_20 = "0.2s";
-/* 0px border radius. */
-export const KUI_BORDER_RADIUS_0 = "0px";
-/* 2px border radius. */
-export const KUI_BORDER_RADIUS_10 = "2px";
-/* 4px border radius. */
-export const KUI_BORDER_RADIUS_20 = "4px";
-/* 6px border radius. */
-export const KUI_BORDER_RADIUS_30 = "6px";
-/* 8px border radius. */
-export const KUI_BORDER_RADIUS_40 = "8px";
-/* 10px border radius. */
-export const KUI_BORDER_RADIUS_50 = "10px";
-/* 50% border radius used to create circles. */
-export const KUI_BORDER_RADIUS_CIRCLE = "50%";
-/* 100px border radius used to create pill shapes. */
-export const KUI_BORDER_RADIUS_ROUND = "100px";
-/* 0px border width. */
-export const KUI_BORDER_WIDTH_0 = "0px";
-/* 1px border width. */
-export const KUI_BORDER_WIDTH_10 = "1px";
-/* 2px border width. */
-export const KUI_BORDER_WIDTH_20 = "2px";
-/* 4px border width. */
-export const KUI_BORDER_WIDTH_30 = "4px";
-/* Used for larger mobile screens. Any viewport width under this value is considered mobile. */
-export const KUI_BREAKPOINT_MOBILE = "640px";
-/* Used for tablet screens. */
-export const KUI_BREAKPOINT_PHABLET = "768px";
-/* Used for larger tablet screens. Any viewport width less than this value will likely show a mobile layout. Any viewport width this value and greater will likely show a desktop layout. */
-export const KUI_BREAKPOINT_TABLET = "1024px";
-/* Used for standard desktop screens. */
-export const KUI_BREAKPOINT_LAPTOP = "1280px";
-/* Used for larger desktop screens. */
-export const KUI_BREAKPOINT_DESKTOP = "1536px";
-/* Danger color for icons. */
-export const KUI_ICON_COLOR_DANGER = "#f50045";
-/* Neutral color for icons. */
-export const KUI_ICON_COLOR_NEUTRAL = "#828a9e";
-/* Primary color for icons. */
-export const KUI_ICON_COLOR_PRIMARY = "#306fff";
-/* Success color for icons. */
-export const KUI_ICON_COLOR_SUCCESS = "#00a17b";
-/* Warning color for icons. */
-export const KUI_ICON_COLOR_WARNING = "#ffc400";
-/* 10px icon size. */
-export const KUI_ICON_SIZE_10 = "10px";
-/* 12px icon size. */
-export const KUI_ICON_SIZE_20 = "12px";
-/* 16px icon size. */
-export const KUI_ICON_SIZE_30 = "16px";
-/* 20px icon size. */
-export const KUI_ICON_SIZE_40 = "20px";
-/* 24px icon size (default). */
-export const KUI_ICON_SIZE_50 = "24px";
-/* 32px icon size. */
-export const KUI_ICON_SIZE_60 = "32px";
-/* 40px icon size. */
-export const KUI_ICON_SIZE_70 = "40px";
-/* 48px icon size. */
-export const KUI_ICON_SIZE_80 = "48px";
-/* Background color for the CONNECT method (purple.10). */
-export const KUI_METHOD_COLOR_BACKGROUND_CONNECT = "#f1f0ff";
-/* Background color for the DELETE method (red.10). */
-export const KUI_METHOD_COLOR_BACKGROUND_DELETE = "#ffe5e5";
-/* Background color for the GET method (blue.10). */
-export const KUI_METHOD_COLOR_BACKGROUND_GET = "#eefaff";
-/* Background color for the HEAD method (gray.70). */
-export const KUI_METHOD_COLOR_BACKGROUND_HEAD = "#52596e";
-/* Background color for the OPTIONS method (gray.20). */
-export const KUI_METHOD_COLOR_BACKGROUND_OPTIONS = "#e0e4ea";
-/* Background color for the PATCH method (aqua.10). */
-export const KUI_METHOD_COLOR_BACKGROUND_PATCH = "#ecfcff";
-/* Background color for the POST method (green.10). */
-export const KUI_METHOD_COLOR_BACKGROUND_POST = "#ecfffb";
-/* Background color for the PUT method (yellow.10). */
-export const KUI_METHOD_COLOR_BACKGROUND_PUT = "#fffce0";
-/* Background color for the TRACE method (pink.10). */
-export const KUI_METHOD_COLOR_BACKGROUND_TRACE = "#fff0f7";
-/* Text color for the CONNECT method (purple.60). */
-export const KUI_METHOD_COLOR_TEXT_CONNECT = "#6f28ff";
-/* Strong text color for the CONNECT method (purple.70). */
-export const KUI_METHOD_COLOR_TEXT_CONNECT_STRONG = "#5e00f5";
-/* Text color for the DELETE method (red.60). */
-export const KUI_METHOD_COLOR_TEXT_DELETE = "#d60027";
-/* Strong text color for the DELETE method (red.70). */
-export const KUI_METHOD_COLOR_TEXT_DELETE_STRONG = "#ad000e";
-/* Text color for the GET method (blue.60). */
-export const KUI_METHOD_COLOR_TEXT_GET = "#0044f4";
-/* Strong text color for the GET method (blue.70). */
-export const KUI_METHOD_COLOR_TEXT_GET_STRONG = "#0030cc";
-/* Text color for the HEAD method (gray.20). */
-export const KUI_METHOD_COLOR_TEXT_HEAD = "#e0e4ea";
-/* Strong text color for the HEAD method (gray.40). */
-export const KUI_METHOD_COLOR_TEXT_HEAD_STRONG = "#afb7c5";
-/* Text color for the OPTIONS method (gray.70). */
-export const KUI_METHOD_COLOR_TEXT_OPTIONS = "#52596e";
-/* Strong text color for the OPTIONS method (gray.80). */
-export const KUI_METHOD_COLOR_TEXT_OPTIONS_STRONG = "#3a3f51";
-/* Text color for the PATCH method (aqua.60). */
-export const KUI_METHOD_COLOR_TEXT_PATCH = "#00819d";
-/* Strong text color for the PATCH method (aqua.70). */
-export const KUI_METHOD_COLOR_TEXT_PATCH_STRONG = "#00647a";
-/* Text color for the POST method (green.60). */
-export const KUI_METHOD_COLOR_TEXT_POST = "#007d60";
-/* Strong text color for the POST method (green.70). */
-export const KUI_METHOD_COLOR_TEXT_POST_STRONG = "#005944";
-/* Text color for the PUT method (yellow.60). */
-export const KUI_METHOD_COLOR_TEXT_PUT = "#995c00";
-/* Strong text color for the PUT method (yellow.70). */
-export const KUI_METHOD_COLOR_TEXT_PUT_STRONG = "#804400";
-/* Text color for the TRACE method (pink.60). */
-export const KUI_METHOD_COLOR_TEXT_TRACE = "#d60067";
-/* Strong text color for the TRACE method (pink.70). */
-export const KUI_METHOD_COLOR_TEXT_TRACE_STRONG = "#ad0053";
-/* blue.100 */
-export const KUI_NAVIGATION_COLOR_BACKGROUND = "#000933";
-/* The background color of a selected navigation item. */
-export const KUI_NAVIGATION_COLOR_BACKGROUND_SELECTED = "rgba(255, 255, 255, 0.12)";
-/* rgba(white, 0.12) */
-export const KUI_NAVIGATION_COLOR_BORDER = "rgba(255, 255, 255, 0.12)";
-/* The border color for a selected child navigation item. */
-export const KUI_NAVIGATION_COLOR_BORDER_CHILD = "#00fabe";
-/* The color of the navigation section divider. */
-export const KUI_NAVIGATION_COLOR_BORDER_DIVIDER = "rgba(255, 255, 255, 0.24)";
-/* Navigation link and icon color. */
-export const KUI_NAVIGATION_COLOR_TEXT = "#bee2ff";
-/* Navigation link and icon focus-visible color. */
-export const KUI_NAVIGATION_COLOR_TEXT_FOCUS = "#ffffff";
-/* Navigation link and icon hover color. */
-export const KUI_NAVIGATION_COLOR_TEXT_HOVER = "#eefaff";
-/* Navigation link and icon selected color. */
-export const KUI_NAVIGATION_COLOR_TEXT_SELECTED = "#00fabe";
-/* The box-shadow for a focus-visible navigation link. */
-export const KUI_NAVIGATION_SHADOW_BORDER = "0 0 0 1px rgba(255, 255, 255, 0.12) inset";
-/* The left box-shadow for an active child navigation link. */
-export const KUI_NAVIGATION_SHADOW_BORDER_CHILD = "4px 0 0 0 #00fabe inset";
-/* Navigation link focus-visible box-shadow. */
-export const KUI_NAVIGATION_SHADOW_FOCUS = "0 0 0 1px rgba(255, 255, 255, 0.60) inset";
-/* Color representing response status code 100 (blue.20). */
-export const KUI_STATUS_COLOR_100 = "#bee2ff";
-/* Color representing response status code 101 (blue.30). */
-export const KUI_STATUS_COLOR_101 = "#8fc1ff";
-/* Color representing response status code 102 (blue.40). */
-export const KUI_STATUS_COLOR_102 = "#5f9aff";
-/* Color representing response status code 103 (blue.50). */
-export const KUI_STATUS_COLOR_103 = "#306fff";
-/* Color representing response status code 200 (green.20). */
-export const KUI_STATUS_COLOR_200 = "#b5ffee";
-/* Color representing response status code 201 (green.30). */
-export const KUI_STATUS_COLOR_201 = "#00fabe";
-/* Color representing response status code 202 (green.40). */
-export const KUI_STATUS_COLOR_202 = "#00d6a4";
-/* Color representing response status code 203 (green.50). */
-export const KUI_STATUS_COLOR_203 = "#00a17b";
-/* Color representing response status code 204 (green.60). */
-export const KUI_STATUS_COLOR_204 = "#007d60";
-/* Color representing response status code 205 (green.70). */
-export const KUI_STATUS_COLOR_205 = "#005944";
-/* Color representing response status code 206 (green.20). */
-export const KUI_STATUS_COLOR_206 = "#b5ffee";
-/* Color representing response status code 207 (green.30). */
-export const KUI_STATUS_COLOR_207 = "#00fabe";
-/* Color representing response status code 208 (green.40). */
-export const KUI_STATUS_COLOR_208 = "#b5ffee";
-/* Color representing response status code 226 (green.50). */
-export const KUI_STATUS_COLOR_226 = "#00a17b";
-/* Color representing response status code 100 (yellow.20). */
-export const KUI_STATUS_COLOR_300 = "#fff296";
-/* Color representing response status code 101 (yellow.30). */
-export const KUI_STATUS_COLOR_301 = "#ffe04b";
-/* Color representing response status code 102 (yellow.40). */
-export const KUI_STATUS_COLOR_302 = "#ffc400";
-/* Color representing response status code 103 (yellow.50). */
-export const KUI_STATUS_COLOR_303 = "#b37600";
-/* Color representing response status code 103 (yellow.60). */
-export const KUI_STATUS_COLOR_304 = "#995c00";
-/* Color representing response status code 103 (yellow.70). */
-export const KUI_STATUS_COLOR_305 = "#804400";
-/* Color representing response status code 103 (yellow.20). */
-export const KUI_STATUS_COLOR_307 = "#fff296";
-/* Color representing response status code 103 (yellow.30). */
-export const KUI_STATUS_COLOR_308 = "#ffe04b";
-/* Color representing response status code 400 (orange.20). */
-export const KUI_STATUS_COLOR_400 = "#FFC2B3";
-/* Color representing response status code 401 (orange.30). */
-export const KUI_STATUS_COLOR_401 = "#FF9877";
-/* Color representing response status code 402 (orange.40). */
-export const KUI_STATUS_COLOR_402 = "#FF723C";
-/* Color representing response status code 403 (orange.50). */
-export const KUI_STATUS_COLOR_403 = "#F75008";
-/* Color representing response status code 404 (orange.60). */
-export const KUI_STATUS_COLOR_404 = "#D13500";
-/* Color representing response status code 405 (orange.70). */
-export const KUI_STATUS_COLOR_405 = "#A31F00";
-/* Color representing response status code 406 (orange.20). */
-export const KUI_STATUS_COLOR_406 = "#FFC2B3";
-/* Color representing response status code 407 (orange.30). */
-export const KUI_STATUS_COLOR_407 = "#FF9877";
-/* Color representing response status code 408 (orange.40). */
-export const KUI_STATUS_COLOR_408 = "#FF723C";
-/* Color representing response status code 409 (orange.50). */
-export const KUI_STATUS_COLOR_409 = "#F75008";
-/* Color representing response status code 410 (orange.60). */
-export const KUI_STATUS_COLOR_410 = "#D13500";
-/* Color representing response status code 411 (orange.70). */
-export const KUI_STATUS_COLOR_411 = "#A31F00";
-/* Color representing response status code 412 (orange.20). */
-export const KUI_STATUS_COLOR_412 = "#FFC2B3";
-/* Color representing response status code 413 (orange.30). */
-export const KUI_STATUS_COLOR_413 = "#FF9877";
-/* Color representing response status code 414 (orange.40). */
-export const KUI_STATUS_COLOR_414 = "#FF723C";
-/* Color representing response status code 415 (orange.50). */
-export const KUI_STATUS_COLOR_415 = "#F75008";
-/* Color representing response status code 416 (orange.60). */
-export const KUI_STATUS_COLOR_416 = "#D13500";
-/* Color representing response status code 417 (orange.70). */
-export const KUI_STATUS_COLOR_417 = "#A31F00";
-/* Color representing response status code 418 (orange.20). */
-export const KUI_STATUS_COLOR_418 = "#FFC2B3";
-/* Color representing response status code 421 (orange.30). */
-export const KUI_STATUS_COLOR_421 = "#FF9877";
-/* Color representing response status code 422 (orange.40). */
-export const KUI_STATUS_COLOR_422 = "#FF723C";
-/* Color representing response status code 423 (orange.50). */
-export const KUI_STATUS_COLOR_423 = "#F75008";
-/* Color representing response status code 424 (orange.60). */
-export const KUI_STATUS_COLOR_424 = "#D13500";
-/* Color representing response status code 425 (orange.70). */
-export const KUI_STATUS_COLOR_425 = "#A31F00";
-/* Color representing response status code 426 (orange.20). */
-export const KUI_STATUS_COLOR_426 = "#FFC2B3";
-/* Color representing response status code 428 (orange.30). */
-export const KUI_STATUS_COLOR_428 = "#FF9877";
-/* Color representing response status code 429 (orange.40). */
-export const KUI_STATUS_COLOR_429 = "#FF723C";
-/* Color representing response status code 431 (orange.50). */
-export const KUI_STATUS_COLOR_431 = "#F75008";
-/* Color representing response status code 451 (orange.60). */
-export const KUI_STATUS_COLOR_451 = "#D13500";
-/* Color representing response status code 500 (red.20). */
-export const KUI_STATUS_COLOR_500 = "#ffabab";
-/* Color representing response status code 501 (red.30). */
-export const KUI_STATUS_COLOR_501 = "#ff7272";
-/* Color representing response status code 502 (red.40). */
-export const KUI_STATUS_COLOR_502 = "#ff3954";
-/* Color representing response status code 503 (red.50). */
-export const KUI_STATUS_COLOR_503 = "#f50045";
-/* Color representing response status code 504 (red.60). */
-export const KUI_STATUS_COLOR_504 = "#d60027";
-/* Color representing response status code 505 (red.70). */
-export const KUI_STATUS_COLOR_505 = "#ad000e";
-/* Color representing response status code 506 (red.20). */
-export const KUI_STATUS_COLOR_506 = "#ffabab";
-/* Color representing response status code 507 (red.30). */
-export const KUI_STATUS_COLOR_507 = "#ff7272";
-/* Color representing response status code 508 (red.40). */
-export const KUI_STATUS_COLOR_508 = "#ff3954";
-/* Color representing response status code 510 (red.50). */
-export const KUI_STATUS_COLOR_510 = "#f50045";
-/* Color representing response status code 511 (red.60). */
-export const KUI_STATUS_COLOR_511 = "#d60027";
-/* Color for unknown response status codes in the 100-199 range (blue.10). */
-export const KUI_STATUS_COLOR_1NA = "#eefaff";
-/* Color for unknown response status codes in the 200-299 range (green.10). */
-export const KUI_STATUS_COLOR_2NA = "#ecfffb";
-/* Color for unknown response status codes in the 300-399 range (yellow.10). */
-export const KUI_STATUS_COLOR_3NA = "#fffce0";
-/* Color for unknown response status codes in the 400-499 range (orange.10). */
-export const KUI_STATUS_COLOR_4NA = "#FFF1EF";
-/* Color for unknown response status codes in the 500-599 range (red.10). */
-export const KUI_STATUS_COLOR_5NA = "#ffe5e5";
-/* Color for a group of response status codes in the 100-199 range (blue.40). */
-export const KUI_STATUS_COLOR_100S = "#5f9aff";
-/* Color for a group of response status codes in the 200-299 range (green.40). */
-export const KUI_STATUS_COLOR_200S = "#00d6a4";
-/* Color for a group of response status codes in the 300-399 range (yellow.40). */
-export const KUI_STATUS_COLOR_300S = "#ffc400";
-/* Color for a group of response status codes in the 400-499 range (orange.40). */
-export const KUI_STATUS_COLOR_400S = "#FF723C";
-/* Color for a group of response status codes in the 500-599 range (red.40). */
-export const KUI_STATUS_COLOR_500S = "#ff3954";
-/* Background color for http status 100 elements (blue.10). */
-export const KUI_STATUS_COLOR_BACKGROUND_100 = "#eefaff";
-/* Background color for http status 200 elements (green.10). */
-export const KUI_STATUS_COLOR_BACKGROUND_200 = "#ecfffb";
-/* Background color for http status 300 elements (yellow.10). */
-export const KUI_STATUS_COLOR_BACKGROUND_300 = "#fffce0";
-/* Background color for http status 400 elements (orange.10). */
-export const KUI_STATUS_COLOR_BACKGROUND_400 = "#FFF1EF";
-/* Background color for http status 500 elements (red.10). */
-export const KUI_STATUS_COLOR_BACKGROUND_500 = "#ffe5e5";
-/* Text color for http status 100 elements (blue.60). */
-export const KUI_STATUS_COLOR_TEXT_100 = "#0044f4";
-/* Text color for http status 200 elements (green.60). */
-export const KUI_STATUS_COLOR_TEXT_200 = "#007d60";
-/* Text color for http status 300 elements (yellow.60). */
-export const KUI_STATUS_COLOR_TEXT_300 = "#995c00";
-/* Text color for http status 400 elements (orange.60). */
-export const KUI_STATUS_COLOR_TEXT_400 = "#D13500";
-/* Text color for http status 500 elements (red.60). */
-export const KUI_STATUS_COLOR_TEXT_500 = "#d60027";
-/* The standard monospace text font family. Typically used for code blocks, inline code, and copyable text. */
-export const KUI_FONT_FAMILY_CODE = "'JetBrains Mono', Consolas, monospace";
-/* The standard heading text font family. */
-export const KUI_FONT_FAMILY_HEADING = "'Inter', Roboto, Helvetica, sans-serif";
-/* The standard text font family. */
-export const KUI_FONT_FAMILY_TEXT = "'Inter', Roboto, Helvetica, sans-serif";
-export const KUI_FONT_SIZE_10 = "10px";
-export const KUI_FONT_SIZE_20 = "12px";
-export const KUI_FONT_SIZE_30 = "14px";
-export const KUI_FONT_SIZE_40 = "16px";
-export const KUI_FONT_SIZE_50 = "18px";
-export const KUI_FONT_SIZE_60 = "20px";
-export const KUI_FONT_SIZE_70 = "24px";
-export const KUI_FONT_SIZE_80 = "32px";
-export const KUI_FONT_SIZE_90 = "40px";
-export const KUI_FONT_SIZE_100 = "48px";
-/* 700: The bold font weight. */
-export const KUI_FONT_WEIGHT_BOLD = "700";
-/* 500: The medium font weight. */
-export const KUI_FONT_WEIGHT_MEDIUM = "500";
-/* 400: The normal font weight. */
-export const KUI_FONT_WEIGHT_REGULAR = "400";
-/* 600: The semibold font weight. */
-export const KUI_FONT_WEIGHT_SEMIBOLD = "600";
-/* Alias for letter-spacing-normal */
-export const KUI_LETTER_SPACING_0 = "normal";
-/* -0.12px */
-export const KUI_LETTER_SPACING_MINUS_10 = "-0.12px";
-/* -0.24px */
-export const KUI_LETTER_SPACING_MINUS_20 = "-0.24px";
-/* -0.32px */
-export const KUI_LETTER_SPACING_MINUS_30 = "-0.32px";
-/* -0.4px */
-export const KUI_LETTER_SPACING_MINUS_40 = "-0.4px";
-/* -0.48px */
-export const KUI_LETTER_SPACING_MINUS_50 = "-0.48px";
-/* normal */
-export const KUI_LETTER_SPACING_NORMAL = "normal";
-/* 12px */
-export const KUI_LINE_HEIGHT_10 = "12px";
-/* 16px */
-export const KUI_LINE_HEIGHT_20 = "16px";
-/* 20px */
-export const KUI_LINE_HEIGHT_30 = "20px";
-/* 24px */
-export const KUI_LINE_HEIGHT_40 = "24px";
-/* 28px */
-export const KUI_LINE_HEIGHT_50 = "28px";
-/* 32px */
-export const KUI_LINE_HEIGHT_60 = "32px";
-/* 36px */
-export const KUI_LINE_HEIGHT_70 = "36px";
-/* 40px */
-export const KUI_LINE_HEIGHT_80 = "40px";
-/* 48px */
-export const KUI_LINE_HEIGHT_90 = "48px";
-/* 56px */
-export const KUI_LINE_HEIGHT_100 = "56px";
-/* 0px 4px 20px 0px rgba(0, 0, 0, 0.08) */
-export const KUI_SHADOW = "0px 4px 20px 0px rgba(0, 0, 0, 0.08)";
-/* 0px 0px 0px 1px gray.20 inset */
-export const KUI_SHADOW_BORDER = "0px 0px 0px 1px #e0e4ea inset";
-/* 0px 0px 0px 1px red.60 inset */
-export const KUI_SHADOW_BORDER_DANGER = "0px 0px 0px 1px #d60027 inset";
-/* 0px 0px 0px 1px red.70 inset */
-export const KUI_SHADOW_BORDER_DANGER_STRONG = "0px 0px 0px 1px #ad000e inset";
-/* 0px 0px 0px 1px gray.20 inset */
-export const KUI_SHADOW_BORDER_DISABLED = "0px 0px 0px 1px #e0e4ea inset";
-/* 0px 0px 0px 1px blue.60 inset */
-export const KUI_SHADOW_BORDER_PRIMARY = "0px 0px 0px 1px #0044f4 inset";
-/* 0px 0px 0px 1px blue.90 inset */
-export const KUI_SHADOW_BORDER_PRIMARY_STRONGEST = "0px 0px 0px 1px #001466 inset";
-/* 0px 0px 0px 1px blue.40 inset */
-export const KUI_SHADOW_BORDER_PRIMARY_WEAK = "0px 0px 0px 1px #5f9aff inset";
-/* 0px 0px 0px 4px rgba(0, 68, 244, 0.2) */
-export const KUI_SHADOW_FOCUS = "0px 0px 0px 4px rgba(0, 68, 244, 0.2)";
-/* 0px value for gaps, margin, or padding. */
-export const KUI_SPACE_0 = "0px";
-/* 2px value for gaps, margin, or padding. */
-export const KUI_SPACE_10 = "2px";
-/* 4px value for gaps, margin, or padding. */
-export const KUI_SPACE_20 = "4px";
-/* 6px value for gaps, margin, or padding. */
-export const KUI_SPACE_30 = "6px";
-/* 8px value for gaps, margin, or padding. */
-export const KUI_SPACE_40 = "8px";
-/* 12px value for gaps, margin, or padding. */
-export const KUI_SPACE_50 = "12px";
-/* 16px value for gaps, margin, or padding. */
-export const KUI_SPACE_60 = "16px";
-/* 20px value for gaps, margin, or padding. */
-export const KUI_SPACE_70 = "20px";
-/* 24px value for gaps, margin, or padding. */
-export const KUI_SPACE_80 = "24px";
-/* 32px value for gaps, margin, or padding. */
-export const KUI_SPACE_90 = "32px";
-/* 40px value for gaps, margin, or padding. */
-export const KUI_SPACE_100 = "40px";
-/* 48px value for gaps, margin, or padding. */
-export const KUI_SPACE_110 = "48px";
-/* 56px value for gaps, margin, or padding. */
-export const KUI_SPACE_120 = "56px";
-/* 64px value for gaps, margin, or padding. */
-export const KUI_SPACE_130 = "64px";
-/* 80px value for gaps, margin, or padding. */
-export const KUI_SPACE_140 = "80px";
-/* 96px value for gaps, margin, or padding. */
-export const KUI_SPACE_150 = "96px";
-/* auto */
-export const KUI_SPACE_AUTO = "auto";
+export const KUI_COLOR_BACKGROUND = undefined;
+export const KUI_COLOR_BACKGROUND_DANGER = undefined;
+export const KUI_COLOR_BACKGROUND_DANGER_STRONG = undefined;
+export const KUI_COLOR_BACKGROUND_DANGER_STRONGER = undefined;
+export const KUI_COLOR_BACKGROUND_DANGER_STRONGEST = undefined;
+export const KUI_COLOR_BACKGROUND_DANGER_WEAK = undefined;
+export const KUI_COLOR_BACKGROUND_DANGER_WEAKER = undefined;
+export const KUI_COLOR_BACKGROUND_DANGER_WEAKEST = undefined;
+export const KUI_COLOR_BACKGROUND_DECORATIVE_AQUA_WEAKEST = undefined;
+export const KUI_COLOR_BACKGROUND_DECORATIVE_PURPLE = undefined;
+export const KUI_COLOR_BACKGROUND_DECORATIVE_PURPLE_WEAKEST = undefined;
+export const KUI_COLOR_BACKGROUND_DISABLED = undefined;
+export const KUI_COLOR_BACKGROUND_INFO = undefined;
+export const KUI_COLOR_BACKGROUND_INFO_STRONG = undefined;
+export const KUI_COLOR_BACKGROUND_INFO_STRONGER = undefined;
+export const KUI_COLOR_BACKGROUND_INFO_STRONGEST = undefined;
+export const KUI_COLOR_BACKGROUND_INFO_WEAK = undefined;
+export const KUI_COLOR_BACKGROUND_INFO_WEAKER = undefined;
+export const KUI_COLOR_BACKGROUND_INFO_WEAKEST = undefined;
+export const KUI_COLOR_BACKGROUND_INVERSE = undefined;
+export const KUI_COLOR_BACKGROUND_NEUTRAL = undefined;
+export const KUI_COLOR_BACKGROUND_NEUTRAL_STRONG = undefined;
+export const KUI_COLOR_BACKGROUND_NEUTRAL_STRONGER = undefined;
+export const KUI_COLOR_BACKGROUND_NEUTRAL_STRONGEST = undefined;
+export const KUI_COLOR_BACKGROUND_NEUTRAL_WEAK = undefined;
+export const KUI_COLOR_BACKGROUND_NEUTRAL_WEAKER = undefined;
+export const KUI_COLOR_BACKGROUND_NEUTRAL_WEAKEST = undefined;
+export const KUI_COLOR_BACKGROUND_OVERLAY = undefined;
+export const KUI_COLOR_BACKGROUND_PRIMARY = undefined;
+export const KUI_COLOR_BACKGROUND_PRIMARY_STRONG = undefined;
+export const KUI_COLOR_BACKGROUND_PRIMARY_STRONGER = undefined;
+export const KUI_COLOR_BACKGROUND_PRIMARY_STRONGEST = undefined;
+export const KUI_COLOR_BACKGROUND_PRIMARY_WEAK = undefined;
+export const KUI_COLOR_BACKGROUND_PRIMARY_WEAKER = undefined;
+export const KUI_COLOR_BACKGROUND_PRIMARY_WEAKEST = undefined;
+export const KUI_COLOR_BACKGROUND_SUCCESS = undefined;
+export const KUI_COLOR_BACKGROUND_SUCCESS_STRONG = undefined;
+export const KUI_COLOR_BACKGROUND_SUCCESS_STRONGER = undefined;
+export const KUI_COLOR_BACKGROUND_SUCCESS_STRONGEST = undefined;
+export const KUI_COLOR_BACKGROUND_SUCCESS_WEAK = undefined;
+export const KUI_COLOR_BACKGROUND_SUCCESS_WEAKER = undefined;
+export const KUI_COLOR_BACKGROUND_SUCCESS_WEAKEST = undefined;
+export const KUI_COLOR_BACKGROUND_TRANSPARENT = undefined;
+export const KUI_COLOR_BACKGROUND_WARNING = undefined;
+export const KUI_COLOR_BACKGROUND_WARNING_STRONG = undefined;
+export const KUI_COLOR_BACKGROUND_WARNING_STRONGER = undefined;
+export const KUI_COLOR_BACKGROUND_WARNING_STRONGEST = undefined;
+export const KUI_COLOR_BACKGROUND_WARNING_WEAK = undefined;
+export const KUI_COLOR_BACKGROUND_WARNING_WEAKER = undefined;
+export const KUI_COLOR_BACKGROUND_WARNING_WEAKEST = undefined;
+export const KUI_COLOR_BORDER = undefined;
+export const KUI_COLOR_BORDER_DANGER = undefined;
+export const KUI_COLOR_BORDER_DANGER_STRONG = undefined;
+export const KUI_COLOR_BORDER_DANGER_STRONGER = undefined;
+export const KUI_COLOR_BORDER_DANGER_STRONGEST = undefined;
+export const KUI_COLOR_BORDER_DANGER_WEAK = undefined;
+export const KUI_COLOR_BORDER_DANGER_WEAKER = undefined;
+export const KUI_COLOR_BORDER_DANGER_WEAKEST = undefined;
+export const KUI_COLOR_BORDER_DECORATIVE_PURPLE = undefined;
+export const KUI_COLOR_BORDER_DISABLED = undefined;
+export const KUI_COLOR_BORDER_INVERSE = undefined;
+export const KUI_COLOR_BORDER_NEUTRAL = undefined;
+export const KUI_COLOR_BORDER_NEUTRAL_STRONG = undefined;
+export const KUI_COLOR_BORDER_NEUTRAL_STRONGER = undefined;
+export const KUI_COLOR_BORDER_NEUTRAL_STRONGEST = undefined;
+export const KUI_COLOR_BORDER_NEUTRAL_WEAK = undefined;
+export const KUI_COLOR_BORDER_NEUTRAL_WEAKER = undefined;
+export const KUI_COLOR_BORDER_NEUTRAL_WEAKEST = undefined;
+export const KUI_COLOR_BORDER_PRIMARY = undefined;
+export const KUI_COLOR_BORDER_PRIMARY_STRONG = undefined;
+export const KUI_COLOR_BORDER_PRIMARY_STRONGER = undefined;
+export const KUI_COLOR_BORDER_PRIMARY_STRONGEST = undefined;
+export const KUI_COLOR_BORDER_PRIMARY_WEAK = undefined;
+export const KUI_COLOR_BORDER_PRIMARY_WEAKER = undefined;
+export const KUI_COLOR_BORDER_PRIMARY_WEAKEST = undefined;
+export const KUI_COLOR_BORDER_TRANSPARENT = undefined;
+export const KUI_COLOR_TEXT = undefined;
+export const KUI_COLOR_TEXT_DANGER = undefined;
+export const KUI_COLOR_TEXT_DANGER_STRONG = undefined;
+export const KUI_COLOR_TEXT_DANGER_STRONGER = undefined;
+export const KUI_COLOR_TEXT_DANGER_STRONGEST = undefined;
+export const KUI_COLOR_TEXT_DANGER_WEAK = undefined;
+export const KUI_COLOR_TEXT_DANGER_WEAKER = undefined;
+export const KUI_COLOR_TEXT_DANGER_WEAKEST = undefined;
+export const KUI_COLOR_TEXT_DECORATIVE_AQUA = undefined;
+export const KUI_COLOR_TEXT_DECORATIVE_PINK = undefined;
+export const KUI_COLOR_TEXT_DECORATIVE_PURPLE = undefined;
+export const KUI_COLOR_TEXT_DECORATIVE_PURPLE_STRONG = undefined;
+export const KUI_COLOR_TEXT_DISABLED = undefined;
+export const KUI_COLOR_TEXT_INFO = undefined;
+export const KUI_COLOR_TEXT_INFO_STRONG = undefined;
+export const KUI_COLOR_TEXT_INFO_STRONGER = undefined;
+export const KUI_COLOR_TEXT_INFO_STRONGEST = undefined;
+export const KUI_COLOR_TEXT_INFO_WEAK = undefined;
+export const KUI_COLOR_TEXT_INFO_WEAKER = undefined;
+export const KUI_COLOR_TEXT_INFO_WEAKEST = undefined;
+export const KUI_COLOR_TEXT_INVERSE = undefined;
+export const KUI_COLOR_TEXT_NEUTRAL = undefined;
+export const KUI_COLOR_TEXT_NEUTRAL_STRONG = undefined;
+export const KUI_COLOR_TEXT_NEUTRAL_STRONGER = undefined;
+export const KUI_COLOR_TEXT_NEUTRAL_STRONGEST = undefined;
+export const KUI_COLOR_TEXT_NEUTRAL_WEAK = undefined;
+export const KUI_COLOR_TEXT_NEUTRAL_WEAKER = undefined;
+export const KUI_COLOR_TEXT_NEUTRAL_WEAKEST = undefined;
+export const KUI_COLOR_TEXT_PRIMARY = undefined;
+export const KUI_COLOR_TEXT_PRIMARY_STRONG = undefined;
+export const KUI_COLOR_TEXT_PRIMARY_STRONGER = undefined;
+export const KUI_COLOR_TEXT_PRIMARY_STRONGEST = undefined;
+export const KUI_COLOR_TEXT_PRIMARY_WEAK = undefined;
+export const KUI_COLOR_TEXT_PRIMARY_WEAKER = undefined;
+export const KUI_COLOR_TEXT_PRIMARY_WEAKEST = undefined;
+export const KUI_COLOR_TEXT_SUCCESS = undefined;
+export const KUI_COLOR_TEXT_SUCCESS_STRONG = undefined;
+export const KUI_COLOR_TEXT_SUCCESS_STRONGER = undefined;
+export const KUI_COLOR_TEXT_SUCCESS_STRONGEST = undefined;
+export const KUI_COLOR_TEXT_SUCCESS_WEAK = undefined;
+export const KUI_COLOR_TEXT_SUCCESS_WEAKER = undefined;
+export const KUI_COLOR_TEXT_SUCCESS_WEAKEST = undefined;
+export const KUI_COLOR_TEXT_WARNING = undefined;
+export const KUI_COLOR_TEXT_WARNING_STRONG = undefined;
+export const KUI_COLOR_TEXT_WARNING_STRONGER = undefined;
+export const KUI_COLOR_TEXT_WARNING_STRONGEST = undefined;
+export const KUI_COLOR_TEXT_WARNING_WEAK = undefined;
+export const KUI_COLOR_TEXT_WARNING_WEAKER = undefined;
+export const KUI_COLOR_TEXT_WARNING_WEAKEST = undefined;
+export const KUI_ANIMATION_DURATION_20 = undefined;
+export const KUI_BORDER_RADIUS_0 = undefined;
+export const KUI_BORDER_RADIUS_10 = undefined;
+export const KUI_BORDER_RADIUS_20 = undefined;
+export const KUI_BORDER_RADIUS_30 = undefined;
+export const KUI_BORDER_RADIUS_40 = undefined;
+export const KUI_BORDER_RADIUS_50 = undefined;
+export const KUI_BORDER_RADIUS_CIRCLE = undefined;
+export const KUI_BORDER_RADIUS_ROUND = undefined;
+export const KUI_BORDER_WIDTH_0 = undefined;
+export const KUI_BORDER_WIDTH_10 = undefined;
+export const KUI_BORDER_WIDTH_20 = undefined;
+export const KUI_BORDER_WIDTH_30 = undefined;
+export const KUI_BREAKPOINT_MOBILE = undefined;
+export const KUI_BREAKPOINT_PHABLET = undefined;
+export const KUI_BREAKPOINT_TABLET = undefined;
+export const KUI_BREAKPOINT_LAPTOP = undefined;
+export const KUI_BREAKPOINT_DESKTOP = undefined;
+export const KUI_ICON_COLOR_DANGER = undefined;
+export const KUI_ICON_COLOR_NEUTRAL = undefined;
+export const KUI_ICON_COLOR_PRIMARY = undefined;
+export const KUI_ICON_COLOR_SUCCESS = undefined;
+export const KUI_ICON_COLOR_WARNING = undefined;
+export const KUI_ICON_SIZE_10 = undefined;
+export const KUI_ICON_SIZE_20 = undefined;
+export const KUI_ICON_SIZE_30 = undefined;
+export const KUI_ICON_SIZE_40 = undefined;
+export const KUI_ICON_SIZE_50 = undefined;
+export const KUI_ICON_SIZE_60 = undefined;
+export const KUI_ICON_SIZE_70 = undefined;
+export const KUI_ICON_SIZE_80 = undefined;
+export const KUI_METHOD_COLOR_BACKGROUND_CONNECT = undefined;
+export const KUI_METHOD_COLOR_BACKGROUND_DELETE = undefined;
+export const KUI_METHOD_COLOR_BACKGROUND_GET = undefined;
+export const KUI_METHOD_COLOR_BACKGROUND_HEAD = undefined;
+export const KUI_METHOD_COLOR_BACKGROUND_OPTIONS = undefined;
+export const KUI_METHOD_COLOR_BACKGROUND_PATCH = undefined;
+export const KUI_METHOD_COLOR_BACKGROUND_POST = undefined;
+export const KUI_METHOD_COLOR_BACKGROUND_PUT = undefined;
+export const KUI_METHOD_COLOR_BACKGROUND_TRACE = undefined;
+export const KUI_METHOD_COLOR_TEXT_CONNECT = undefined;
+export const KUI_METHOD_COLOR_TEXT_CONNECT_STRONG = undefined;
+export const KUI_METHOD_COLOR_TEXT_DELETE = undefined;
+export const KUI_METHOD_COLOR_TEXT_DELETE_STRONG = undefined;
+export const KUI_METHOD_COLOR_TEXT_GET = undefined;
+export const KUI_METHOD_COLOR_TEXT_GET_STRONG = undefined;
+export const KUI_METHOD_COLOR_TEXT_HEAD = undefined;
+export const KUI_METHOD_COLOR_TEXT_HEAD_STRONG = undefined;
+export const KUI_METHOD_COLOR_TEXT_OPTIONS = undefined;
+export const KUI_METHOD_COLOR_TEXT_OPTIONS_STRONG = undefined;
+export const KUI_METHOD_COLOR_TEXT_PATCH = undefined;
+export const KUI_METHOD_COLOR_TEXT_PATCH_STRONG = undefined;
+export const KUI_METHOD_COLOR_TEXT_POST = undefined;
+export const KUI_METHOD_COLOR_TEXT_POST_STRONG = undefined;
+export const KUI_METHOD_COLOR_TEXT_PUT = undefined;
+export const KUI_METHOD_COLOR_TEXT_PUT_STRONG = undefined;
+export const KUI_METHOD_COLOR_TEXT_TRACE = undefined;
+export const KUI_METHOD_COLOR_TEXT_TRACE_STRONG = undefined;
+export const KUI_NAVIGATION_COLOR_BACKGROUND = undefined;
+export const KUI_NAVIGATION_COLOR_BACKGROUND_SELECTED = undefined;
+export const KUI_NAVIGATION_COLOR_BORDER = undefined;
+export const KUI_NAVIGATION_COLOR_BORDER_CHILD = undefined;
+export const KUI_NAVIGATION_COLOR_BORDER_DIVIDER = undefined;
+export const KUI_NAVIGATION_COLOR_TEXT = undefined;
+export const KUI_NAVIGATION_COLOR_TEXT_FOCUS = undefined;
+export const KUI_NAVIGATION_COLOR_TEXT_HOVER = undefined;
+export const KUI_NAVIGATION_COLOR_TEXT_SELECTED = undefined;
+export const KUI_NAVIGATION_SHADOW_BORDER = undefined;
+export const KUI_NAVIGATION_SHADOW_BORDER_CHILD = undefined;
+export const KUI_NAVIGATION_SHADOW_FOCUS = undefined;
+export const KUI_STATUS_COLOR_100 = undefined;
+export const KUI_STATUS_COLOR_101 = undefined;
+export const KUI_STATUS_COLOR_102 = undefined;
+export const KUI_STATUS_COLOR_103 = undefined;
+export const KUI_STATUS_COLOR_200 = undefined;
+export const KUI_STATUS_COLOR_201 = undefined;
+export const KUI_STATUS_COLOR_202 = undefined;
+export const KUI_STATUS_COLOR_203 = undefined;
+export const KUI_STATUS_COLOR_204 = undefined;
+export const KUI_STATUS_COLOR_205 = undefined;
+export const KUI_STATUS_COLOR_206 = undefined;
+export const KUI_STATUS_COLOR_207 = undefined;
+export const KUI_STATUS_COLOR_208 = undefined;
+export const KUI_STATUS_COLOR_226 = undefined;
+export const KUI_STATUS_COLOR_300 = undefined;
+export const KUI_STATUS_COLOR_301 = undefined;
+export const KUI_STATUS_COLOR_302 = undefined;
+export const KUI_STATUS_COLOR_303 = undefined;
+export const KUI_STATUS_COLOR_304 = undefined;
+export const KUI_STATUS_COLOR_305 = undefined;
+export const KUI_STATUS_COLOR_307 = undefined;
+export const KUI_STATUS_COLOR_308 = undefined;
+export const KUI_STATUS_COLOR_400 = undefined;
+export const KUI_STATUS_COLOR_401 = undefined;
+export const KUI_STATUS_COLOR_402 = undefined;
+export const KUI_STATUS_COLOR_403 = undefined;
+export const KUI_STATUS_COLOR_404 = undefined;
+export const KUI_STATUS_COLOR_405 = undefined;
+export const KUI_STATUS_COLOR_406 = undefined;
+export const KUI_STATUS_COLOR_407 = undefined;
+export const KUI_STATUS_COLOR_408 = undefined;
+export const KUI_STATUS_COLOR_409 = undefined;
+export const KUI_STATUS_COLOR_410 = undefined;
+export const KUI_STATUS_COLOR_411 = undefined;
+export const KUI_STATUS_COLOR_412 = undefined;
+export const KUI_STATUS_COLOR_413 = undefined;
+export const KUI_STATUS_COLOR_414 = undefined;
+export const KUI_STATUS_COLOR_415 = undefined;
+export const KUI_STATUS_COLOR_416 = undefined;
+export const KUI_STATUS_COLOR_417 = undefined;
+export const KUI_STATUS_COLOR_418 = undefined;
+export const KUI_STATUS_COLOR_421 = undefined;
+export const KUI_STATUS_COLOR_422 = undefined;
+export const KUI_STATUS_COLOR_423 = undefined;
+export const KUI_STATUS_COLOR_424 = undefined;
+export const KUI_STATUS_COLOR_425 = undefined;
+export const KUI_STATUS_COLOR_426 = undefined;
+export const KUI_STATUS_COLOR_428 = undefined;
+export const KUI_STATUS_COLOR_429 = undefined;
+export const KUI_STATUS_COLOR_431 = undefined;
+export const KUI_STATUS_COLOR_451 = undefined;
+export const KUI_STATUS_COLOR_500 = undefined;
+export const KUI_STATUS_COLOR_501 = undefined;
+export const KUI_STATUS_COLOR_502 = undefined;
+export const KUI_STATUS_COLOR_503 = undefined;
+export const KUI_STATUS_COLOR_504 = undefined;
+export const KUI_STATUS_COLOR_505 = undefined;
+export const KUI_STATUS_COLOR_506 = undefined;
+export const KUI_STATUS_COLOR_507 = undefined;
+export const KUI_STATUS_COLOR_508 = undefined;
+export const KUI_STATUS_COLOR_510 = undefined;
+export const KUI_STATUS_COLOR_511 = undefined;
+export const KUI_STATUS_COLOR_1NA = undefined;
+export const KUI_STATUS_COLOR_2NA = undefined;
+export const KUI_STATUS_COLOR_3NA = undefined;
+export const KUI_STATUS_COLOR_4NA = undefined;
+export const KUI_STATUS_COLOR_5NA = undefined;
+export const KUI_STATUS_COLOR_100S = undefined;
+export const KUI_STATUS_COLOR_200S = undefined;
+export const KUI_STATUS_COLOR_300S = undefined;
+export const KUI_STATUS_COLOR_400S = undefined;
+export const KUI_STATUS_COLOR_500S = undefined;
+export const KUI_STATUS_COLOR_BACKGROUND_100 = undefined;
+export const KUI_STATUS_COLOR_BACKGROUND_200 = undefined;
+export const KUI_STATUS_COLOR_BACKGROUND_300 = undefined;
+export const KUI_STATUS_COLOR_BACKGROUND_400 = undefined;
+export const KUI_STATUS_COLOR_BACKGROUND_500 = undefined;
+export const KUI_STATUS_COLOR_TEXT_100 = undefined;
+export const KUI_STATUS_COLOR_TEXT_200 = undefined;
+export const KUI_STATUS_COLOR_TEXT_300 = undefined;
+export const KUI_STATUS_COLOR_TEXT_400 = undefined;
+export const KUI_STATUS_COLOR_TEXT_500 = undefined;
+export const KUI_FONT_FAMILY_CODE = undefined;
+export const KUI_FONT_FAMILY_HEADING = undefined;
+export const KUI_FONT_FAMILY_TEXT = undefined;
+export const KUI_FONT_SIZE_10 = undefined;
+export const KUI_FONT_SIZE_20 = undefined;
+export const KUI_FONT_SIZE_30 = undefined;
+export const KUI_FONT_SIZE_40 = undefined;
+export const KUI_FONT_SIZE_50 = undefined;
+export const KUI_FONT_SIZE_60 = undefined;
+export const KUI_FONT_SIZE_70 = undefined;
+export const KUI_FONT_SIZE_80 = undefined;
+export const KUI_FONT_SIZE_90 = undefined;
+export const KUI_FONT_SIZE_100 = undefined;
+export const KUI_FONT_WEIGHT_BOLD = undefined;
+export const KUI_FONT_WEIGHT_MEDIUM = undefined;
+export const KUI_FONT_WEIGHT_REGULAR = undefined;
+export const KUI_FONT_WEIGHT_SEMIBOLD = undefined;
+export const KUI_LETTER_SPACING_0 = undefined;
+export const KUI_LETTER_SPACING_MINUS_10 = undefined;
+export const KUI_LETTER_SPACING_MINUS_20 = undefined;
+export const KUI_LETTER_SPACING_MINUS_30 = undefined;
+export const KUI_LETTER_SPACING_MINUS_40 = undefined;
+export const KUI_LETTER_SPACING_MINUS_50 = undefined;
+export const KUI_LETTER_SPACING_NORMAL = undefined;
+export const KUI_LINE_HEIGHT_10 = undefined;
+export const KUI_LINE_HEIGHT_20 = undefined;
+export const KUI_LINE_HEIGHT_30 = undefined;
+export const KUI_LINE_HEIGHT_40 = undefined;
+export const KUI_LINE_HEIGHT_50 = undefined;
+export const KUI_LINE_HEIGHT_60 = undefined;
+export const KUI_LINE_HEIGHT_70 = undefined;
+export const KUI_LINE_HEIGHT_80 = undefined;
+export const KUI_LINE_HEIGHT_90 = undefined;
+export const KUI_LINE_HEIGHT_100 = undefined;
+export const KUI_SHADOW = undefined;
+export const KUI_SHADOW_BORDER = undefined;
+export const KUI_SHADOW_BORDER_DANGER = undefined;
+export const KUI_SHADOW_BORDER_DANGER_STRONG = undefined;
+export const KUI_SHADOW_BORDER_DISABLED = undefined;
+export const KUI_SHADOW_BORDER_PRIMARY = undefined;
+export const KUI_SHADOW_BORDER_PRIMARY_STRONGEST = undefined;
+export const KUI_SHADOW_BORDER_PRIMARY_WEAK = undefined;
+export const KUI_SHADOW_FOCUS = undefined;
+export const KUI_SPACE_0 = undefined;
+export const KUI_SPACE_10 = undefined;
+export const KUI_SPACE_20 = undefined;
+export const KUI_SPACE_30 = undefined;
+export const KUI_SPACE_40 = undefined;
+export const KUI_SPACE_50 = undefined;
+export const KUI_SPACE_60 = undefined;
+export const KUI_SPACE_70 = undefined;
+export const KUI_SPACE_80 = undefined;
+export const KUI_SPACE_90 = undefined;
+export const KUI_SPACE_100 = undefined;
+export const KUI_SPACE_110 = undefined;
+export const KUI_SPACE_120 = undefined;
+export const KUI_SPACE_130 = undefined;
+export const KUI_SPACE_140 = undefined;
+export const KUI_SPACE_150 = undefined;
+export const KUI_SPACE_AUTO = undefined;
 ```
 
 </details>
@@ -3404,343 +1769,343 @@ export const KUI_SPACE_AUTO = "auto";
 
 ```json
 {
-  "kui_color_background": "#ffffff",
-  "kui_color_background_danger": "#d60027",
-  "kui_color_background_danger_strong": "#ad000e",
-  "kui_color_background_danger_stronger": "#850000",
-  "kui_color_background_danger_strongest": "#5c0000",
-  "kui_color_background_danger_weak": "#ff3954",
-  "kui_color_background_danger_weaker": "#ffabab",
-  "kui_color_background_danger_weakest": "#ffe5e5",
-  "kui_color_background_decorative_aqua_weakest": "#ecfcff",
-  "kui_color_background_decorative_purple": "#6f28ff",
-  "kui_color_background_decorative_purple_weakest": "#f1f0ff",
-  "kui_color_background_disabled": "#e0e4ea",
-  "kui_color_background_info": "#0044f4",
-  "kui_color_background_info_strong": "#0030cc",
-  "kui_color_background_info_stronger": "#002099",
-  "kui_color_background_info_strongest": "#001466",
-  "kui_color_background_info_weak": "#5f9aff",
-  "kui_color_background_info_weaker": "#bee2ff",
-  "kui_color_background_info_weakest": "#eefaff",
-  "kui_color_background_inverse": "#000933",
-  "kui_color_background_neutral": "#6c7489",
-  "kui_color_background_neutral_strong": "#52596e",
-  "kui_color_background_neutral_stronger": "#3a3f51",
-  "kui_color_background_neutral_strongest": "#232633",
-  "kui_color_background_neutral_weak": "#afb7c5",
-  "kui_color_background_neutral_weaker": "#e0e4ea",
-  "kui_color_background_neutral_weakest": "#f9fafb",
-  "kui_color_background_overlay": "rgba(0, 9, 51, 0.6)",
-  "kui_color_background_primary": "#0044f4",
-  "kui_color_background_primary_strong": "#0030cc",
-  "kui_color_background_primary_stronger": "#002099",
-  "kui_color_background_primary_strongest": "#001466",
-  "kui_color_background_primary_weak": "#5f9aff",
-  "kui_color_background_primary_weaker": "#bee2ff",
-  "kui_color_background_primary_weakest": "#eefaff",
-  "kui_color_background_success": "#007d60",
-  "kui_color_background_success_strong": "#005944",
-  "kui_color_background_success_stronger": "#004737",
-  "kui_color_background_success_strongest": "#003629",
-  "kui_color_background_success_weak": "#00d6a4",
-  "kui_color_background_success_weaker": "#b5ffee",
-  "kui_color_background_success_weakest": "#ecfffb",
-  "kui_color_background_transparent": "transparent",
-  "kui_color_background_warning": "#995c00",
-  "kui_color_background_warning_strong": "#804400",
-  "kui_color_background_warning_stronger": "#662d00",
-  "kui_color_background_warning_strongest": "#4d1b00",
-  "kui_color_background_warning_weak": "#ffc400",
-  "kui_color_background_warning_weaker": "#fff296",
-  "kui_color_background_warning_weakest": "#fffce0",
-  "kui_color_border": "#e0e4ea",
-  "kui_color_border_danger": "#d60027",
-  "kui_color_border_danger_strong": "#ad000e",
-  "kui_color_border_danger_stronger": "#850000",
-  "kui_color_border_danger_strongest": "#5c0000",
-  "kui_color_border_danger_weak": "#ff3954",
-  "kui_color_border_danger_weaker": "#ffabab",
-  "kui_color_border_danger_weakest": "#ffe5e5",
-  "kui_color_border_decorative_purple": "#6f28ff",
-  "kui_color_border_disabled": "#e0e4ea",
-  "kui_color_border_inverse": "rgba(255, 255, 255, 0.2)",
-  "kui_color_border_neutral": "#6c7489",
-  "kui_color_border_neutral_strong": "#52596e",
-  "kui_color_border_neutral_stronger": "#3a3f51",
-  "kui_color_border_neutral_strongest": "#232633",
-  "kui_color_border_neutral_weak": "#afb7c5",
-  "kui_color_border_neutral_weaker": "#e0e4ea",
-  "kui_color_border_neutral_weakest": "#f9fafb",
-  "kui_color_border_primary": "#0044f4",
-  "kui_color_border_primary_strong": "#0030cc",
-  "kui_color_border_primary_stronger": "#002099",
-  "kui_color_border_primary_strongest": "#001466",
-  "kui_color_border_primary_weak": "#5f9aff",
-  "kui_color_border_primary_weaker": "#bee2ff",
-  "kui_color_border_primary_weakest": "#eefaff",
-  "kui_color_border_transparent": "transparent",
-  "kui_color_text": "#000933",
-  "kui_color_text_danger": "#d60027",
-  "kui_color_text_danger_strong": "#ad000e",
-  "kui_color_text_danger_stronger": "#850000",
-  "kui_color_text_danger_strongest": "#5c0000",
-  "kui_color_text_danger_weak": "#ff3954",
-  "kui_color_text_danger_weaker": "#ffabab",
-  "kui_color_text_danger_weakest": "#ffe5e5",
-  "kui_color_text_decorative_aqua": "#00abd2",
-  "kui_color_text_decorative_pink": "#d60067",
-  "kui_color_text_decorative_purple": "#6f28ff",
-  "kui_color_text_decorative_purple_strong": "#5e00f5",
-  "kui_color_text_disabled": "#afb7c5",
-  "kui_color_text_info": "#0044f4",
-  "kui_color_text_info_strong": "#0030cc",
-  "kui_color_text_info_stronger": "#002099",
-  "kui_color_text_info_strongest": "#001466",
-  "kui_color_text_info_weak": "#5f9aff",
-  "kui_color_text_info_weaker": "#bee2ff",
-  "kui_color_text_info_weakest": "#eefaff",
-  "kui_color_text_inverse": "#ffffff",
-  "kui_color_text_neutral": "#6c7489",
-  "kui_color_text_neutral_strong": "#52596e",
-  "kui_color_text_neutral_stronger": "#3a3f51",
-  "kui_color_text_neutral_strongest": "#232633",
-  "kui_color_text_neutral_weak": "#afb7c5",
-  "kui_color_text_neutral_weaker": "#e0e4ea",
-  "kui_color_text_neutral_weakest": "#f9fafb",
-  "kui_color_text_primary": "#0044f4",
-  "kui_color_text_primary_strong": "#0030cc",
-  "kui_color_text_primary_stronger": "#002099",
-  "kui_color_text_primary_strongest": "#001466",
-  "kui_color_text_primary_weak": "#5f9aff",
-  "kui_color_text_primary_weaker": "#bee2ff",
-  "kui_color_text_primary_weakest": "#eefaff",
-  "kui_color_text_success": "#007d60",
-  "kui_color_text_success_strong": "#005944",
-  "kui_color_text_success_stronger": "#004737",
-  "kui_color_text_success_strongest": "#003629",
-  "kui_color_text_success_weak": "#00d6a4",
-  "kui_color_text_success_weaker": "#b5ffee",
-  "kui_color_text_success_weakest": "#ecfffb",
-  "kui_color_text_warning": "#995c00",
-  "kui_color_text_warning_strong": "#804400",
-  "kui_color_text_warning_stronger": "#662d00",
-  "kui_color_text_warning_strongest": "#4d1b00",
-  "kui_color_text_warning_weak": "#ffc400",
-  "kui_color_text_warning_weaker": "#fff296",
-  "kui_color_text_warning_weakest": "#fffce0",
-  "kui_animation_duration_20": "0.2s",
-  "kui_border_radius_0": "0px",
-  "kui_border_radius_10": "2px",
-  "kui_border_radius_20": "4px",
-  "kui_border_radius_30": "6px",
-  "kui_border_radius_40": "8px",
-  "kui_border_radius_50": "10px",
-  "kui_border_radius_circle": "50%",
-  "kui_border_radius_round": "100px",
-  "kui_border_width_0": "0px",
-  "kui_border_width_10": "1px",
-  "kui_border_width_20": "2px",
-  "kui_border_width_30": "4px",
-  "kui_breakpoint_mobile": "640px",
-  "kui_breakpoint_phablet": "768px",
-  "kui_breakpoint_tablet": "1024px",
-  "kui_breakpoint_laptop": "1280px",
-  "kui_breakpoint_desktop": "1536px",
-  "kui_icon_color_danger": "#f50045",
-  "kui_icon_color_neutral": "#828a9e",
-  "kui_icon_color_primary": "#306fff",
-  "kui_icon_color_success": "#00a17b",
-  "kui_icon_color_warning": "#ffc400",
-  "kui_icon_size_10": "10px",
-  "kui_icon_size_20": "12px",
-  "kui_icon_size_30": "16px",
-  "kui_icon_size_40": "20px",
-  "kui_icon_size_50": "24px",
-  "kui_icon_size_60": "32px",
-  "kui_icon_size_70": "40px",
-  "kui_icon_size_80": "48px",
-  "kui_method_color_background_connect": "#f1f0ff",
-  "kui_method_color_background_delete": "#ffe5e5",
-  "kui_method_color_background_get": "#eefaff",
-  "kui_method_color_background_head": "#52596e",
-  "kui_method_color_background_options": "#e0e4ea",
-  "kui_method_color_background_patch": "#ecfcff",
-  "kui_method_color_background_post": "#ecfffb",
-  "kui_method_color_background_put": "#fffce0",
-  "kui_method_color_background_trace": "#fff0f7",
-  "kui_method_color_text_connect": "#6f28ff",
-  "kui_method_color_text_connect_strong": "#5e00f5",
-  "kui_method_color_text_delete": "#d60027",
-  "kui_method_color_text_delete_strong": "#ad000e",
-  "kui_method_color_text_get": "#0044f4",
-  "kui_method_color_text_get_strong": "#0030cc",
-  "kui_method_color_text_head": "#e0e4ea",
-  "kui_method_color_text_head_strong": "#afb7c5",
-  "kui_method_color_text_options": "#52596e",
-  "kui_method_color_text_options_strong": "#3a3f51",
-  "kui_method_color_text_patch": "#00819d",
-  "kui_method_color_text_patch_strong": "#00647a",
-  "kui_method_color_text_post": "#007d60",
-  "kui_method_color_text_post_strong": "#005944",
-  "kui_method_color_text_put": "#995c00",
-  "kui_method_color_text_put_strong": "#804400",
-  "kui_method_color_text_trace": "#d60067",
-  "kui_method_color_text_trace_strong": "#ad0053",
-  "kui_navigation_color_background": "#000933",
-  "kui_navigation_color_background_selected": "rgba(255, 255, 255, 0.12)",
-  "kui_navigation_color_border": "rgba(255, 255, 255, 0.12)",
-  "kui_navigation_color_border_child": "#00fabe",
-  "kui_navigation_color_border_divider": "rgba(255, 255, 255, 0.24)",
-  "kui_navigation_color_text": "#bee2ff",
-  "kui_navigation_color_text_focus": "#ffffff",
-  "kui_navigation_color_text_hover": "#eefaff",
-  "kui_navigation_color_text_selected": "#00fabe",
-  "kui_navigation_shadow_border": "0 0 0 1px rgba(255, 255, 255, 0.12) inset",
-  "kui_navigation_shadow_border_child": "4px 0 0 0 #00fabe inset",
-  "kui_navigation_shadow_focus": "0 0 0 1px rgba(255, 255, 255, 0.60) inset",
-  "kui_status_color_100": "#bee2ff",
-  "kui_status_color_101": "#8fc1ff",
-  "kui_status_color_102": "#5f9aff",
-  "kui_status_color_103": "#306fff",
-  "kui_status_color_200": "#b5ffee",
-  "kui_status_color_201": "#00fabe",
-  "kui_status_color_202": "#00d6a4",
-  "kui_status_color_203": "#00a17b",
-  "kui_status_color_204": "#007d60",
-  "kui_status_color_205": "#005944",
-  "kui_status_color_206": "#b5ffee",
-  "kui_status_color_207": "#00fabe",
-  "kui_status_color_208": "#b5ffee",
-  "kui_status_color_226": "#00a17b",
-  "kui_status_color_300": "#fff296",
-  "kui_status_color_301": "#ffe04b",
-  "kui_status_color_302": "#ffc400",
-  "kui_status_color_303": "#b37600",
-  "kui_status_color_304": "#995c00",
-  "kui_status_color_305": "#804400",
-  "kui_status_color_307": "#fff296",
-  "kui_status_color_308": "#ffe04b",
-  "kui_status_color_400": "#FFC2B3",
-  "kui_status_color_401": "#FF9877",
-  "kui_status_color_402": "#FF723C",
-  "kui_status_color_403": "#F75008",
-  "kui_status_color_404": "#D13500",
-  "kui_status_color_405": "#A31F00",
-  "kui_status_color_406": "#FFC2B3",
-  "kui_status_color_407": "#FF9877",
-  "kui_status_color_408": "#FF723C",
-  "kui_status_color_409": "#F75008",
-  "kui_status_color_410": "#D13500",
-  "kui_status_color_411": "#A31F00",
-  "kui_status_color_412": "#FFC2B3",
-  "kui_status_color_413": "#FF9877",
-  "kui_status_color_414": "#FF723C",
-  "kui_status_color_415": "#F75008",
-  "kui_status_color_416": "#D13500",
-  "kui_status_color_417": "#A31F00",
-  "kui_status_color_418": "#FFC2B3",
-  "kui_status_color_421": "#FF9877",
-  "kui_status_color_422": "#FF723C",
-  "kui_status_color_423": "#F75008",
-  "kui_status_color_424": "#D13500",
-  "kui_status_color_425": "#A31F00",
-  "kui_status_color_426": "#FFC2B3",
-  "kui_status_color_428": "#FF9877",
-  "kui_status_color_429": "#FF723C",
-  "kui_status_color_431": "#F75008",
-  "kui_status_color_451": "#D13500",
-  "kui_status_color_500": "#ffabab",
-  "kui_status_color_501": "#ff7272",
-  "kui_status_color_502": "#ff3954",
-  "kui_status_color_503": "#f50045",
-  "kui_status_color_504": "#d60027",
-  "kui_status_color_505": "#ad000e",
-  "kui_status_color_506": "#ffabab",
-  "kui_status_color_507": "#ff7272",
-  "kui_status_color_508": "#ff3954",
-  "kui_status_color_510": "#f50045",
-  "kui_status_color_511": "#d60027",
-  "kui_status_color_1na": "#eefaff",
-  "kui_status_color_2na": "#ecfffb",
-  "kui_status_color_3na": "#fffce0",
-  "kui_status_color_4na": "#FFF1EF",
-  "kui_status_color_5na": "#ffe5e5",
-  "kui_status_color_100s": "#5f9aff",
-  "kui_status_color_200s": "#00d6a4",
-  "kui_status_color_300s": "#ffc400",
-  "kui_status_color_400s": "#FF723C",
-  "kui_status_color_500s": "#ff3954",
-  "kui_status_color_background_100": "#eefaff",
-  "kui_status_color_background_200": "#ecfffb",
-  "kui_status_color_background_300": "#fffce0",
-  "kui_status_color_background_400": "#FFF1EF",
-  "kui_status_color_background_500": "#ffe5e5",
-  "kui_status_color_text_100": "#0044f4",
-  "kui_status_color_text_200": "#007d60",
-  "kui_status_color_text_300": "#995c00",
-  "kui_status_color_text_400": "#D13500",
-  "kui_status_color_text_500": "#d60027",
-  "kui_font_family_code": "'JetBrains Mono', Consolas, monospace",
-  "kui_font_family_heading": "'Inter', Roboto, Helvetica, sans-serif",
-  "kui_font_family_text": "'Inter', Roboto, Helvetica, sans-serif",
-  "kui_font_size_10": "10px",
-  "kui_font_size_20": "12px",
-  "kui_font_size_30": "14px",
-  "kui_font_size_40": "16px",
-  "kui_font_size_50": "18px",
-  "kui_font_size_60": "20px",
-  "kui_font_size_70": "24px",
-  "kui_font_size_80": "32px",
-  "kui_font_size_90": "40px",
-  "kui_font_size_100": "48px",
-  "kui_font_weight_bold": "700",
-  "kui_font_weight_medium": "500",
-  "kui_font_weight_regular": "400",
-  "kui_font_weight_semibold": "600",
-  "kui_letter_spacing_0": "normal",
-  "kui_letter_spacing_minus_10": "-0.12px",
-  "kui_letter_spacing_minus_20": "-0.24px",
-  "kui_letter_spacing_minus_30": "-0.32px",
-  "kui_letter_spacing_minus_40": "-0.4px",
-  "kui_letter_spacing_minus_50": "-0.48px",
-  "kui_letter_spacing_normal": "normal",
-  "kui_line_height_10": "12px",
-  "kui_line_height_20": "16px",
-  "kui_line_height_30": "20px",
-  "kui_line_height_40": "24px",
-  "kui_line_height_50": "28px",
-  "kui_line_height_60": "32px",
-  "kui_line_height_70": "36px",
-  "kui_line_height_80": "40px",
-  "kui_line_height_90": "48px",
-  "kui_line_height_100": "56px",
-  "kui_shadow": "0px 4px 20px 0px rgba(0, 0, 0, 0.08)",
-  "kui_shadow_border": "0px 0px 0px 1px #e0e4ea inset",
-  "kui_shadow_border_danger": "0px 0px 0px 1px #d60027 inset",
-  "kui_shadow_border_danger_strong": "0px 0px 0px 1px #ad000e inset",
-  "kui_shadow_border_disabled": "0px 0px 0px 1px #e0e4ea inset",
-  "kui_shadow_border_primary": "0px 0px 0px 1px #0044f4 inset",
-  "kui_shadow_border_primary_strongest": "0px 0px 0px 1px #001466 inset",
-  "kui_shadow_border_primary_weak": "0px 0px 0px 1px #5f9aff inset",
-  "kui_shadow_focus": "0px 0px 0px 4px rgba(0, 68, 244, 0.2)",
-  "kui_space_0": "0px",
-  "kui_space_10": "2px",
-  "kui_space_20": "4px",
-  "kui_space_30": "6px",
-  "kui_space_40": "8px",
-  "kui_space_50": "12px",
-  "kui_space_60": "16px",
-  "kui_space_70": "20px",
-  "kui_space_80": "24px",
-  "kui_space_90": "32px",
-  "kui_space_100": "40px",
-  "kui_space_110": "48px",
-  "kui_space_120": "56px",
-  "kui_space_130": "64px",
-  "kui_space_140": "80px",
-  "kui_space_150": "96px",
-  "kui_space_auto": "auto"
+  "kui_color_background": undefined,
+  "kui_color_background_danger": undefined,
+  "kui_color_background_danger_strong": undefined,
+  "kui_color_background_danger_stronger": undefined,
+  "kui_color_background_danger_strongest": undefined,
+  "kui_color_background_danger_weak": undefined,
+  "kui_color_background_danger_weaker": undefined,
+  "kui_color_background_danger_weakest": undefined,
+  "kui_color_background_decorative_aqua_weakest": undefined,
+  "kui_color_background_decorative_purple": undefined,
+  "kui_color_background_decorative_purple_weakest": undefined,
+  "kui_color_background_disabled": undefined,
+  "kui_color_background_info": undefined,
+  "kui_color_background_info_strong": undefined,
+  "kui_color_background_info_stronger": undefined,
+  "kui_color_background_info_strongest": undefined,
+  "kui_color_background_info_weak": undefined,
+  "kui_color_background_info_weaker": undefined,
+  "kui_color_background_info_weakest": undefined,
+  "kui_color_background_inverse": undefined,
+  "kui_color_background_neutral": undefined,
+  "kui_color_background_neutral_strong": undefined,
+  "kui_color_background_neutral_stronger": undefined,
+  "kui_color_background_neutral_strongest": undefined,
+  "kui_color_background_neutral_weak": undefined,
+  "kui_color_background_neutral_weaker": undefined,
+  "kui_color_background_neutral_weakest": undefined,
+  "kui_color_background_overlay": undefined,
+  "kui_color_background_primary": undefined,
+  "kui_color_background_primary_strong": undefined,
+  "kui_color_background_primary_stronger": undefined,
+  "kui_color_background_primary_strongest": undefined,
+  "kui_color_background_primary_weak": undefined,
+  "kui_color_background_primary_weaker": undefined,
+  "kui_color_background_primary_weakest": undefined,
+  "kui_color_background_success": undefined,
+  "kui_color_background_success_strong": undefined,
+  "kui_color_background_success_stronger": undefined,
+  "kui_color_background_success_strongest": undefined,
+  "kui_color_background_success_weak": undefined,
+  "kui_color_background_success_weaker": undefined,
+  "kui_color_background_success_weakest": undefined,
+  "kui_color_background_transparent": undefined,
+  "kui_color_background_warning": undefined,
+  "kui_color_background_warning_strong": undefined,
+  "kui_color_background_warning_stronger": undefined,
+  "kui_color_background_warning_strongest": undefined,
+  "kui_color_background_warning_weak": undefined,
+  "kui_color_background_warning_weaker": undefined,
+  "kui_color_background_warning_weakest": undefined,
+  "kui_color_border": undefined,
+  "kui_color_border_danger": undefined,
+  "kui_color_border_danger_strong": undefined,
+  "kui_color_border_danger_stronger": undefined,
+  "kui_color_border_danger_strongest": undefined,
+  "kui_color_border_danger_weak": undefined,
+  "kui_color_border_danger_weaker": undefined,
+  "kui_color_border_danger_weakest": undefined,
+  "kui_color_border_decorative_purple": undefined,
+  "kui_color_border_disabled": undefined,
+  "kui_color_border_inverse": undefined,
+  "kui_color_border_neutral": undefined,
+  "kui_color_border_neutral_strong": undefined,
+  "kui_color_border_neutral_stronger": undefined,
+  "kui_color_border_neutral_strongest": undefined,
+  "kui_color_border_neutral_weak": undefined,
+  "kui_color_border_neutral_weaker": undefined,
+  "kui_color_border_neutral_weakest": undefined,
+  "kui_color_border_primary": undefined,
+  "kui_color_border_primary_strong": undefined,
+  "kui_color_border_primary_stronger": undefined,
+  "kui_color_border_primary_strongest": undefined,
+  "kui_color_border_primary_weak": undefined,
+  "kui_color_border_primary_weaker": undefined,
+  "kui_color_border_primary_weakest": undefined,
+  "kui_color_border_transparent": undefined,
+  "kui_color_text": undefined,
+  "kui_color_text_danger": undefined,
+  "kui_color_text_danger_strong": undefined,
+  "kui_color_text_danger_stronger": undefined,
+  "kui_color_text_danger_strongest": undefined,
+  "kui_color_text_danger_weak": undefined,
+  "kui_color_text_danger_weaker": undefined,
+  "kui_color_text_danger_weakest": undefined,
+  "kui_color_text_decorative_aqua": undefined,
+  "kui_color_text_decorative_pink": undefined,
+  "kui_color_text_decorative_purple": undefined,
+  "kui_color_text_decorative_purple_strong": undefined,
+  "kui_color_text_disabled": undefined,
+  "kui_color_text_info": undefined,
+  "kui_color_text_info_strong": undefined,
+  "kui_color_text_info_stronger": undefined,
+  "kui_color_text_info_strongest": undefined,
+  "kui_color_text_info_weak": undefined,
+  "kui_color_text_info_weaker": undefined,
+  "kui_color_text_info_weakest": undefined,
+  "kui_color_text_inverse": undefined,
+  "kui_color_text_neutral": undefined,
+  "kui_color_text_neutral_strong": undefined,
+  "kui_color_text_neutral_stronger": undefined,
+  "kui_color_text_neutral_strongest": undefined,
+  "kui_color_text_neutral_weak": undefined,
+  "kui_color_text_neutral_weaker": undefined,
+  "kui_color_text_neutral_weakest": undefined,
+  "kui_color_text_primary": undefined,
+  "kui_color_text_primary_strong": undefined,
+  "kui_color_text_primary_stronger": undefined,
+  "kui_color_text_primary_strongest": undefined,
+  "kui_color_text_primary_weak": undefined,
+  "kui_color_text_primary_weaker": undefined,
+  "kui_color_text_primary_weakest": undefined,
+  "kui_color_text_success": undefined,
+  "kui_color_text_success_strong": undefined,
+  "kui_color_text_success_stronger": undefined,
+  "kui_color_text_success_strongest": undefined,
+  "kui_color_text_success_weak": undefined,
+  "kui_color_text_success_weaker": undefined,
+  "kui_color_text_success_weakest": undefined,
+  "kui_color_text_warning": undefined,
+  "kui_color_text_warning_strong": undefined,
+  "kui_color_text_warning_stronger": undefined,
+  "kui_color_text_warning_strongest": undefined,
+  "kui_color_text_warning_weak": undefined,
+  "kui_color_text_warning_weaker": undefined,
+  "kui_color_text_warning_weakest": undefined,
+  "kui_animation_duration_20": undefined,
+  "kui_border_radius_0": undefined,
+  "kui_border_radius_10": undefined,
+  "kui_border_radius_20": undefined,
+  "kui_border_radius_30": undefined,
+  "kui_border_radius_40": undefined,
+  "kui_border_radius_50": undefined,
+  "kui_border_radius_circle": undefined,
+  "kui_border_radius_round": undefined,
+  "kui_border_width_0": undefined,
+  "kui_border_width_10": undefined,
+  "kui_border_width_20": undefined,
+  "kui_border_width_30": undefined,
+  "kui_breakpoint_mobile": undefined,
+  "kui_breakpoint_phablet": undefined,
+  "kui_breakpoint_tablet": undefined,
+  "kui_breakpoint_laptop": undefined,
+  "kui_breakpoint_desktop": undefined,
+  "kui_icon_color_danger": undefined,
+  "kui_icon_color_neutral": undefined,
+  "kui_icon_color_primary": undefined,
+  "kui_icon_color_success": undefined,
+  "kui_icon_color_warning": undefined,
+  "kui_icon_size_10": undefined,
+  "kui_icon_size_20": undefined,
+  "kui_icon_size_30": undefined,
+  "kui_icon_size_40": undefined,
+  "kui_icon_size_50": undefined,
+  "kui_icon_size_60": undefined,
+  "kui_icon_size_70": undefined,
+  "kui_icon_size_80": undefined,
+  "kui_method_color_background_connect": undefined,
+  "kui_method_color_background_delete": undefined,
+  "kui_method_color_background_get": undefined,
+  "kui_method_color_background_head": undefined,
+  "kui_method_color_background_options": undefined,
+  "kui_method_color_background_patch": undefined,
+  "kui_method_color_background_post": undefined,
+  "kui_method_color_background_put": undefined,
+  "kui_method_color_background_trace": undefined,
+  "kui_method_color_text_connect": undefined,
+  "kui_method_color_text_connect_strong": undefined,
+  "kui_method_color_text_delete": undefined,
+  "kui_method_color_text_delete_strong": undefined,
+  "kui_method_color_text_get": undefined,
+  "kui_method_color_text_get_strong": undefined,
+  "kui_method_color_text_head": undefined,
+  "kui_method_color_text_head_strong": undefined,
+  "kui_method_color_text_options": undefined,
+  "kui_method_color_text_options_strong": undefined,
+  "kui_method_color_text_patch": undefined,
+  "kui_method_color_text_patch_strong": undefined,
+  "kui_method_color_text_post": undefined,
+  "kui_method_color_text_post_strong": undefined,
+  "kui_method_color_text_put": undefined,
+  "kui_method_color_text_put_strong": undefined,
+  "kui_method_color_text_trace": undefined,
+  "kui_method_color_text_trace_strong": undefined,
+  "kui_navigation_color_background": undefined,
+  "kui_navigation_color_background_selected": undefined,
+  "kui_navigation_color_border": undefined,
+  "kui_navigation_color_border_child": undefined,
+  "kui_navigation_color_border_divider": undefined,
+  "kui_navigation_color_text": undefined,
+  "kui_navigation_color_text_focus": undefined,
+  "kui_navigation_color_text_hover": undefined,
+  "kui_navigation_color_text_selected": undefined,
+  "kui_navigation_shadow_border": undefined,
+  "kui_navigation_shadow_border_child": undefined,
+  "kui_navigation_shadow_focus": undefined,
+  "kui_status_color_100": undefined,
+  "kui_status_color_101": undefined,
+  "kui_status_color_102": undefined,
+  "kui_status_color_103": undefined,
+  "kui_status_color_200": undefined,
+  "kui_status_color_201": undefined,
+  "kui_status_color_202": undefined,
+  "kui_status_color_203": undefined,
+  "kui_status_color_204": undefined,
+  "kui_status_color_205": undefined,
+  "kui_status_color_206": undefined,
+  "kui_status_color_207": undefined,
+  "kui_status_color_208": undefined,
+  "kui_status_color_226": undefined,
+  "kui_status_color_300": undefined,
+  "kui_status_color_301": undefined,
+  "kui_status_color_302": undefined,
+  "kui_status_color_303": undefined,
+  "kui_status_color_304": undefined,
+  "kui_status_color_305": undefined,
+  "kui_status_color_307": undefined,
+  "kui_status_color_308": undefined,
+  "kui_status_color_400": undefined,
+  "kui_status_color_401": undefined,
+  "kui_status_color_402": undefined,
+  "kui_status_color_403": undefined,
+  "kui_status_color_404": undefined,
+  "kui_status_color_405": undefined,
+  "kui_status_color_406": undefined,
+  "kui_status_color_407": undefined,
+  "kui_status_color_408": undefined,
+  "kui_status_color_409": undefined,
+  "kui_status_color_410": undefined,
+  "kui_status_color_411": undefined,
+  "kui_status_color_412": undefined,
+  "kui_status_color_413": undefined,
+  "kui_status_color_414": undefined,
+  "kui_status_color_415": undefined,
+  "kui_status_color_416": undefined,
+  "kui_status_color_417": undefined,
+  "kui_status_color_418": undefined,
+  "kui_status_color_421": undefined,
+  "kui_status_color_422": undefined,
+  "kui_status_color_423": undefined,
+  "kui_status_color_424": undefined,
+  "kui_status_color_425": undefined,
+  "kui_status_color_426": undefined,
+  "kui_status_color_428": undefined,
+  "kui_status_color_429": undefined,
+  "kui_status_color_431": undefined,
+  "kui_status_color_451": undefined,
+  "kui_status_color_500": undefined,
+  "kui_status_color_501": undefined,
+  "kui_status_color_502": undefined,
+  "kui_status_color_503": undefined,
+  "kui_status_color_504": undefined,
+  "kui_status_color_505": undefined,
+  "kui_status_color_506": undefined,
+  "kui_status_color_507": undefined,
+  "kui_status_color_508": undefined,
+  "kui_status_color_510": undefined,
+  "kui_status_color_511": undefined,
+  "kui_status_color_1na": undefined,
+  "kui_status_color_2na": undefined,
+  "kui_status_color_3na": undefined,
+  "kui_status_color_4na": undefined,
+  "kui_status_color_5na": undefined,
+  "kui_status_color_100s": undefined,
+  "kui_status_color_200s": undefined,
+  "kui_status_color_300s": undefined,
+  "kui_status_color_400s": undefined,
+  "kui_status_color_500s": undefined,
+  "kui_status_color_background_100": undefined,
+  "kui_status_color_background_200": undefined,
+  "kui_status_color_background_300": undefined,
+  "kui_status_color_background_400": undefined,
+  "kui_status_color_background_500": undefined,
+  "kui_status_color_text_100": undefined,
+  "kui_status_color_text_200": undefined,
+  "kui_status_color_text_300": undefined,
+  "kui_status_color_text_400": undefined,
+  "kui_status_color_text_500": undefined,
+  "kui_font_family_code": undefined,
+  "kui_font_family_heading": undefined,
+  "kui_font_family_text": undefined,
+  "kui_font_size_10": undefined,
+  "kui_font_size_20": undefined,
+  "kui_font_size_30": undefined,
+  "kui_font_size_40": undefined,
+  "kui_font_size_50": undefined,
+  "kui_font_size_60": undefined,
+  "kui_font_size_70": undefined,
+  "kui_font_size_80": undefined,
+  "kui_font_size_90": undefined,
+  "kui_font_size_100": undefined,
+  "kui_font_weight_bold": undefined,
+  "kui_font_weight_medium": undefined,
+  "kui_font_weight_regular": undefined,
+  "kui_font_weight_semibold": undefined,
+  "kui_letter_spacing_0": undefined,
+  "kui_letter_spacing_minus_10": undefined,
+  "kui_letter_spacing_minus_20": undefined,
+  "kui_letter_spacing_minus_30": undefined,
+  "kui_letter_spacing_minus_40": undefined,
+  "kui_letter_spacing_minus_50": undefined,
+  "kui_letter_spacing_normal": undefined,
+  "kui_line_height_10": undefined,
+  "kui_line_height_20": undefined,
+  "kui_line_height_30": undefined,
+  "kui_line_height_40": undefined,
+  "kui_line_height_50": undefined,
+  "kui_line_height_60": undefined,
+  "kui_line_height_70": undefined,
+  "kui_line_height_80": undefined,
+  "kui_line_height_90": undefined,
+  "kui_line_height_100": undefined,
+  "kui_shadow": undefined,
+  "kui_shadow_border": undefined,
+  "kui_shadow_border_danger": undefined,
+  "kui_shadow_border_danger_strong": undefined,
+  "kui_shadow_border_disabled": undefined,
+  "kui_shadow_border_primary": undefined,
+  "kui_shadow_border_primary_strongest": undefined,
+  "kui_shadow_border_primary_weak": undefined,
+  "kui_shadow_focus": undefined,
+  "kui_space_0": undefined,
+  "kui_space_10": undefined,
+  "kui_space_20": undefined,
+  "kui_space_30": undefined,
+  "kui_space_40": undefined,
+  "kui_space_50": undefined,
+  "kui_space_60": undefined,
+  "kui_space_70": undefined,
+  "kui_space_80": undefined,
+  "kui_space_90": undefined,
+  "kui_space_100": undefined,
+  "kui_space_110": undefined,
+  "kui_space_120": undefined,
+  "kui_space_130": undefined,
+  "kui_space_140": undefined,
+  "kui_space_150": undefined,
+  "kui_space_auto": undefined
 }
 ```
 

--- a/TOKENS.md
+++ b/TOKENS.md
@@ -18,343 +18,670 @@ This document outlines the majority of the available tokens.
 <summary>Click to view the list of SCSS variables</summary>
 
 ```scss
-$kui-color-background: ;
-$kui-color-background-danger: ;
-$kui-color-background-danger-strong: ;
-$kui-color-background-danger-stronger: ;
-$kui-color-background-danger-strongest: ;
-$kui-color-background-danger-weak: ;
-$kui-color-background-danger-weaker: ;
-$kui-color-background-danger-weakest: ;
-$kui-color-background-decorative-aqua-weakest: ;
-$kui-color-background-decorative-purple: ;
-$kui-color-background-decorative-purple-weakest: ;
-$kui-color-background-disabled: ;
-$kui-color-background-info: ;
-$kui-color-background-info-strong: ;
-$kui-color-background-info-stronger: ;
-$kui-color-background-info-strongest: ;
-$kui-color-background-info-weak: ;
-$kui-color-background-info-weaker: ;
-$kui-color-background-info-weakest: ;
-$kui-color-background-inverse: ;
-$kui-color-background-neutral: ;
-$kui-color-background-neutral-strong: ;
-$kui-color-background-neutral-stronger: ;
-$kui-color-background-neutral-strongest: ;
-$kui-color-background-neutral-weak: ;
-$kui-color-background-neutral-weaker: ;
-$kui-color-background-neutral-weakest: ;
-$kui-color-background-overlay: ;
-$kui-color-background-primary: ;
-$kui-color-background-primary-strong: ;
-$kui-color-background-primary-stronger: ;
-$kui-color-background-primary-strongest: ;
-$kui-color-background-primary-weak: ;
-$kui-color-background-primary-weaker: ;
-$kui-color-background-primary-weakest: ;
-$kui-color-background-success: ;
-$kui-color-background-success-strong: ;
-$kui-color-background-success-stronger: ;
-$kui-color-background-success-strongest: ;
-$kui-color-background-success-weak: ;
-$kui-color-background-success-weaker: ;
-$kui-color-background-success-weakest: ;
-$kui-color-background-transparent: ;
-$kui-color-background-warning: ;
-$kui-color-background-warning-strong: ;
-$kui-color-background-warning-stronger: ;
-$kui-color-background-warning-strongest: ;
-$kui-color-background-warning-weak: ;
-$kui-color-background-warning-weaker: ;
-$kui-color-background-warning-weakest: ;
-$kui-color-border: ;
-$kui-color-border-danger: ;
-$kui-color-border-danger-strong: ;
-$kui-color-border-danger-stronger: ;
-$kui-color-border-danger-strongest: ;
-$kui-color-border-danger-weak: ;
-$kui-color-border-danger-weaker: ;
-$kui-color-border-danger-weakest: ;
-$kui-color-border-decorative-purple: ;
-$kui-color-border-disabled: ;
-$kui-color-border-inverse: ;
-$kui-color-border-neutral: ;
-$kui-color-border-neutral-strong: ;
-$kui-color-border-neutral-stronger: ;
-$kui-color-border-neutral-strongest: ;
-$kui-color-border-neutral-weak: ;
-$kui-color-border-neutral-weaker: ;
-$kui-color-border-neutral-weakest: ;
-$kui-color-border-primary: ;
-$kui-color-border-primary-strong: ;
-$kui-color-border-primary-stronger: ;
-$kui-color-border-primary-strongest: ;
-$kui-color-border-primary-weak: ;
-$kui-color-border-primary-weaker: ;
-$kui-color-border-primary-weakest: ;
-$kui-color-border-transparent: ;
-$kui-color-text: ;
-$kui-color-text-danger: ;
-$kui-color-text-danger-strong: ;
-$kui-color-text-danger-stronger: ;
-$kui-color-text-danger-strongest: ;
-$kui-color-text-danger-weak: ;
-$kui-color-text-danger-weaker: ;
-$kui-color-text-danger-weakest: ;
-$kui-color-text-decorative-aqua: ;
-$kui-color-text-decorative-pink: ;
-$kui-color-text-decorative-purple: ;
-$kui-color-text-decorative-purple-strong: ;
-$kui-color-text-disabled: ;
-$kui-color-text-info: ;
-$kui-color-text-info-strong: ;
-$kui-color-text-info-stronger: ;
-$kui-color-text-info-strongest: ;
-$kui-color-text-info-weak: ;
-$kui-color-text-info-weaker: ;
-$kui-color-text-info-weakest: ;
-$kui-color-text-inverse: ;
-$kui-color-text-neutral: ;
-$kui-color-text-neutral-strong: ;
-$kui-color-text-neutral-stronger: ;
-$kui-color-text-neutral-strongest: ;
-$kui-color-text-neutral-weak: ;
-$kui-color-text-neutral-weaker: ;
-$kui-color-text-neutral-weakest: ;
-$kui-color-text-primary: ;
-$kui-color-text-primary-strong: ;
-$kui-color-text-primary-stronger: ;
-$kui-color-text-primary-strongest: ;
-$kui-color-text-primary-weak: ;
-$kui-color-text-primary-weaker: ;
-$kui-color-text-primary-weakest: ;
-$kui-color-text-success: ;
-$kui-color-text-success-strong: ;
-$kui-color-text-success-stronger: ;
-$kui-color-text-success-strongest: ;
-$kui-color-text-success-weak: ;
-$kui-color-text-success-weaker: ;
-$kui-color-text-success-weakest: ;
-$kui-color-text-warning: ;
-$kui-color-text-warning-strong: ;
-$kui-color-text-warning-stronger: ;
-$kui-color-text-warning-strongest: ;
-$kui-color-text-warning-weak: ;
-$kui-color-text-warning-weaker: ;
-$kui-color-text-warning-weakest: ;
-$kui-animation-duration-20: ;
-$kui-border-radius-0: ;
-$kui-border-radius-10: ;
-$kui-border-radius-20: ;
-$kui-border-radius-30: ;
-$kui-border-radius-40: ;
-$kui-border-radius-50: ;
-$kui-border-radius-circle: ;
-$kui-border-radius-round: ;
-$kui-border-width-0: ;
-$kui-border-width-10: ;
-$kui-border-width-20: ;
-$kui-border-width-30: ;
-$kui-breakpoint-mobile: ;
-$kui-breakpoint-phablet: ;
-$kui-breakpoint-tablet: ;
-$kui-breakpoint-laptop: ;
-$kui-breakpoint-desktop: ;
-$kui-icon-color-danger: ;
-$kui-icon-color-neutral: ;
-$kui-icon-color-primary: ;
-$kui-icon-color-success: ;
-$kui-icon-color-warning: ;
-$kui-icon-size-10: ;
-$kui-icon-size-20: ;
-$kui-icon-size-30: ;
-$kui-icon-size-40: ;
-$kui-icon-size-50: ;
-$kui-icon-size-60: ;
-$kui-icon-size-70: ;
-$kui-icon-size-80: ;
-$kui-method-color-background-connect: ;
-$kui-method-color-background-delete: ;
-$kui-method-color-background-get: ;
-$kui-method-color-background-head: ;
-$kui-method-color-background-options: ;
-$kui-method-color-background-patch: ;
-$kui-method-color-background-post: ;
-$kui-method-color-background-put: ;
-$kui-method-color-background-trace: ;
-$kui-method-color-text-connect: ;
-$kui-method-color-text-connect-strong: ;
-$kui-method-color-text-delete: ;
-$kui-method-color-text-delete-strong: ;
-$kui-method-color-text-get: ;
-$kui-method-color-text-get-strong: ;
-$kui-method-color-text-head: ;
-$kui-method-color-text-head-strong: ;
-$kui-method-color-text-options: ;
-$kui-method-color-text-options-strong: ;
-$kui-method-color-text-patch: ;
-$kui-method-color-text-patch-strong: ;
-$kui-method-color-text-post: ;
-$kui-method-color-text-post-strong: ;
-$kui-method-color-text-put: ;
-$kui-method-color-text-put-strong: ;
-$kui-method-color-text-trace: ;
-$kui-method-color-text-trace-strong: ;
-$kui-navigation-color-background: ;
-$kui-navigation-color-background-selected: ;
-$kui-navigation-color-border: ;
-$kui-navigation-color-border-child: ;
-$kui-navigation-color-border-divider: ;
-$kui-navigation-color-text: ;
-$kui-navigation-color-text-focus: ;
-$kui-navigation-color-text-hover: ;
-$kui-navigation-color-text-selected: ;
-$kui-navigation-shadow-border: ;
-$kui-navigation-shadow-border-child: ;
-$kui-navigation-shadow-focus: ;
-$kui-status-color-100: ;
-$kui-status-color-101: ;
-$kui-status-color-102: ;
-$kui-status-color-103: ;
-$kui-status-color-200: ;
-$kui-status-color-201: ;
-$kui-status-color-202: ;
-$kui-status-color-203: ;
-$kui-status-color-204: ;
-$kui-status-color-205: ;
-$kui-status-color-206: ;
-$kui-status-color-207: ;
-$kui-status-color-208: ;
-$kui-status-color-226: ;
-$kui-status-color-300: ;
-$kui-status-color-301: ;
-$kui-status-color-302: ;
-$kui-status-color-303: ;
-$kui-status-color-304: ;
-$kui-status-color-305: ;
-$kui-status-color-307: ;
-$kui-status-color-308: ;
-$kui-status-color-400: ;
-$kui-status-color-401: ;
-$kui-status-color-402: ;
-$kui-status-color-403: ;
-$kui-status-color-404: ;
-$kui-status-color-405: ;
-$kui-status-color-406: ;
-$kui-status-color-407: ;
-$kui-status-color-408: ;
-$kui-status-color-409: ;
-$kui-status-color-410: ;
-$kui-status-color-411: ;
-$kui-status-color-412: ;
-$kui-status-color-413: ;
-$kui-status-color-414: ;
-$kui-status-color-415: ;
-$kui-status-color-416: ;
-$kui-status-color-417: ;
-$kui-status-color-418: ;
-$kui-status-color-421: ;
-$kui-status-color-422: ;
-$kui-status-color-423: ;
-$kui-status-color-424: ;
-$kui-status-color-425: ;
-$kui-status-color-426: ;
-$kui-status-color-428: ;
-$kui-status-color-429: ;
-$kui-status-color-431: ;
-$kui-status-color-451: ;
-$kui-status-color-500: ;
-$kui-status-color-501: ;
-$kui-status-color-502: ;
-$kui-status-color-503: ;
-$kui-status-color-504: ;
-$kui-status-color-505: ;
-$kui-status-color-506: ;
-$kui-status-color-507: ;
-$kui-status-color-508: ;
-$kui-status-color-510: ;
-$kui-status-color-511: ;
-$kui-status-color-1na: ;
-$kui-status-color-2na: ;
-$kui-status-color-3na: ;
-$kui-status-color-4na: ;
-$kui-status-color-5na: ;
-$kui-status-color-100s: ;
-$kui-status-color-200s: ;
-$kui-status-color-300s: ;
-$kui-status-color-400s: ;
-$kui-status-color-500s: ;
-$kui-status-color-background-100: ;
-$kui-status-color-background-200: ;
-$kui-status-color-background-300: ;
-$kui-status-color-background-400: ;
-$kui-status-color-background-500: ;
-$kui-status-color-text-100: ;
-$kui-status-color-text-200: ;
-$kui-status-color-text-300: ;
-$kui-status-color-text-400: ;
-$kui-status-color-text-500: ;
-$kui-font-family-code: ;
-$kui-font-family-heading: ;
-$kui-font-family-text: ;
-$kui-font-size-10: ;
-$kui-font-size-20: ;
-$kui-font-size-30: ;
-$kui-font-size-40: ;
-$kui-font-size-50: ;
-$kui-font-size-60: ;
-$kui-font-size-70: ;
-$kui-font-size-80: ;
-$kui-font-size-90: ;
-$kui-font-size-100: ;
-$kui-font-weight-bold: ;
-$kui-font-weight-medium: ;
-$kui-font-weight-regular: ;
-$kui-font-weight-semibold: ;
-$kui-letter-spacing-0: ;
-$kui-letter-spacing-minus-10: ;
-$kui-letter-spacing-minus-20: ;
-$kui-letter-spacing-minus-30: ;
-$kui-letter-spacing-minus-40: ;
-$kui-letter-spacing-minus-50: ;
-$kui-letter-spacing-normal: ;
-$kui-line-height-10: ;
-$kui-line-height-20: ;
-$kui-line-height-30: ;
-$kui-line-height-40: ;
-$kui-line-height-50: ;
-$kui-line-height-60: ;
-$kui-line-height-70: ;
-$kui-line-height-80: ;
-$kui-line-height-90: ;
-$kui-line-height-100: ;
-$kui-shadow: ;
-$kui-shadow-border: ;
-$kui-shadow-border-danger: ;
-$kui-shadow-border-danger-strong: ;
-$kui-shadow-border-disabled: ;
-$kui-shadow-border-primary: ;
-$kui-shadow-border-primary-strongest: ;
-$kui-shadow-border-primary-weak: ;
-$kui-shadow-focus: ;
-$kui-space-0: ;
-$kui-space-10: ;
-$kui-space-20: ;
-$kui-space-30: ;
-$kui-space-40: ;
-$kui-space-50: ;
-$kui-space-60: ;
-$kui-space-70: ;
-$kui-space-80: ;
-$kui-space-90: ;
-$kui-space-100: ;
-$kui-space-110: ;
-$kui-space-120: ;
-$kui-space-130: ;
-$kui-space-140: ;
-$kui-space-150: ;
-$kui-space-auto: ;
+/* Default background color for containers (white). */
+$kui-color-background: #ffffff;
+/* Background color for danger actions or messages (red.60). */
+$kui-color-background-danger: #d60027;
+/* Strong background color for danger actions or messages (red.70). */
+$kui-color-background-danger-strong: #ad000e;
+/* Stronger background color for danger actions or messages (red.80). */
+$kui-color-background-danger-stronger: #850000;
+/* Strongest background color for danger actions or messages (red.90). */
+$kui-color-background-danger-strongest: #5c0000;
+/* Weak background color for danger actions or messages (red.40). */
+$kui-color-background-danger-weak: #ff3954;
+/* Weaker background color for danger actions or messages (red.20). */
+$kui-color-background-danger-weaker: #ffabab;
+/* Weakest background color for danger actions or messages (red.10). */
+$kui-color-background-danger-weakest: #ffe5e5;
+/* Weakest background color for decorative purposes (aqua.10). */
+$kui-color-background-decorative-aqua-weakest: #ecfcff;
+/* Background color for decorative purposes (purple.60). */
+$kui-color-background-decorative-purple: #6f28ff;
+/* Weakest background color for decorative purposes (purple.10). */
+$kui-color-background-decorative-purple-weakest: #f1f0ff;
+/* Background color for disabled elements (gray.20). */
+$kui-color-background-disabled: #e0e4ea;
+/* Background color for info elements (blue.60). */
+$kui-color-background-info: #0044f4;
+/* Strong background color for info elements (blue.70). */
+$kui-color-background-info-strong: #0030cc;
+/* Stronger background color for info elements (blue.80). */
+$kui-color-background-info-stronger: #002099;
+/* Strongest background color for info elements (blue.90). */
+$kui-color-background-info-strongest: #001466;
+/* Weak background color for info elements (blue.40). */
+$kui-color-background-info-weak: #5f9aff;
+/* Weaker background color for info elements (blue.20). */
+$kui-color-background-info-weaker: #bee2ff;
+/* Weakest background color for info elements (blue.10). */
+$kui-color-background-info-weakest: #eefaff;
+/* Inverse background color for containers (blue.100) */
+$kui-color-background-inverse: #000933;
+/* Background color for neutral elements (gray.60). */
+$kui-color-background-neutral: #6c7489;
+/* Strong background color for neutral elements (gray.70). */
+$kui-color-background-neutral-strong: #52596e;
+/* Stronger background color for neutral elements (gray.80). */
+$kui-color-background-neutral-stronger: #3a3f51;
+/* Strongest background color for neutral elements (gray.90). */
+$kui-color-background-neutral-strongest: #232633;
+/* Weak background color for neutral elements (gray.40). */
+$kui-color-background-neutral-weak: #afb7c5;
+/* Weaker background color for neutral elements (gray.20). */
+$kui-color-background-neutral-weaker: #e0e4ea;
+/* Weakest background color for neutral elements (gray.10). */
+$kui-color-background-neutral-weakest: #f9fafb;
+/* Overlay background color (rgba(0, 9, 51, 0.6)) */
+$kui-color-background-overlay: rgba(0, 9, 51, 0.6);
+/* Background color for primary actions or messages (blue.60). */
+$kui-color-background-primary: #0044f4;
+/* Strong background color for primary actions or messages (blue.70). */
+$kui-color-background-primary-strong: #0030cc;
+/* Stronger background color for primary actions or messages (blue.80). */
+$kui-color-background-primary-stronger: #002099;
+/* Strongest background color for primary actions or messages (blue.90). */
+$kui-color-background-primary-strongest: #001466;
+/* Weak background color for primary actions or messages (blue.40). */
+$kui-color-background-primary-weak: #5f9aff;
+/* Weaker background color for primary actions or messages (blue.20). */
+$kui-color-background-primary-weaker: #bee2ff;
+/* Weakest background color for primary actions or messages (blue.10) */
+$kui-color-background-primary-weakest: #eefaff;
+/* Background color for success elements (green.60). */
+$kui-color-background-success: #007d60;
+/* Strong background color for success elements (green.70). */
+$kui-color-background-success-strong: #005944;
+/* Stronger background color for success elements (green.80). */
+$kui-color-background-success-stronger: #004737;
+/* Strongest background color for success elements (green.90). */
+$kui-color-background-success-strongest: #003629;
+/* Weak background color for success elements (green.40). */
+$kui-color-background-success-weak: #00d6a4;
+/* Weaker background color for success elements (green.20). */
+$kui-color-background-success-weaker: #b5ffee;
+/* Weakest background color for success elements (green.10). */
+$kui-color-background-success-weakest: #ecfffb;
+/* Transparent background color (transparent). */
+$kui-color-background-transparent: transparent;
+/* Background color for warning elements (yellow.60). */
+$kui-color-background-warning: #995c00;
+/* Strong background color for warning elements (yellow.70). */
+$kui-color-background-warning-strong: #804400;
+/* Stronger background color for warning elements (yellow.80). */
+$kui-color-background-warning-stronger: #662d00;
+/* Strongest background color for warning elements (yellow.90). */
+$kui-color-background-warning-strongest: #4d1b00;
+/* Weak background color for warning elements (yellow.40). */
+$kui-color-background-warning-weak: #ffc400;
+/* Weaker background color for warning elements (yellow.20). */
+$kui-color-background-warning-weaker: #fff296;
+/* Weakest background color for warning elements (yellow.10). */
+$kui-color-background-warning-weakest: #fffce0;
+/* Default border color for containers (gray.20). */
+$kui-color-border: #e0e4ea;
+/* Border color for danger actions or messages (red.60). */
+$kui-color-border-danger: #d60027;
+/* Strong border color for danger actions or messages (red.70). */
+$kui-color-border-danger-strong: #ad000e;
+/* Stronger border color for danger actions or messages (red.80). */
+$kui-color-border-danger-stronger: #850000;
+/* Strongest border color for danger actions or messages (red.90). */
+$kui-color-border-danger-strongest: #5c0000;
+/* Weak border color for danger actions or messages (red.40). */
+$kui-color-border-danger-weak: #ff3954;
+/* Weaker border color for danger actions or messages (red.20). */
+$kui-color-border-danger-weaker: #ffabab;
+/* Weakest border color for danger actions or messages (red.10). */
+$kui-color-border-danger-weakest: #ffe5e5;
+/* Border color for decorative purposes (purple.60). */
+$kui-color-border-decorative-purple: #6f28ff;
+/* Border color for disabled elements (gray.20). */
+$kui-color-border-disabled: #e0e4ea;
+/* Inverse border color (rgba(255, 255, 255, 0.2)). */
+$kui-color-border-inverse: rgba(255, 255, 255, 0.2);
+/* Border color for neutral elements (gray.60) */
+$kui-color-border-neutral: #6c7489;
+/* Strong border color for neutral elements (gray.70) */
+$kui-color-border-neutral-strong: #52596e;
+/* Stronger border color for neutral elements (gray.80) */
+$kui-color-border-neutral-stronger: #3a3f51;
+/* Strongest border color for neutral elements (gray.90) */
+$kui-color-border-neutral-strongest: #232633;
+/* Weak border color for neutral elements (gray.40) */
+$kui-color-border-neutral-weak: #afb7c5;
+/* Weaker border color for neutral elements (gray.20) */
+$kui-color-border-neutral-weaker: #e0e4ea;
+/* Weakest border color for neutral elements (gray.10) */
+$kui-color-border-neutral-weakest: #f9fafb;
+/* Border color for primary actions or messages (blue.60). */
+$kui-color-border-primary: #0044f4;
+/* Strong border color for primary actions or messages (blue.70). */
+$kui-color-border-primary-strong: #0030cc;
+/* Stronger border color for primary actions or messages (blue.80). */
+$kui-color-border-primary-stronger: #002099;
+/* Strongest border color for primary actions or messages (blue.90). */
+$kui-color-border-primary-strongest: #001466;
+/* Weak border color for primary actions or messages (blue.40). */
+$kui-color-border-primary-weak: #5f9aff;
+/* Weaker border color for primary actions or messages (blue.20). */
+$kui-color-border-primary-weaker: #bee2ff;
+/* Weakest border color for primary actions or messages (blue.10). */
+$kui-color-border-primary-weakest: #eefaff;
+/* Transparent border color (transparent). */
+$kui-color-border-transparent: transparent;
+/* Default text color (blue.100). */
+$kui-color-text: #000933;
+/* Text color for danger actions or messages (red.60). */
+$kui-color-text-danger: #d60027;
+/* Strong text color for danger actions or messages (red.70). */
+$kui-color-text-danger-strong: #ad000e;
+/* Stronger text color for danger actions or messages (red.80). */
+$kui-color-text-danger-stronger: #850000;
+/* Strongest text color for danger actions or messages (red.90). */
+$kui-color-text-danger-strongest: #5c0000;
+/* Weak text color for danger actions or messages (red.40). */
+$kui-color-text-danger-weak: #ff3954;
+/* Weaker text color for danger actions or messages (red.20). */
+$kui-color-text-danger-weaker: #ffabab;
+/* Weakest text color for danger actions or messages (red.10). */
+$kui-color-text-danger-weakest: #ffe5e5;
+/* Text color for decorative purposes (aqua.50). */
+$kui-color-text-decorative-aqua: #00abd2;
+/* Text color for decorative purposes (pink.60). */
+$kui-color-text-decorative-pink: #d60067;
+/* Text color for decorative purposes (purple.60). */
+$kui-color-text-decorative-purple: #6f28ff;
+/* Strong text color for decorative purposes (purple.70). */
+$kui-color-text-decorative-purple-strong: #5e00f5;
+/* Text color for disabled elements (gray.40). */
+$kui-color-text-disabled: #afb7c5;
+/* Text color for info elements (blue.60). */
+$kui-color-text-info: #0044f4;
+/* Strong text color for info elements (blue.70). */
+$kui-color-text-info-strong: #0030cc;
+/* Stronger text color for info elements (blue.80). */
+$kui-color-text-info-stronger: #002099;
+/* Strongest text color for info elements (blue.90). */
+$kui-color-text-info-strongest: #001466;
+/* Weak text color for info elements (blue.40). */
+$kui-color-text-info-weak: #5f9aff;
+/* Weaker text color for info elements (blue.20). */
+$kui-color-text-info-weaker: #bee2ff;
+/* Weakest text color for info elements (blue.10). */
+$kui-color-text-info-weakest: #eefaff;
+/* Inverse text color (white). */
+$kui-color-text-inverse: #ffffff;
+/* Text color for neutral elements (gray.60). */
+$kui-color-text-neutral: #6c7489;
+/* Strong text color for neutral elements (gray.70). */
+$kui-color-text-neutral-strong: #52596e;
+/* Stronger text color for neutral elements (gray.80). */
+$kui-color-text-neutral-stronger: #3a3f51;
+/* Strongest text color for neutral elements (gray.90). */
+$kui-color-text-neutral-strongest: #232633;
+/* Weak text color for neutral elements (gray.40). */
+$kui-color-text-neutral-weak: #afb7c5;
+/* Weaker text color for neutral elements (gray.20). */
+$kui-color-text-neutral-weaker: #e0e4ea;
+/* Weakest text color for neutral elements (gray.10). */
+$kui-color-text-neutral-weakest: #f9fafb;
+/* Text color for primary actions or messages (blue.60). */
+$kui-color-text-primary: #0044f4;
+/* Strong text color for primary actions or messages (blue.70). */
+$kui-color-text-primary-strong: #0030cc;
+/* Stronger text color for primary actions or messages (blue.80). */
+$kui-color-text-primary-stronger: #002099;
+/* Strongest text color for primary actions or messages (blue.90). */
+$kui-color-text-primary-strongest: #001466;
+/* Weak text color for primary actions or messages (blue.40). */
+$kui-color-text-primary-weak: #5f9aff;
+/* Weaker text color for primary actions or messages (blue.20). */
+$kui-color-text-primary-weaker: #bee2ff;
+/* Weakest text color for primary actions or messages (blue.10). */
+$kui-color-text-primary-weakest: #eefaff;
+/* Text color for success elements (green.60). */
+$kui-color-text-success: #007d60;
+/* Strong text color for success elements (green.70). */
+$kui-color-text-success-strong: #005944;
+/* Stronger text color for success elements (green.80). */
+$kui-color-text-success-stronger: #004737;
+/* Stronger text color for success elements (green.90). */
+$kui-color-text-success-strongest: #003629;
+/* Weak text color for success elements (green.40). */
+$kui-color-text-success-weak: #00d6a4;
+/* Weaker text color for success elements (green.20). */
+$kui-color-text-success-weaker: #b5ffee;
+/* Weakest text color for success elements (green.10). */
+$kui-color-text-success-weakest: #ecfffb;
+/* Text color for warning elements (yellow.60). */
+$kui-color-text-warning: #995c00;
+/* Strong text color for warning elements (yellow.70). */
+$kui-color-text-warning-strong: #804400;
+/* Stronger text color for warning elements (yellow.80). */
+$kui-color-text-warning-stronger: #662d00;
+/* Strongest text color for warning elements (yellow.90). */
+$kui-color-text-warning-strongest: #4d1b00;
+/* Weak text color for warning elements (yellow.40). */
+$kui-color-text-warning-weak: #ffc400;
+/* Weaker text color for warning elements (yellow.20). */
+$kui-color-text-warning-weaker: #fff296;
+/* Weakest text color for warning elements (yellow.10). */
+$kui-color-text-warning-weakest: #fffce0;
+/* Default transition timing */
+$kui-animation-duration-20: 0.2s;
+/* 0px border radius. */
+$kui-border-radius-0: 0px;
+/* 2px border radius. */
+$kui-border-radius-10: 2px;
+/* 4px border radius. */
+$kui-border-radius-20: 4px;
+/* 6px border radius. */
+$kui-border-radius-30: 6px;
+/* 8px border radius. */
+$kui-border-radius-40: 8px;
+/* 10px border radius. */
+$kui-border-radius-50: 10px;
+/* 50% border radius used to create circles. */
+$kui-border-radius-circle: 50%;
+/* 100px border radius used to create pill shapes. */
+$kui-border-radius-round: 100px;
+/* 0px border width. */
+$kui-border-width-0: 0px;
+/* 1px border width. */
+$kui-border-width-10: 1px;
+/* 2px border width. */
+$kui-border-width-20: 2px;
+/* 4px border width. */
+$kui-border-width-30: 4px;
+/* Used for larger mobile screens. Any viewport width under this value is considered mobile. */
+$kui-breakpoint-mobile: 640px;
+/* Used for tablet screens. */
+$kui-breakpoint-phablet: 768px;
+/* Used for larger tablet screens. Any viewport width less than this value will likely show a mobile layout. Any viewport width this value and greater will likely show a desktop layout. */
+$kui-breakpoint-tablet: 1024px;
+/* Used for standard desktop screens. */
+$kui-breakpoint-laptop: 1280px;
+/* Used for larger desktop screens. */
+$kui-breakpoint-desktop: 1536px;
+/* Danger color for icons. */
+$kui-icon-color-danger: #f50045;
+/* Neutral color for icons. */
+$kui-icon-color-neutral: #828a9e;
+/* Primary color for icons. */
+$kui-icon-color-primary: #306fff;
+/* Success color for icons. */
+$kui-icon-color-success: #00a17b;
+/* Warning color for icons. */
+$kui-icon-color-warning: #ffc400;
+/* 10px icon size. */
+$kui-icon-size-10: 10px;
+/* 12px icon size. */
+$kui-icon-size-20: 12px;
+/* 16px icon size. */
+$kui-icon-size-30: 16px;
+/* 20px icon size. */
+$kui-icon-size-40: 20px;
+/* 24px icon size (default). */
+$kui-icon-size-50: 24px;
+/* 32px icon size. */
+$kui-icon-size-60: 32px;
+/* 40px icon size. */
+$kui-icon-size-70: 40px;
+/* 48px icon size. */
+$kui-icon-size-80: 48px;
+/* Background color for the CONNECT method (purple.10). */
+$kui-method-color-background-connect: #f1f0ff;
+/* Background color for the DELETE method (red.10). */
+$kui-method-color-background-delete: #ffe5e5;
+/* Background color for the GET method (blue.10). */
+$kui-method-color-background-get: #eefaff;
+/* Background color for the HEAD method (gray.70). */
+$kui-method-color-background-head: #52596e;
+/* Background color for the OPTIONS method (gray.20). */
+$kui-method-color-background-options: #e0e4ea;
+/* Background color for the PATCH method (aqua.10). */
+$kui-method-color-background-patch: #ecfcff;
+/* Background color for the POST method (green.10). */
+$kui-method-color-background-post: #ecfffb;
+/* Background color for the PUT method (yellow.10). */
+$kui-method-color-background-put: #fffce0;
+/* Background color for the TRACE method (pink.10). */
+$kui-method-color-background-trace: #fff0f7;
+/* Text color for the CONNECT method (purple.60). */
+$kui-method-color-text-connect: #6f28ff;
+/* Strong text color for the CONNECT method (purple.70). */
+$kui-method-color-text-connect-strong: #5e00f5;
+/* Text color for the DELETE method (red.60). */
+$kui-method-color-text-delete: #d60027;
+/* Strong text color for the DELETE method (red.70). */
+$kui-method-color-text-delete-strong: #ad000e;
+/* Text color for the GET method (blue.60). */
+$kui-method-color-text-get: #0044f4;
+/* Strong text color for the GET method (blue.70). */
+$kui-method-color-text-get-strong: #0030cc;
+/* Text color for the HEAD method (gray.20). */
+$kui-method-color-text-head: #e0e4ea;
+/* Strong text color for the HEAD method (gray.40). */
+$kui-method-color-text-head-strong: #afb7c5;
+/* Text color for the OPTIONS method (gray.70). */
+$kui-method-color-text-options: #52596e;
+/* Strong text color for the OPTIONS method (gray.80). */
+$kui-method-color-text-options-strong: #3a3f51;
+/* Text color for the PATCH method (aqua.60). */
+$kui-method-color-text-patch: #00819d;
+/* Strong text color for the PATCH method (aqua.70). */
+$kui-method-color-text-patch-strong: #00647a;
+/* Text color for the POST method (green.60). */
+$kui-method-color-text-post: #007d60;
+/* Strong text color for the POST method (green.70). */
+$kui-method-color-text-post-strong: #005944;
+/* Text color for the PUT method (yellow.60). */
+$kui-method-color-text-put: #995c00;
+/* Strong text color for the PUT method (yellow.70). */
+$kui-method-color-text-put-strong: #804400;
+/* Text color for the TRACE method (pink.60). */
+$kui-method-color-text-trace: #d60067;
+/* Strong text color for the TRACE method (pink.70). */
+$kui-method-color-text-trace-strong: #ad0053;
+/* blue.100 */
+$kui-navigation-color-background: #000933;
+/* The background color of a selected navigation item. */
+$kui-navigation-color-background-selected: rgba(255, 255, 255, 0.12);
+/* rgba(255, 255, 255, 0.12) */
+$kui-navigation-color-border: rgba(255, 255, 255, 0.12);
+/* The border color for a selected child navigation item. */
+$kui-navigation-color-border-child: #00fabe;
+/* The color of the navigation section divider. */
+$kui-navigation-color-border-divider: rgba(255, 255, 255, 0.24);
+/* Navigation link and icon color. */
+$kui-navigation-color-text: #bee2ff;
+/* Navigation link and icon focus-visible color. */
+$kui-navigation-color-text-focus: #ffffff;
+/* Navigation link and icon hover color. */
+$kui-navigation-color-text-hover: #eefaff;
+/* Navigation link and icon selected color. */
+$kui-navigation-color-text-selected: #00fabe;
+/* The box-shadow for a focus-visible navigation link. */
+$kui-navigation-shadow-border: 0 0 0 1px rgba(255, 255, 255, 0.12) inset;
+/* The left box-shadow for an active child navigation link. */
+$kui-navigation-shadow-border-child: 4px 0 0 0 #00fabe inset;
+/* Navigation link focus-visible box-shadow. */
+$kui-navigation-shadow-focus: 0 0 0 1px rgba(255, 255, 255, 0.60) inset;
+/* Color representing response status code 100 (blue.20). */
+$kui-status-color-100: #bee2ff;
+/* Color representing response status code 101 (blue.30). */
+$kui-status-color-101: #8fc1ff;
+/* Color representing response status code 102 (blue.40). */
+$kui-status-color-102: #5f9aff;
+/* Color representing response status code 103 (blue.50). */
+$kui-status-color-103: #306fff;
+/* Color representing response status code 200 (green.20). */
+$kui-status-color-200: #b5ffee;
+/* Color representing response status code 201 (green.30). */
+$kui-status-color-201: #00fabe;
+/* Color representing response status code 202 (green.40). */
+$kui-status-color-202: #00d6a4;
+/* Color representing response status code 203 (green.50). */
+$kui-status-color-203: #00a17b;
+/* Color representing response status code 204 (green.60). */
+$kui-status-color-204: #007d60;
+/* Color representing response status code 205 (green.70). */
+$kui-status-color-205: #005944;
+/* Color representing response status code 206 (green.20). */
+$kui-status-color-206: #b5ffee;
+/* Color representing response status code 207 (green.30). */
+$kui-status-color-207: #00fabe;
+/* Color representing response status code 208 (green.40). */
+$kui-status-color-208: #b5ffee;
+/* Color representing response status code 226 (green.50). */
+$kui-status-color-226: #00a17b;
+/* Color representing response status code 100 (yellow.20). */
+$kui-status-color-300: #fff296;
+/* Color representing response status code 101 (yellow.30). */
+$kui-status-color-301: #ffe04b;
+/* Color representing response status code 102 (yellow.40). */
+$kui-status-color-302: #ffc400;
+/* Color representing response status code 103 (yellow.50). */
+$kui-status-color-303: #b37600;
+/* Color representing response status code 103 (yellow.60). */
+$kui-status-color-304: #995c00;
+/* Color representing response status code 103 (yellow.70). */
+$kui-status-color-305: #804400;
+/* Color representing response status code 103 (yellow.20). */
+$kui-status-color-307: #fff296;
+/* Color representing response status code 103 (yellow.30). */
+$kui-status-color-308: #ffe04b;
+/* Color representing response status code 400 (orange.20). */
+$kui-status-color-400: #FFC2B3;
+/* Color representing response status code 401 (orange.30). */
+$kui-status-color-401: #FF9877;
+/* Color representing response status code 402 (orange.40). */
+$kui-status-color-402: #FF723C;
+/* Color representing response status code 403 (orange.50). */
+$kui-status-color-403: #F75008;
+/* Color representing response status code 404 (orange.60). */
+$kui-status-color-404: #D13500;
+/* Color representing response status code 405 (orange.70). */
+$kui-status-color-405: #A31F00;
+/* Color representing response status code 406 (orange.20). */
+$kui-status-color-406: #FFC2B3;
+/* Color representing response status code 407 (orange.30). */
+$kui-status-color-407: #FF9877;
+/* Color representing response status code 408 (orange.40). */
+$kui-status-color-408: #FF723C;
+/* Color representing response status code 409 (orange.50). */
+$kui-status-color-409: #F75008;
+/* Color representing response status code 410 (orange.60). */
+$kui-status-color-410: #D13500;
+/* Color representing response status code 411 (orange.70). */
+$kui-status-color-411: #A31F00;
+/* Color representing response status code 412 (orange.20). */
+$kui-status-color-412: #FFC2B3;
+/* Color representing response status code 413 (orange.30). */
+$kui-status-color-413: #FF9877;
+/* Color representing response status code 414 (orange.40). */
+$kui-status-color-414: #FF723C;
+/* Color representing response status code 415 (orange.50). */
+$kui-status-color-415: #F75008;
+/* Color representing response status code 416 (orange.60). */
+$kui-status-color-416: #D13500;
+/* Color representing response status code 417 (orange.70). */
+$kui-status-color-417: #A31F00;
+/* Color representing response status code 418 (orange.20). */
+$kui-status-color-418: #FFC2B3;
+/* Color representing response status code 421 (orange.30). */
+$kui-status-color-421: #FF9877;
+/* Color representing response status code 422 (orange.40). */
+$kui-status-color-422: #FF723C;
+/* Color representing response status code 423 (orange.50). */
+$kui-status-color-423: #F75008;
+/* Color representing response status code 424 (orange.60). */
+$kui-status-color-424: #D13500;
+/* Color representing response status code 425 (orange.70). */
+$kui-status-color-425: #A31F00;
+/* Color representing response status code 426 (orange.20). */
+$kui-status-color-426: #FFC2B3;
+/* Color representing response status code 428 (orange.30). */
+$kui-status-color-428: #FF9877;
+/* Color representing response status code 429 (orange.40). */
+$kui-status-color-429: #FF723C;
+/* Color representing response status code 431 (orange.50). */
+$kui-status-color-431: #F75008;
+/* Color representing response status code 451 (orange.60). */
+$kui-status-color-451: #D13500;
+/* Color representing response status code 500 (red.20). */
+$kui-status-color-500: #ffabab;
+/* Color representing response status code 501 (red.30). */
+$kui-status-color-501: #ff7272;
+/* Color representing response status code 502 (red.40). */
+$kui-status-color-502: #ff3954;
+/* Color representing response status code 503 (red.50). */
+$kui-status-color-503: #f50045;
+/* Color representing response status code 504 (red.60). */
+$kui-status-color-504: #d60027;
+/* Color representing response status code 505 (red.70). */
+$kui-status-color-505: #ad000e;
+/* Color representing response status code 506 (red.20). */
+$kui-status-color-506: #ffabab;
+/* Color representing response status code 507 (red.30). */
+$kui-status-color-507: #ff7272;
+/* Color representing response status code 508 (red.40). */
+$kui-status-color-508: #ff3954;
+/* Color representing response status code 510 (red.50). */
+$kui-status-color-510: #f50045;
+/* Color representing response status code 511 (red.60). */
+$kui-status-color-511: #d60027;
+/* Color for unknown response status codes in the 100-199 range (blue.10). */
+$kui-status-color-1na: #eefaff;
+/* Color for unknown response status codes in the 200-299 range (green.10). */
+$kui-status-color-2na: #ecfffb;
+/* Color for unknown response status codes in the 300-399 range (yellow.10). */
+$kui-status-color-3na: #fffce0;
+/* Color for unknown response status codes in the 400-499 range (orange.10). */
+$kui-status-color-4na: #FFF1EF;
+/* Color for unknown response status codes in the 500-599 range (red.10). */
+$kui-status-color-5na: #ffe5e5;
+/* Color for a group of response status codes in the 100-199 range (blue.40). */
+$kui-status-color-100s: #5f9aff;
+/* Color for a group of response status codes in the 200-299 range (green.40). */
+$kui-status-color-200s: #00d6a4;
+/* Color for a group of response status codes in the 300-399 range (yellow.40). */
+$kui-status-color-300s: #ffc400;
+/* Color for a group of response status codes in the 400-499 range (orange.40). */
+$kui-status-color-400s: #FF723C;
+/* Color for a group of response status codes in the 500-599 range (red.40). */
+$kui-status-color-500s: #ff3954;
+/* Background color for http status 100 elements (blue.10). */
+$kui-status-color-background-100: #eefaff;
+/* Background color for http status 200 elements (green.10). */
+$kui-status-color-background-200: #ecfffb;
+/* Background color for http status 300 elements (yellow.10). */
+$kui-status-color-background-300: #fffce0;
+/* Background color for http status 400 elements (orange.10). */
+$kui-status-color-background-400: #FFF1EF;
+/* Background color for http status 500 elements (red.10). */
+$kui-status-color-background-500: #ffe5e5;
+/* Text color for http status 100 elements (blue.60). */
+$kui-status-color-text-100: #0044f4;
+/* Text color for http status 200 elements (green.60). */
+$kui-status-color-text-200: #007d60;
+/* Text color for http status 300 elements (yellow.60). */
+$kui-status-color-text-300: #995c00;
+/* Text color for http status 400 elements (orange.60). */
+$kui-status-color-text-400: #D13500;
+/* Text color for http status 500 elements (red.60). */
+$kui-status-color-text-500: #d60027;
+/* The standard monospace text font family. Typically used for code blocks, inline code, and copyable text. */
+$kui-font-family-code: 'JetBrains Mono', Consolas, monospace;
+/* The standard heading text font family. */
+$kui-font-family-heading: 'Inter', Roboto, Helvetica, sans-serif;
+/* The standard text font family. */
+$kui-font-family-text: 'Inter', Roboto, Helvetica, sans-serif;
+$kui-font-size-10: 10px;
+$kui-font-size-20: 12px;
+$kui-font-size-30: 14px;
+$kui-font-size-40: 16px;
+$kui-font-size-50: 18px;
+$kui-font-size-60: 20px;
+$kui-font-size-70: 24px;
+$kui-font-size-80: 32px;
+$kui-font-size-90: 40px;
+$kui-font-size-100: 48px;
+/* 700: The bold font weight. */
+$kui-font-weight-bold: 700;
+/* 500: The medium font weight. */
+$kui-font-weight-medium: 500;
+/* 400: The normal font weight. */
+$kui-font-weight-regular: 400;
+/* 600: The semibold font weight. */
+$kui-font-weight-semibold: 600;
+/* Alias for letter-spacing-normal */
+$kui-letter-spacing-0: normal;
+/* -0.12px */
+$kui-letter-spacing-minus-10: -0.12px;
+/* -0.24px */
+$kui-letter-spacing-minus-20: -0.24px;
+/* -0.32px */
+$kui-letter-spacing-minus-30: -0.32px;
+/* -0.4px */
+$kui-letter-spacing-minus-40: -0.4px;
+/* -0.48px */
+$kui-letter-spacing-minus-50: -0.48px;
+/* normal */
+$kui-letter-spacing-normal: normal;
+/* 12px */
+$kui-line-height-10: 12px;
+/* 16px */
+$kui-line-height-20: 16px;
+/* 20px */
+$kui-line-height-30: 20px;
+/* 24px */
+$kui-line-height-40: 24px;
+/* 28px */
+$kui-line-height-50: 28px;
+/* 32px */
+$kui-line-height-60: 32px;
+/* 36px */
+$kui-line-height-70: 36px;
+/* 40px */
+$kui-line-height-80: 40px;
+/* 48px */
+$kui-line-height-90: 48px;
+/* 56px */
+$kui-line-height-100: 56px;
+/* 0px 4px 20px 0px rgba(0, 0, 0, 0.08) */
+$kui-shadow: 0px 4px 20px 0px rgba(0, 0, 0, 0.08);
+/* 0px 0px 0px 1px gray.20 inset */
+$kui-shadow-border: 0px 0px 0px 1px #e0e4ea inset;
+/* 0px 0px 0px 1px red.60 inset */
+$kui-shadow-border-danger: 0px 0px 0px 1px #d60027 inset;
+/* 0px 0px 0px 1px red.70 inset */
+$kui-shadow-border-danger-strong: 0px 0px 0px 1px #ad000e inset;
+/* 0px 0px 0px 1px gray.20 inset */
+$kui-shadow-border-disabled: 0px 0px 0px 1px #e0e4ea inset;
+/* 0px 0px 0px 1px blue.60 inset */
+$kui-shadow-border-primary: 0px 0px 0px 1px #0044f4 inset;
+/* 0px 0px 0px 1px blue.90 inset */
+$kui-shadow-border-primary-strongest: 0px 0px 0px 1px #001466 inset;
+/* 0px 0px 0px 1px blue.40 inset */
+$kui-shadow-border-primary-weak: 0px 0px 0px 1px #5f9aff inset;
+/* 0px 0px 0px 4px rgba(0, 68, 244, 0.2) */
+$kui-shadow-focus: 0px 0px 0px 4px rgba(0, 68, 244, 0.2);
+/* 0px value for gaps, margin, or padding. */
+$kui-space-0: 0px;
+/* 2px value for gaps, margin, or padding. */
+$kui-space-10: 2px;
+/* 4px value for gaps, margin, or padding. */
+$kui-space-20: 4px;
+/* 6px value for gaps, margin, or padding. */
+$kui-space-30: 6px;
+/* 8px value for gaps, margin, or padding. */
+$kui-space-40: 8px;
+/* 12px value for gaps, margin, or padding. */
+$kui-space-50: 12px;
+/* 16px value for gaps, margin, or padding. */
+$kui-space-60: 16px;
+/* 20px value for gaps, margin, or padding. */
+$kui-space-70: 20px;
+/* 24px value for gaps, margin, or padding. */
+$kui-space-80: 24px;
+/* 32px value for gaps, margin, or padding. */
+$kui-space-90: 32px;
+/* 40px value for gaps, margin, or padding. */
+$kui-space-100: 40px;
+/* 48px value for gaps, margin, or padding. */
+$kui-space-110: 48px;
+/* 56px value for gaps, margin, or padding. */
+$kui-space-120: 56px;
+/* 64px value for gaps, margin, or padding. */
+$kui-space-130: 64px;
+/* 80px value for gaps, margin, or padding. */
+$kui-space-140: 80px;
+/* 96px value for gaps, margin, or padding. */
+$kui-space-150: 96px;
+/* auto */
+$kui-space-auto: auto;
 ```
 
 </details>
@@ -367,343 +694,670 @@ $kui-space-auto: ;
 
 ```scss
 $tokens-map: (
-  'kui-color-background': ;
-  'kui-color-background-danger': ;
-  'kui-color-background-danger-strong': ;
-  'kui-color-background-danger-stronger': ;
-  'kui-color-background-danger-strongest': ;
-  'kui-color-background-danger-weak': ;
-  'kui-color-background-danger-weaker': ;
-  'kui-color-background-danger-weakest': ;
-  'kui-color-background-decorative-aqua-weakest': ;
-  'kui-color-background-decorative-purple': ;
-  'kui-color-background-decorative-purple-weakest': ;
-  'kui-color-background-disabled': ;
-  'kui-color-background-info': ;
-  'kui-color-background-info-strong': ;
-  'kui-color-background-info-stronger': ;
-  'kui-color-background-info-strongest': ;
-  'kui-color-background-info-weak': ;
-  'kui-color-background-info-weaker': ;
-  'kui-color-background-info-weakest': ;
-  'kui-color-background-inverse': ;
-  'kui-color-background-neutral': ;
-  'kui-color-background-neutral-strong': ;
-  'kui-color-background-neutral-stronger': ;
-  'kui-color-background-neutral-strongest': ;
-  'kui-color-background-neutral-weak': ;
-  'kui-color-background-neutral-weaker': ;
-  'kui-color-background-neutral-weakest': ;
-  'kui-color-background-overlay': ;
-  'kui-color-background-primary': ;
-  'kui-color-background-primary-strong': ;
-  'kui-color-background-primary-stronger': ;
-  'kui-color-background-primary-strongest': ;
-  'kui-color-background-primary-weak': ;
-  'kui-color-background-primary-weaker': ;
-  'kui-color-background-primary-weakest': ;
-  'kui-color-background-success': ;
-  'kui-color-background-success-strong': ;
-  'kui-color-background-success-stronger': ;
-  'kui-color-background-success-strongest': ;
-  'kui-color-background-success-weak': ;
-  'kui-color-background-success-weaker': ;
-  'kui-color-background-success-weakest': ;
-  'kui-color-background-transparent': ;
-  'kui-color-background-warning': ;
-  'kui-color-background-warning-strong': ;
-  'kui-color-background-warning-stronger': ;
-  'kui-color-background-warning-strongest': ;
-  'kui-color-background-warning-weak': ;
-  'kui-color-background-warning-weaker': ;
-  'kui-color-background-warning-weakest': ;
-  'kui-color-border': ;
-  'kui-color-border-danger': ;
-  'kui-color-border-danger-strong': ;
-  'kui-color-border-danger-stronger': ;
-  'kui-color-border-danger-strongest': ;
-  'kui-color-border-danger-weak': ;
-  'kui-color-border-danger-weaker': ;
-  'kui-color-border-danger-weakest': ;
-  'kui-color-border-decorative-purple': ;
-  'kui-color-border-disabled': ;
-  'kui-color-border-inverse': ;
-  'kui-color-border-neutral': ;
-  'kui-color-border-neutral-strong': ;
-  'kui-color-border-neutral-stronger': ;
-  'kui-color-border-neutral-strongest': ;
-  'kui-color-border-neutral-weak': ;
-  'kui-color-border-neutral-weaker': ;
-  'kui-color-border-neutral-weakest': ;
-  'kui-color-border-primary': ;
-  'kui-color-border-primary-strong': ;
-  'kui-color-border-primary-stronger': ;
-  'kui-color-border-primary-strongest': ;
-  'kui-color-border-primary-weak': ;
-  'kui-color-border-primary-weaker': ;
-  'kui-color-border-primary-weakest': ;
-  'kui-color-border-transparent': ;
-  'kui-color-text': ;
-  'kui-color-text-danger': ;
-  'kui-color-text-danger-strong': ;
-  'kui-color-text-danger-stronger': ;
-  'kui-color-text-danger-strongest': ;
-  'kui-color-text-danger-weak': ;
-  'kui-color-text-danger-weaker': ;
-  'kui-color-text-danger-weakest': ;
-  'kui-color-text-decorative-aqua': ;
-  'kui-color-text-decorative-pink': ;
-  'kui-color-text-decorative-purple': ;
-  'kui-color-text-decorative-purple-strong': ;
-  'kui-color-text-disabled': ;
-  'kui-color-text-info': ;
-  'kui-color-text-info-strong': ;
-  'kui-color-text-info-stronger': ;
-  'kui-color-text-info-strongest': ;
-  'kui-color-text-info-weak': ;
-  'kui-color-text-info-weaker': ;
-  'kui-color-text-info-weakest': ;
-  'kui-color-text-inverse': ;
-  'kui-color-text-neutral': ;
-  'kui-color-text-neutral-strong': ;
-  'kui-color-text-neutral-stronger': ;
-  'kui-color-text-neutral-strongest': ;
-  'kui-color-text-neutral-weak': ;
-  'kui-color-text-neutral-weaker': ;
-  'kui-color-text-neutral-weakest': ;
-  'kui-color-text-primary': ;
-  'kui-color-text-primary-strong': ;
-  'kui-color-text-primary-stronger': ;
-  'kui-color-text-primary-strongest': ;
-  'kui-color-text-primary-weak': ;
-  'kui-color-text-primary-weaker': ;
-  'kui-color-text-primary-weakest': ;
-  'kui-color-text-success': ;
-  'kui-color-text-success-strong': ;
-  'kui-color-text-success-stronger': ;
-  'kui-color-text-success-strongest': ;
-  'kui-color-text-success-weak': ;
-  'kui-color-text-success-weaker': ;
-  'kui-color-text-success-weakest': ;
-  'kui-color-text-warning': ;
-  'kui-color-text-warning-strong': ;
-  'kui-color-text-warning-stronger': ;
-  'kui-color-text-warning-strongest': ;
-  'kui-color-text-warning-weak': ;
-  'kui-color-text-warning-weaker': ;
-  'kui-color-text-warning-weakest': ;
-  'kui-animation-duration-20': ;
-  'kui-border-radius-0': ;
-  'kui-border-radius-10': ;
-  'kui-border-radius-20': ;
-  'kui-border-radius-30': ;
-  'kui-border-radius-40': ;
-  'kui-border-radius-50': ;
-  'kui-border-radius-circle': ;
-  'kui-border-radius-round': ;
-  'kui-border-width-0': ;
-  'kui-border-width-10': ;
-  'kui-border-width-20': ;
-  'kui-border-width-30': ;
-  'kui-breakpoint-mobile': ;
-  'kui-breakpoint-phablet': ;
-  'kui-breakpoint-tablet': ;
-  'kui-breakpoint-laptop': ;
-  'kui-breakpoint-desktop': ;
-  'kui-icon-color-danger': ;
-  'kui-icon-color-neutral': ;
-  'kui-icon-color-primary': ;
-  'kui-icon-color-success': ;
-  'kui-icon-color-warning': ;
-  'kui-icon-size-10': ;
-  'kui-icon-size-20': ;
-  'kui-icon-size-30': ;
-  'kui-icon-size-40': ;
-  'kui-icon-size-50': ;
-  'kui-icon-size-60': ;
-  'kui-icon-size-70': ;
-  'kui-icon-size-80': ;
-  'kui-method-color-background-connect': ;
-  'kui-method-color-background-delete': ;
-  'kui-method-color-background-get': ;
-  'kui-method-color-background-head': ;
-  'kui-method-color-background-options': ;
-  'kui-method-color-background-patch': ;
-  'kui-method-color-background-post': ;
-  'kui-method-color-background-put': ;
-  'kui-method-color-background-trace': ;
-  'kui-method-color-text-connect': ;
-  'kui-method-color-text-connect-strong': ;
-  'kui-method-color-text-delete': ;
-  'kui-method-color-text-delete-strong': ;
-  'kui-method-color-text-get': ;
-  'kui-method-color-text-get-strong': ;
-  'kui-method-color-text-head': ;
-  'kui-method-color-text-head-strong': ;
-  'kui-method-color-text-options': ;
-  'kui-method-color-text-options-strong': ;
-  'kui-method-color-text-patch': ;
-  'kui-method-color-text-patch-strong': ;
-  'kui-method-color-text-post': ;
-  'kui-method-color-text-post-strong': ;
-  'kui-method-color-text-put': ;
-  'kui-method-color-text-put-strong': ;
-  'kui-method-color-text-trace': ;
-  'kui-method-color-text-trace-strong': ;
-  'kui-navigation-color-background': ;
-  'kui-navigation-color-background-selected': ;
-  'kui-navigation-color-border': ;
-  'kui-navigation-color-border-child': ;
-  'kui-navigation-color-border-divider': ;
-  'kui-navigation-color-text': ;
-  'kui-navigation-color-text-focus': ;
-  'kui-navigation-color-text-hover': ;
-  'kui-navigation-color-text-selected': ;
-  'kui-navigation-shadow-border': ;
-  'kui-navigation-shadow-border-child': ;
-  'kui-navigation-shadow-focus': ;
-  'kui-status-color-100': ;
-  'kui-status-color-101': ;
-  'kui-status-color-102': ;
-  'kui-status-color-103': ;
-  'kui-status-color-200': ;
-  'kui-status-color-201': ;
-  'kui-status-color-202': ;
-  'kui-status-color-203': ;
-  'kui-status-color-204': ;
-  'kui-status-color-205': ;
-  'kui-status-color-206': ;
-  'kui-status-color-207': ;
-  'kui-status-color-208': ;
-  'kui-status-color-226': ;
-  'kui-status-color-300': ;
-  'kui-status-color-301': ;
-  'kui-status-color-302': ;
-  'kui-status-color-303': ;
-  'kui-status-color-304': ;
-  'kui-status-color-305': ;
-  'kui-status-color-307': ;
-  'kui-status-color-308': ;
-  'kui-status-color-400': ;
-  'kui-status-color-401': ;
-  'kui-status-color-402': ;
-  'kui-status-color-403': ;
-  'kui-status-color-404': ;
-  'kui-status-color-405': ;
-  'kui-status-color-406': ;
-  'kui-status-color-407': ;
-  'kui-status-color-408': ;
-  'kui-status-color-409': ;
-  'kui-status-color-410': ;
-  'kui-status-color-411': ;
-  'kui-status-color-412': ;
-  'kui-status-color-413': ;
-  'kui-status-color-414': ;
-  'kui-status-color-415': ;
-  'kui-status-color-416': ;
-  'kui-status-color-417': ;
-  'kui-status-color-418': ;
-  'kui-status-color-421': ;
-  'kui-status-color-422': ;
-  'kui-status-color-423': ;
-  'kui-status-color-424': ;
-  'kui-status-color-425': ;
-  'kui-status-color-426': ;
-  'kui-status-color-428': ;
-  'kui-status-color-429': ;
-  'kui-status-color-431': ;
-  'kui-status-color-451': ;
-  'kui-status-color-500': ;
-  'kui-status-color-501': ;
-  'kui-status-color-502': ;
-  'kui-status-color-503': ;
-  'kui-status-color-504': ;
-  'kui-status-color-505': ;
-  'kui-status-color-506': ;
-  'kui-status-color-507': ;
-  'kui-status-color-508': ;
-  'kui-status-color-510': ;
-  'kui-status-color-511': ;
-  'kui-status-color-1na': ;
-  'kui-status-color-2na': ;
-  'kui-status-color-3na': ;
-  'kui-status-color-4na': ;
-  'kui-status-color-5na': ;
-  'kui-status-color-100s': ;
-  'kui-status-color-200s': ;
-  'kui-status-color-300s': ;
-  'kui-status-color-400s': ;
-  'kui-status-color-500s': ;
-  'kui-status-color-background-100': ;
-  'kui-status-color-background-200': ;
-  'kui-status-color-background-300': ;
-  'kui-status-color-background-400': ;
-  'kui-status-color-background-500': ;
-  'kui-status-color-text-100': ;
-  'kui-status-color-text-200': ;
-  'kui-status-color-text-300': ;
-  'kui-status-color-text-400': ;
-  'kui-status-color-text-500': ;
-  'kui-font-family-code': ;
-  'kui-font-family-heading': ;
-  'kui-font-family-text': ;
-  'kui-font-size-10': ;
-  'kui-font-size-20': ;
-  'kui-font-size-30': ;
-  'kui-font-size-40': ;
-  'kui-font-size-50': ;
-  'kui-font-size-60': ;
-  'kui-font-size-70': ;
-  'kui-font-size-80': ;
-  'kui-font-size-90': ;
-  'kui-font-size-100': ;
-  'kui-font-weight-bold': ;
-  'kui-font-weight-medium': ;
-  'kui-font-weight-regular': ;
-  'kui-font-weight-semibold': ;
-  'kui-letter-spacing-0': ;
-  'kui-letter-spacing-minus-10': ;
-  'kui-letter-spacing-minus-20': ;
-  'kui-letter-spacing-minus-30': ;
-  'kui-letter-spacing-minus-40': ;
-  'kui-letter-spacing-minus-50': ;
-  'kui-letter-spacing-normal': ;
-  'kui-line-height-10': ;
-  'kui-line-height-20': ;
-  'kui-line-height-30': ;
-  'kui-line-height-40': ;
-  'kui-line-height-50': ;
-  'kui-line-height-60': ;
-  'kui-line-height-70': ;
-  'kui-line-height-80': ;
-  'kui-line-height-90': ;
-  'kui-line-height-100': ;
-  'kui-shadow': ;
-  'kui-shadow-border': ;
-  'kui-shadow-border-danger': ;
-  'kui-shadow-border-danger-strong': ;
-  'kui-shadow-border-disabled': ;
-  'kui-shadow-border-primary': ;
-  'kui-shadow-border-primary-strongest': ;
-  'kui-shadow-border-primary-weak': ;
-  'kui-shadow-focus': ;
-  'kui-space-0': ;
-  'kui-space-10': ;
-  'kui-space-20': ;
-  'kui-space-30': ;
-  'kui-space-40': ;
-  'kui-space-50': ;
-  'kui-space-60': ;
-  'kui-space-70': ;
-  'kui-space-80': ;
-  'kui-space-90': ;
-  'kui-space-100': ;
-  'kui-space-110': ;
-  'kui-space-120': ;
-  'kui-space-130': ;
-  'kui-space-140': ;
-  'kui-space-150': ;
-  'kui-space-auto': ;
+  /* Default background color for containers (white). */
+  'kui-color-background': #ffffff;
+  /* Background color for danger actions or messages (red.60). */
+  'kui-color-background-danger': #d60027;
+  /* Strong background color for danger actions or messages (red.70). */
+  'kui-color-background-danger-strong': #ad000e;
+  /* Stronger background color for danger actions or messages (red.80). */
+  'kui-color-background-danger-stronger': #850000;
+  /* Strongest background color for danger actions or messages (red.90). */
+  'kui-color-background-danger-strongest': #5c0000;
+  /* Weak background color for danger actions or messages (red.40). */
+  'kui-color-background-danger-weak': #ff3954;
+  /* Weaker background color for danger actions or messages (red.20). */
+  'kui-color-background-danger-weaker': #ffabab;
+  /* Weakest background color for danger actions or messages (red.10). */
+  'kui-color-background-danger-weakest': #ffe5e5;
+  /* Weakest background color for decorative purposes (aqua.10). */
+  'kui-color-background-decorative-aqua-weakest': #ecfcff;
+  /* Background color for decorative purposes (purple.60). */
+  'kui-color-background-decorative-purple': #6f28ff;
+  /* Weakest background color for decorative purposes (purple.10). */
+  'kui-color-background-decorative-purple-weakest': #f1f0ff;
+  /* Background color for disabled elements (gray.20). */
+  'kui-color-background-disabled': #e0e4ea;
+  /* Background color for info elements (blue.60). */
+  'kui-color-background-info': #0044f4;
+  /* Strong background color for info elements (blue.70). */
+  'kui-color-background-info-strong': #0030cc;
+  /* Stronger background color for info elements (blue.80). */
+  'kui-color-background-info-stronger': #002099;
+  /* Strongest background color for info elements (blue.90). */
+  'kui-color-background-info-strongest': #001466;
+  /* Weak background color for info elements (blue.40). */
+  'kui-color-background-info-weak': #5f9aff;
+  /* Weaker background color for info elements (blue.20). */
+  'kui-color-background-info-weaker': #bee2ff;
+  /* Weakest background color for info elements (blue.10). */
+  'kui-color-background-info-weakest': #eefaff;
+  /* Inverse background color for containers (blue.100) */
+  'kui-color-background-inverse': #000933;
+  /* Background color for neutral elements (gray.60). */
+  'kui-color-background-neutral': #6c7489;
+  /* Strong background color for neutral elements (gray.70). */
+  'kui-color-background-neutral-strong': #52596e;
+  /* Stronger background color for neutral elements (gray.80). */
+  'kui-color-background-neutral-stronger': #3a3f51;
+  /* Strongest background color for neutral elements (gray.90). */
+  'kui-color-background-neutral-strongest': #232633;
+  /* Weak background color for neutral elements (gray.40). */
+  'kui-color-background-neutral-weak': #afb7c5;
+  /* Weaker background color for neutral elements (gray.20). */
+  'kui-color-background-neutral-weaker': #e0e4ea;
+  /* Weakest background color for neutral elements (gray.10). */
+  'kui-color-background-neutral-weakest': #f9fafb;
+  /* Overlay background color (rgba(0, 9, 51, 0.6)) */
+  'kui-color-background-overlay': rgba(0, 9, 51, 0.6);
+  /* Background color for primary actions or messages (blue.60). */
+  'kui-color-background-primary': #0044f4;
+  /* Strong background color for primary actions or messages (blue.70). */
+  'kui-color-background-primary-strong': #0030cc;
+  /* Stronger background color for primary actions or messages (blue.80). */
+  'kui-color-background-primary-stronger': #002099;
+  /* Strongest background color for primary actions or messages (blue.90). */
+  'kui-color-background-primary-strongest': #001466;
+  /* Weak background color for primary actions or messages (blue.40). */
+  'kui-color-background-primary-weak': #5f9aff;
+  /* Weaker background color for primary actions or messages (blue.20). */
+  'kui-color-background-primary-weaker': #bee2ff;
+  /* Weakest background color for primary actions or messages (blue.10) */
+  'kui-color-background-primary-weakest': #eefaff;
+  /* Background color for success elements (green.60). */
+  'kui-color-background-success': #007d60;
+  /* Strong background color for success elements (green.70). */
+  'kui-color-background-success-strong': #005944;
+  /* Stronger background color for success elements (green.80). */
+  'kui-color-background-success-stronger': #004737;
+  /* Strongest background color for success elements (green.90). */
+  'kui-color-background-success-strongest': #003629;
+  /* Weak background color for success elements (green.40). */
+  'kui-color-background-success-weak': #00d6a4;
+  /* Weaker background color for success elements (green.20). */
+  'kui-color-background-success-weaker': #b5ffee;
+  /* Weakest background color for success elements (green.10). */
+  'kui-color-background-success-weakest': #ecfffb;
+  /* Transparent background color (transparent). */
+  'kui-color-background-transparent': transparent;
+  /* Background color for warning elements (yellow.60). */
+  'kui-color-background-warning': #995c00;
+  /* Strong background color for warning elements (yellow.70). */
+  'kui-color-background-warning-strong': #804400;
+  /* Stronger background color for warning elements (yellow.80). */
+  'kui-color-background-warning-stronger': #662d00;
+  /* Strongest background color for warning elements (yellow.90). */
+  'kui-color-background-warning-strongest': #4d1b00;
+  /* Weak background color for warning elements (yellow.40). */
+  'kui-color-background-warning-weak': #ffc400;
+  /* Weaker background color for warning elements (yellow.20). */
+  'kui-color-background-warning-weaker': #fff296;
+  /* Weakest background color for warning elements (yellow.10). */
+  'kui-color-background-warning-weakest': #fffce0;
+  /* Default border color for containers (gray.20). */
+  'kui-color-border': #e0e4ea;
+  /* Border color for danger actions or messages (red.60). */
+  'kui-color-border-danger': #d60027;
+  /* Strong border color for danger actions or messages (red.70). */
+  'kui-color-border-danger-strong': #ad000e;
+  /* Stronger border color for danger actions or messages (red.80). */
+  'kui-color-border-danger-stronger': #850000;
+  /* Strongest border color for danger actions or messages (red.90). */
+  'kui-color-border-danger-strongest': #5c0000;
+  /* Weak border color for danger actions or messages (red.40). */
+  'kui-color-border-danger-weak': #ff3954;
+  /* Weaker border color for danger actions or messages (red.20). */
+  'kui-color-border-danger-weaker': #ffabab;
+  /* Weakest border color for danger actions or messages (red.10). */
+  'kui-color-border-danger-weakest': #ffe5e5;
+  /* Border color for decorative purposes (purple.60). */
+  'kui-color-border-decorative-purple': #6f28ff;
+  /* Border color for disabled elements (gray.20). */
+  'kui-color-border-disabled': #e0e4ea;
+  /* Inverse border color (rgba(255, 255, 255, 0.2)). */
+  'kui-color-border-inverse': rgba(255, 255, 255, 0.2);
+  /* Border color for neutral elements (gray.60) */
+  'kui-color-border-neutral': #6c7489;
+  /* Strong border color for neutral elements (gray.70) */
+  'kui-color-border-neutral-strong': #52596e;
+  /* Stronger border color for neutral elements (gray.80) */
+  'kui-color-border-neutral-stronger': #3a3f51;
+  /* Strongest border color for neutral elements (gray.90) */
+  'kui-color-border-neutral-strongest': #232633;
+  /* Weak border color for neutral elements (gray.40) */
+  'kui-color-border-neutral-weak': #afb7c5;
+  /* Weaker border color for neutral elements (gray.20) */
+  'kui-color-border-neutral-weaker': #e0e4ea;
+  /* Weakest border color for neutral elements (gray.10) */
+  'kui-color-border-neutral-weakest': #f9fafb;
+  /* Border color for primary actions or messages (blue.60). */
+  'kui-color-border-primary': #0044f4;
+  /* Strong border color for primary actions or messages (blue.70). */
+  'kui-color-border-primary-strong': #0030cc;
+  /* Stronger border color for primary actions or messages (blue.80). */
+  'kui-color-border-primary-stronger': #002099;
+  /* Strongest border color for primary actions or messages (blue.90). */
+  'kui-color-border-primary-strongest': #001466;
+  /* Weak border color for primary actions or messages (blue.40). */
+  'kui-color-border-primary-weak': #5f9aff;
+  /* Weaker border color for primary actions or messages (blue.20). */
+  'kui-color-border-primary-weaker': #bee2ff;
+  /* Weakest border color for primary actions or messages (blue.10). */
+  'kui-color-border-primary-weakest': #eefaff;
+  /* Transparent border color (transparent). */
+  'kui-color-border-transparent': transparent;
+  /* Default text color (blue.100). */
+  'kui-color-text': #000933;
+  /* Text color for danger actions or messages (red.60). */
+  'kui-color-text-danger': #d60027;
+  /* Strong text color for danger actions or messages (red.70). */
+  'kui-color-text-danger-strong': #ad000e;
+  /* Stronger text color for danger actions or messages (red.80). */
+  'kui-color-text-danger-stronger': #850000;
+  /* Strongest text color for danger actions or messages (red.90). */
+  'kui-color-text-danger-strongest': #5c0000;
+  /* Weak text color for danger actions or messages (red.40). */
+  'kui-color-text-danger-weak': #ff3954;
+  /* Weaker text color for danger actions or messages (red.20). */
+  'kui-color-text-danger-weaker': #ffabab;
+  /* Weakest text color for danger actions or messages (red.10). */
+  'kui-color-text-danger-weakest': #ffe5e5;
+  /* Text color for decorative purposes (aqua.50). */
+  'kui-color-text-decorative-aqua': #00abd2;
+  /* Text color for decorative purposes (pink.60). */
+  'kui-color-text-decorative-pink': #d60067;
+  /* Text color for decorative purposes (purple.60). */
+  'kui-color-text-decorative-purple': #6f28ff;
+  /* Strong text color for decorative purposes (purple.70). */
+  'kui-color-text-decorative-purple-strong': #5e00f5;
+  /* Text color for disabled elements (gray.40). */
+  'kui-color-text-disabled': #afb7c5;
+  /* Text color for info elements (blue.60). */
+  'kui-color-text-info': #0044f4;
+  /* Strong text color for info elements (blue.70). */
+  'kui-color-text-info-strong': #0030cc;
+  /* Stronger text color for info elements (blue.80). */
+  'kui-color-text-info-stronger': #002099;
+  /* Strongest text color for info elements (blue.90). */
+  'kui-color-text-info-strongest': #001466;
+  /* Weak text color for info elements (blue.40). */
+  'kui-color-text-info-weak': #5f9aff;
+  /* Weaker text color for info elements (blue.20). */
+  'kui-color-text-info-weaker': #bee2ff;
+  /* Weakest text color for info elements (blue.10). */
+  'kui-color-text-info-weakest': #eefaff;
+  /* Inverse text color (white). */
+  'kui-color-text-inverse': #ffffff;
+  /* Text color for neutral elements (gray.60). */
+  'kui-color-text-neutral': #6c7489;
+  /* Strong text color for neutral elements (gray.70). */
+  'kui-color-text-neutral-strong': #52596e;
+  /* Stronger text color for neutral elements (gray.80). */
+  'kui-color-text-neutral-stronger': #3a3f51;
+  /* Strongest text color for neutral elements (gray.90). */
+  'kui-color-text-neutral-strongest': #232633;
+  /* Weak text color for neutral elements (gray.40). */
+  'kui-color-text-neutral-weak': #afb7c5;
+  /* Weaker text color for neutral elements (gray.20). */
+  'kui-color-text-neutral-weaker': #e0e4ea;
+  /* Weakest text color for neutral elements (gray.10). */
+  'kui-color-text-neutral-weakest': #f9fafb;
+  /* Text color for primary actions or messages (blue.60). */
+  'kui-color-text-primary': #0044f4;
+  /* Strong text color for primary actions or messages (blue.70). */
+  'kui-color-text-primary-strong': #0030cc;
+  /* Stronger text color for primary actions or messages (blue.80). */
+  'kui-color-text-primary-stronger': #002099;
+  /* Strongest text color for primary actions or messages (blue.90). */
+  'kui-color-text-primary-strongest': #001466;
+  /* Weak text color for primary actions or messages (blue.40). */
+  'kui-color-text-primary-weak': #5f9aff;
+  /* Weaker text color for primary actions or messages (blue.20). */
+  'kui-color-text-primary-weaker': #bee2ff;
+  /* Weakest text color for primary actions or messages (blue.10). */
+  'kui-color-text-primary-weakest': #eefaff;
+  /* Text color for success elements (green.60). */
+  'kui-color-text-success': #007d60;
+  /* Strong text color for success elements (green.70). */
+  'kui-color-text-success-strong': #005944;
+  /* Stronger text color for success elements (green.80). */
+  'kui-color-text-success-stronger': #004737;
+  /* Stronger text color for success elements (green.90). */
+  'kui-color-text-success-strongest': #003629;
+  /* Weak text color for success elements (green.40). */
+  'kui-color-text-success-weak': #00d6a4;
+  /* Weaker text color for success elements (green.20). */
+  'kui-color-text-success-weaker': #b5ffee;
+  /* Weakest text color for success elements (green.10). */
+  'kui-color-text-success-weakest': #ecfffb;
+  /* Text color for warning elements (yellow.60). */
+  'kui-color-text-warning': #995c00;
+  /* Strong text color for warning elements (yellow.70). */
+  'kui-color-text-warning-strong': #804400;
+  /* Stronger text color for warning elements (yellow.80). */
+  'kui-color-text-warning-stronger': #662d00;
+  /* Strongest text color for warning elements (yellow.90). */
+  'kui-color-text-warning-strongest': #4d1b00;
+  /* Weak text color for warning elements (yellow.40). */
+  'kui-color-text-warning-weak': #ffc400;
+  /* Weaker text color for warning elements (yellow.20). */
+  'kui-color-text-warning-weaker': #fff296;
+  /* Weakest text color for warning elements (yellow.10). */
+  'kui-color-text-warning-weakest': #fffce0;
+  /* Default transition timing */
+  'kui-animation-duration-20': 0.2s;
+  /* 0px border radius. */
+  'kui-border-radius-0': 0px;
+  /* 2px border radius. */
+  'kui-border-radius-10': 2px;
+  /* 4px border radius. */
+  'kui-border-radius-20': 4px;
+  /* 6px border radius. */
+  'kui-border-radius-30': 6px;
+  /* 8px border radius. */
+  'kui-border-radius-40': 8px;
+  /* 10px border radius. */
+  'kui-border-radius-50': 10px;
+  /* 50% border radius used to create circles. */
+  'kui-border-radius-circle': 50%;
+  /* 100px border radius used to create pill shapes. */
+  'kui-border-radius-round': 100px;
+  /* 0px border width. */
+  'kui-border-width-0': 0px;
+  /* 1px border width. */
+  'kui-border-width-10': 1px;
+  /* 2px border width. */
+  'kui-border-width-20': 2px;
+  /* 4px border width. */
+  'kui-border-width-30': 4px;
+  /* Used for larger mobile screens. Any viewport width under this value is considered mobile. */
+  'kui-breakpoint-mobile': 640px;
+  /* Used for tablet screens. */
+  'kui-breakpoint-phablet': 768px;
+  /* Used for larger tablet screens. Any viewport width less than this value will likely show a mobile layout. Any viewport width this value and greater will likely show a desktop layout. */
+  'kui-breakpoint-tablet': 1024px;
+  /* Used for standard desktop screens. */
+  'kui-breakpoint-laptop': 1280px;
+  /* Used for larger desktop screens. */
+  'kui-breakpoint-desktop': 1536px;
+  /* Danger color for icons. */
+  'kui-icon-color-danger': #f50045;
+  /* Neutral color for icons. */
+  'kui-icon-color-neutral': #828a9e;
+  /* Primary color for icons. */
+  'kui-icon-color-primary': #306fff;
+  /* Success color for icons. */
+  'kui-icon-color-success': #00a17b;
+  /* Warning color for icons. */
+  'kui-icon-color-warning': #ffc400;
+  /* 10px icon size. */
+  'kui-icon-size-10': 10px;
+  /* 12px icon size. */
+  'kui-icon-size-20': 12px;
+  /* 16px icon size. */
+  'kui-icon-size-30': 16px;
+  /* 20px icon size. */
+  'kui-icon-size-40': 20px;
+  /* 24px icon size (default). */
+  'kui-icon-size-50': 24px;
+  /* 32px icon size. */
+  'kui-icon-size-60': 32px;
+  /* 40px icon size. */
+  'kui-icon-size-70': 40px;
+  /* 48px icon size. */
+  'kui-icon-size-80': 48px;
+  /* Background color for the CONNECT method (purple.10). */
+  'kui-method-color-background-connect': #f1f0ff;
+  /* Background color for the DELETE method (red.10). */
+  'kui-method-color-background-delete': #ffe5e5;
+  /* Background color for the GET method (blue.10). */
+  'kui-method-color-background-get': #eefaff;
+  /* Background color for the HEAD method (gray.70). */
+  'kui-method-color-background-head': #52596e;
+  /* Background color for the OPTIONS method (gray.20). */
+  'kui-method-color-background-options': #e0e4ea;
+  /* Background color for the PATCH method (aqua.10). */
+  'kui-method-color-background-patch': #ecfcff;
+  /* Background color for the POST method (green.10). */
+  'kui-method-color-background-post': #ecfffb;
+  /* Background color for the PUT method (yellow.10). */
+  'kui-method-color-background-put': #fffce0;
+  /* Background color for the TRACE method (pink.10). */
+  'kui-method-color-background-trace': #fff0f7;
+  /* Text color for the CONNECT method (purple.60). */
+  'kui-method-color-text-connect': #6f28ff;
+  /* Strong text color for the CONNECT method (purple.70). */
+  'kui-method-color-text-connect-strong': #5e00f5;
+  /* Text color for the DELETE method (red.60). */
+  'kui-method-color-text-delete': #d60027;
+  /* Strong text color for the DELETE method (red.70). */
+  'kui-method-color-text-delete-strong': #ad000e;
+  /* Text color for the GET method (blue.60). */
+  'kui-method-color-text-get': #0044f4;
+  /* Strong text color for the GET method (blue.70). */
+  'kui-method-color-text-get-strong': #0030cc;
+  /* Text color for the HEAD method (gray.20). */
+  'kui-method-color-text-head': #e0e4ea;
+  /* Strong text color for the HEAD method (gray.40). */
+  'kui-method-color-text-head-strong': #afb7c5;
+  /* Text color for the OPTIONS method (gray.70). */
+  'kui-method-color-text-options': #52596e;
+  /* Strong text color for the OPTIONS method (gray.80). */
+  'kui-method-color-text-options-strong': #3a3f51;
+  /* Text color for the PATCH method (aqua.60). */
+  'kui-method-color-text-patch': #00819d;
+  /* Strong text color for the PATCH method (aqua.70). */
+  'kui-method-color-text-patch-strong': #00647a;
+  /* Text color for the POST method (green.60). */
+  'kui-method-color-text-post': #007d60;
+  /* Strong text color for the POST method (green.70). */
+  'kui-method-color-text-post-strong': #005944;
+  /* Text color for the PUT method (yellow.60). */
+  'kui-method-color-text-put': #995c00;
+  /* Strong text color for the PUT method (yellow.70). */
+  'kui-method-color-text-put-strong': #804400;
+  /* Text color for the TRACE method (pink.60). */
+  'kui-method-color-text-trace': #d60067;
+  /* Strong text color for the TRACE method (pink.70). */
+  'kui-method-color-text-trace-strong': #ad0053;
+  /* blue.100 */
+  'kui-navigation-color-background': #000933;
+  /* The background color of a selected navigation item. */
+  'kui-navigation-color-background-selected': rgba(255, 255, 255, 0.12);
+  /* rgba(255, 255, 255, 0.12) */
+  'kui-navigation-color-border': rgba(255, 255, 255, 0.12);
+  /* The border color for a selected child navigation item. */
+  'kui-navigation-color-border-child': #00fabe;
+  /* The color of the navigation section divider. */
+  'kui-navigation-color-border-divider': rgba(255, 255, 255, 0.24);
+  /* Navigation link and icon color. */
+  'kui-navigation-color-text': #bee2ff;
+  /* Navigation link and icon focus-visible color. */
+  'kui-navigation-color-text-focus': #ffffff;
+  /* Navigation link and icon hover color. */
+  'kui-navigation-color-text-hover': #eefaff;
+  /* Navigation link and icon selected color. */
+  'kui-navigation-color-text-selected': #00fabe;
+  /* The box-shadow for a focus-visible navigation link. */
+  'kui-navigation-shadow-border': 0 0 0 1px rgba(255, 255, 255, 0.12) inset;
+  /* The left box-shadow for an active child navigation link. */
+  'kui-navigation-shadow-border-child': 4px 0 0 0 #00fabe inset;
+  /* Navigation link focus-visible box-shadow. */
+  'kui-navigation-shadow-focus': 0 0 0 1px rgba(255, 255, 255, 0.60) inset;
+  /* Color representing response status code 100 (blue.20). */
+  'kui-status-color-100': #bee2ff;
+  /* Color representing response status code 101 (blue.30). */
+  'kui-status-color-101': #8fc1ff;
+  /* Color representing response status code 102 (blue.40). */
+  'kui-status-color-102': #5f9aff;
+  /* Color representing response status code 103 (blue.50). */
+  'kui-status-color-103': #306fff;
+  /* Color representing response status code 200 (green.20). */
+  'kui-status-color-200': #b5ffee;
+  /* Color representing response status code 201 (green.30). */
+  'kui-status-color-201': #00fabe;
+  /* Color representing response status code 202 (green.40). */
+  'kui-status-color-202': #00d6a4;
+  /* Color representing response status code 203 (green.50). */
+  'kui-status-color-203': #00a17b;
+  /* Color representing response status code 204 (green.60). */
+  'kui-status-color-204': #007d60;
+  /* Color representing response status code 205 (green.70). */
+  'kui-status-color-205': #005944;
+  /* Color representing response status code 206 (green.20). */
+  'kui-status-color-206': #b5ffee;
+  /* Color representing response status code 207 (green.30). */
+  'kui-status-color-207': #00fabe;
+  /* Color representing response status code 208 (green.40). */
+  'kui-status-color-208': #b5ffee;
+  /* Color representing response status code 226 (green.50). */
+  'kui-status-color-226': #00a17b;
+  /* Color representing response status code 100 (yellow.20). */
+  'kui-status-color-300': #fff296;
+  /* Color representing response status code 101 (yellow.30). */
+  'kui-status-color-301': #ffe04b;
+  /* Color representing response status code 102 (yellow.40). */
+  'kui-status-color-302': #ffc400;
+  /* Color representing response status code 103 (yellow.50). */
+  'kui-status-color-303': #b37600;
+  /* Color representing response status code 103 (yellow.60). */
+  'kui-status-color-304': #995c00;
+  /* Color representing response status code 103 (yellow.70). */
+  'kui-status-color-305': #804400;
+  /* Color representing response status code 103 (yellow.20). */
+  'kui-status-color-307': #fff296;
+  /* Color representing response status code 103 (yellow.30). */
+  'kui-status-color-308': #ffe04b;
+  /* Color representing response status code 400 (orange.20). */
+  'kui-status-color-400': #FFC2B3;
+  /* Color representing response status code 401 (orange.30). */
+  'kui-status-color-401': #FF9877;
+  /* Color representing response status code 402 (orange.40). */
+  'kui-status-color-402': #FF723C;
+  /* Color representing response status code 403 (orange.50). */
+  'kui-status-color-403': #F75008;
+  /* Color representing response status code 404 (orange.60). */
+  'kui-status-color-404': #D13500;
+  /* Color representing response status code 405 (orange.70). */
+  'kui-status-color-405': #A31F00;
+  /* Color representing response status code 406 (orange.20). */
+  'kui-status-color-406': #FFC2B3;
+  /* Color representing response status code 407 (orange.30). */
+  'kui-status-color-407': #FF9877;
+  /* Color representing response status code 408 (orange.40). */
+  'kui-status-color-408': #FF723C;
+  /* Color representing response status code 409 (orange.50). */
+  'kui-status-color-409': #F75008;
+  /* Color representing response status code 410 (orange.60). */
+  'kui-status-color-410': #D13500;
+  /* Color representing response status code 411 (orange.70). */
+  'kui-status-color-411': #A31F00;
+  /* Color representing response status code 412 (orange.20). */
+  'kui-status-color-412': #FFC2B3;
+  /* Color representing response status code 413 (orange.30). */
+  'kui-status-color-413': #FF9877;
+  /* Color representing response status code 414 (orange.40). */
+  'kui-status-color-414': #FF723C;
+  /* Color representing response status code 415 (orange.50). */
+  'kui-status-color-415': #F75008;
+  /* Color representing response status code 416 (orange.60). */
+  'kui-status-color-416': #D13500;
+  /* Color representing response status code 417 (orange.70). */
+  'kui-status-color-417': #A31F00;
+  /* Color representing response status code 418 (orange.20). */
+  'kui-status-color-418': #FFC2B3;
+  /* Color representing response status code 421 (orange.30). */
+  'kui-status-color-421': #FF9877;
+  /* Color representing response status code 422 (orange.40). */
+  'kui-status-color-422': #FF723C;
+  /* Color representing response status code 423 (orange.50). */
+  'kui-status-color-423': #F75008;
+  /* Color representing response status code 424 (orange.60). */
+  'kui-status-color-424': #D13500;
+  /* Color representing response status code 425 (orange.70). */
+  'kui-status-color-425': #A31F00;
+  /* Color representing response status code 426 (orange.20). */
+  'kui-status-color-426': #FFC2B3;
+  /* Color representing response status code 428 (orange.30). */
+  'kui-status-color-428': #FF9877;
+  /* Color representing response status code 429 (orange.40). */
+  'kui-status-color-429': #FF723C;
+  /* Color representing response status code 431 (orange.50). */
+  'kui-status-color-431': #F75008;
+  /* Color representing response status code 451 (orange.60). */
+  'kui-status-color-451': #D13500;
+  /* Color representing response status code 500 (red.20). */
+  'kui-status-color-500': #ffabab;
+  /* Color representing response status code 501 (red.30). */
+  'kui-status-color-501': #ff7272;
+  /* Color representing response status code 502 (red.40). */
+  'kui-status-color-502': #ff3954;
+  /* Color representing response status code 503 (red.50). */
+  'kui-status-color-503': #f50045;
+  /* Color representing response status code 504 (red.60). */
+  'kui-status-color-504': #d60027;
+  /* Color representing response status code 505 (red.70). */
+  'kui-status-color-505': #ad000e;
+  /* Color representing response status code 506 (red.20). */
+  'kui-status-color-506': #ffabab;
+  /* Color representing response status code 507 (red.30). */
+  'kui-status-color-507': #ff7272;
+  /* Color representing response status code 508 (red.40). */
+  'kui-status-color-508': #ff3954;
+  /* Color representing response status code 510 (red.50). */
+  'kui-status-color-510': #f50045;
+  /* Color representing response status code 511 (red.60). */
+  'kui-status-color-511': #d60027;
+  /* Color for unknown response status codes in the 100-199 range (blue.10). */
+  'kui-status-color-1na': #eefaff;
+  /* Color for unknown response status codes in the 200-299 range (green.10). */
+  'kui-status-color-2na': #ecfffb;
+  /* Color for unknown response status codes in the 300-399 range (yellow.10). */
+  'kui-status-color-3na': #fffce0;
+  /* Color for unknown response status codes in the 400-499 range (orange.10). */
+  'kui-status-color-4na': #FFF1EF;
+  /* Color for unknown response status codes in the 500-599 range (red.10). */
+  'kui-status-color-5na': #ffe5e5;
+  /* Color for a group of response status codes in the 100-199 range (blue.40). */
+  'kui-status-color-100s': #5f9aff;
+  /* Color for a group of response status codes in the 200-299 range (green.40). */
+  'kui-status-color-200s': #00d6a4;
+  /* Color for a group of response status codes in the 300-399 range (yellow.40). */
+  'kui-status-color-300s': #ffc400;
+  /* Color for a group of response status codes in the 400-499 range (orange.40). */
+  'kui-status-color-400s': #FF723C;
+  /* Color for a group of response status codes in the 500-599 range (red.40). */
+  'kui-status-color-500s': #ff3954;
+  /* Background color for http status 100 elements (blue.10). */
+  'kui-status-color-background-100': #eefaff;
+  /* Background color for http status 200 elements (green.10). */
+  'kui-status-color-background-200': #ecfffb;
+  /* Background color for http status 300 elements (yellow.10). */
+  'kui-status-color-background-300': #fffce0;
+  /* Background color for http status 400 elements (orange.10). */
+  'kui-status-color-background-400': #FFF1EF;
+  /* Background color for http status 500 elements (red.10). */
+  'kui-status-color-background-500': #ffe5e5;
+  /* Text color for http status 100 elements (blue.60). */
+  'kui-status-color-text-100': #0044f4;
+  /* Text color for http status 200 elements (green.60). */
+  'kui-status-color-text-200': #007d60;
+  /* Text color for http status 300 elements (yellow.60). */
+  'kui-status-color-text-300': #995c00;
+  /* Text color for http status 400 elements (orange.60). */
+  'kui-status-color-text-400': #D13500;
+  /* Text color for http status 500 elements (red.60). */
+  'kui-status-color-text-500': #d60027;
+  /* The standard monospace text font family. Typically used for code blocks, inline code, and copyable text. */
+  'kui-font-family-code': 'JetBrains Mono', Consolas, monospace;
+  /* The standard heading text font family. */
+  'kui-font-family-heading': 'Inter', Roboto, Helvetica, sans-serif;
+  /* The standard text font family. */
+  'kui-font-family-text': 'Inter', Roboto, Helvetica, sans-serif;
+  'kui-font-size-10': 10px;
+  'kui-font-size-20': 12px;
+  'kui-font-size-30': 14px;
+  'kui-font-size-40': 16px;
+  'kui-font-size-50': 18px;
+  'kui-font-size-60': 20px;
+  'kui-font-size-70': 24px;
+  'kui-font-size-80': 32px;
+  'kui-font-size-90': 40px;
+  'kui-font-size-100': 48px;
+  /* 700: The bold font weight. */
+  'kui-font-weight-bold': 700;
+  /* 500: The medium font weight. */
+  'kui-font-weight-medium': 500;
+  /* 400: The normal font weight. */
+  'kui-font-weight-regular': 400;
+  /* 600: The semibold font weight. */
+  'kui-font-weight-semibold': 600;
+  /* Alias for letter-spacing-normal */
+  'kui-letter-spacing-0': normal;
+  /* -0.12px */
+  'kui-letter-spacing-minus-10': -0.12px;
+  /* -0.24px */
+  'kui-letter-spacing-minus-20': -0.24px;
+  /* -0.32px */
+  'kui-letter-spacing-minus-30': -0.32px;
+  /* -0.4px */
+  'kui-letter-spacing-minus-40': -0.4px;
+  /* -0.48px */
+  'kui-letter-spacing-minus-50': -0.48px;
+  /* normal */
+  'kui-letter-spacing-normal': normal;
+  /* 12px */
+  'kui-line-height-10': 12px;
+  /* 16px */
+  'kui-line-height-20': 16px;
+  /* 20px */
+  'kui-line-height-30': 20px;
+  /* 24px */
+  'kui-line-height-40': 24px;
+  /* 28px */
+  'kui-line-height-50': 28px;
+  /* 32px */
+  'kui-line-height-60': 32px;
+  /* 36px */
+  'kui-line-height-70': 36px;
+  /* 40px */
+  'kui-line-height-80': 40px;
+  /* 48px */
+  'kui-line-height-90': 48px;
+  /* 56px */
+  'kui-line-height-100': 56px;
+  /* 0px 4px 20px 0px rgba(0, 0, 0, 0.08) */
+  'kui-shadow': 0px 4px 20px 0px rgba(0, 0, 0, 0.08);
+  /* 0px 0px 0px 1px gray.20 inset */
+  'kui-shadow-border': 0px 0px 0px 1px #e0e4ea inset;
+  /* 0px 0px 0px 1px red.60 inset */
+  'kui-shadow-border-danger': 0px 0px 0px 1px #d60027 inset;
+  /* 0px 0px 0px 1px red.70 inset */
+  'kui-shadow-border-danger-strong': 0px 0px 0px 1px #ad000e inset;
+  /* 0px 0px 0px 1px gray.20 inset */
+  'kui-shadow-border-disabled': 0px 0px 0px 1px #e0e4ea inset;
+  /* 0px 0px 0px 1px blue.60 inset */
+  'kui-shadow-border-primary': 0px 0px 0px 1px #0044f4 inset;
+  /* 0px 0px 0px 1px blue.90 inset */
+  'kui-shadow-border-primary-strongest': 0px 0px 0px 1px #001466 inset;
+  /* 0px 0px 0px 1px blue.40 inset */
+  'kui-shadow-border-primary-weak': 0px 0px 0px 1px #5f9aff inset;
+  /* 0px 0px 0px 4px rgba(0, 68, 244, 0.2) */
+  'kui-shadow-focus': 0px 0px 0px 4px rgba(0, 68, 244, 0.2);
+  /* 0px value for gaps, margin, or padding. */
+  'kui-space-0': 0px;
+  /* 2px value for gaps, margin, or padding. */
+  'kui-space-10': 2px;
+  /* 4px value for gaps, margin, or padding. */
+  'kui-space-20': 4px;
+  /* 6px value for gaps, margin, or padding. */
+  'kui-space-30': 6px;
+  /* 8px value for gaps, margin, or padding. */
+  'kui-space-40': 8px;
+  /* 12px value for gaps, margin, or padding. */
+  'kui-space-50': 12px;
+  /* 16px value for gaps, margin, or padding. */
+  'kui-space-60': 16px;
+  /* 20px value for gaps, margin, or padding. */
+  'kui-space-70': 20px;
+  /* 24px value for gaps, margin, or padding. */
+  'kui-space-80': 24px;
+  /* 32px value for gaps, margin, or padding. */
+  'kui-space-90': 32px;
+  /* 40px value for gaps, margin, or padding. */
+  'kui-space-100': 40px;
+  /* 48px value for gaps, margin, or padding. */
+  'kui-space-110': 48px;
+  /* 56px value for gaps, margin, or padding. */
+  'kui-space-120': 56px;
+  /* 64px value for gaps, margin, or padding. */
+  'kui-space-130': 64px;
+  /* 80px value for gaps, margin, or padding. */
+  'kui-space-140': 80px;
+  /* 96px value for gaps, margin, or padding. */
+  'kui-space-150': 96px;
+  /* auto */
+  'kui-space-auto': auto;
 );
 ```
 
@@ -718,343 +1372,670 @@ $tokens-map: (
 <summary>Click to view the list of LESS variables</summary>
 
 ```less
-@kui-color-background: ;
-@kui-color-background-danger: ;
-@kui-color-background-danger-strong: ;
-@kui-color-background-danger-stronger: ;
-@kui-color-background-danger-strongest: ;
-@kui-color-background-danger-weak: ;
-@kui-color-background-danger-weaker: ;
-@kui-color-background-danger-weakest: ;
-@kui-color-background-decorative-aqua-weakest: ;
-@kui-color-background-decorative-purple: ;
-@kui-color-background-decorative-purple-weakest: ;
-@kui-color-background-disabled: ;
-@kui-color-background-info: ;
-@kui-color-background-info-strong: ;
-@kui-color-background-info-stronger: ;
-@kui-color-background-info-strongest: ;
-@kui-color-background-info-weak: ;
-@kui-color-background-info-weaker: ;
-@kui-color-background-info-weakest: ;
-@kui-color-background-inverse: ;
-@kui-color-background-neutral: ;
-@kui-color-background-neutral-strong: ;
-@kui-color-background-neutral-stronger: ;
-@kui-color-background-neutral-strongest: ;
-@kui-color-background-neutral-weak: ;
-@kui-color-background-neutral-weaker: ;
-@kui-color-background-neutral-weakest: ;
-@kui-color-background-overlay: ;
-@kui-color-background-primary: ;
-@kui-color-background-primary-strong: ;
-@kui-color-background-primary-stronger: ;
-@kui-color-background-primary-strongest: ;
-@kui-color-background-primary-weak: ;
-@kui-color-background-primary-weaker: ;
-@kui-color-background-primary-weakest: ;
-@kui-color-background-success: ;
-@kui-color-background-success-strong: ;
-@kui-color-background-success-stronger: ;
-@kui-color-background-success-strongest: ;
-@kui-color-background-success-weak: ;
-@kui-color-background-success-weaker: ;
-@kui-color-background-success-weakest: ;
-@kui-color-background-transparent: ;
-@kui-color-background-warning: ;
-@kui-color-background-warning-strong: ;
-@kui-color-background-warning-stronger: ;
-@kui-color-background-warning-strongest: ;
-@kui-color-background-warning-weak: ;
-@kui-color-background-warning-weaker: ;
-@kui-color-background-warning-weakest: ;
-@kui-color-border: ;
-@kui-color-border-danger: ;
-@kui-color-border-danger-strong: ;
-@kui-color-border-danger-stronger: ;
-@kui-color-border-danger-strongest: ;
-@kui-color-border-danger-weak: ;
-@kui-color-border-danger-weaker: ;
-@kui-color-border-danger-weakest: ;
-@kui-color-border-decorative-purple: ;
-@kui-color-border-disabled: ;
-@kui-color-border-inverse: ;
-@kui-color-border-neutral: ;
-@kui-color-border-neutral-strong: ;
-@kui-color-border-neutral-stronger: ;
-@kui-color-border-neutral-strongest: ;
-@kui-color-border-neutral-weak: ;
-@kui-color-border-neutral-weaker: ;
-@kui-color-border-neutral-weakest: ;
-@kui-color-border-primary: ;
-@kui-color-border-primary-strong: ;
-@kui-color-border-primary-stronger: ;
-@kui-color-border-primary-strongest: ;
-@kui-color-border-primary-weak: ;
-@kui-color-border-primary-weaker: ;
-@kui-color-border-primary-weakest: ;
-@kui-color-border-transparent: ;
-@kui-color-text: ;
-@kui-color-text-danger: ;
-@kui-color-text-danger-strong: ;
-@kui-color-text-danger-stronger: ;
-@kui-color-text-danger-strongest: ;
-@kui-color-text-danger-weak: ;
-@kui-color-text-danger-weaker: ;
-@kui-color-text-danger-weakest: ;
-@kui-color-text-decorative-aqua: ;
-@kui-color-text-decorative-pink: ;
-@kui-color-text-decorative-purple: ;
-@kui-color-text-decorative-purple-strong: ;
-@kui-color-text-disabled: ;
-@kui-color-text-info: ;
-@kui-color-text-info-strong: ;
-@kui-color-text-info-stronger: ;
-@kui-color-text-info-strongest: ;
-@kui-color-text-info-weak: ;
-@kui-color-text-info-weaker: ;
-@kui-color-text-info-weakest: ;
-@kui-color-text-inverse: ;
-@kui-color-text-neutral: ;
-@kui-color-text-neutral-strong: ;
-@kui-color-text-neutral-stronger: ;
-@kui-color-text-neutral-strongest: ;
-@kui-color-text-neutral-weak: ;
-@kui-color-text-neutral-weaker: ;
-@kui-color-text-neutral-weakest: ;
-@kui-color-text-primary: ;
-@kui-color-text-primary-strong: ;
-@kui-color-text-primary-stronger: ;
-@kui-color-text-primary-strongest: ;
-@kui-color-text-primary-weak: ;
-@kui-color-text-primary-weaker: ;
-@kui-color-text-primary-weakest: ;
-@kui-color-text-success: ;
-@kui-color-text-success-strong: ;
-@kui-color-text-success-stronger: ;
-@kui-color-text-success-strongest: ;
-@kui-color-text-success-weak: ;
-@kui-color-text-success-weaker: ;
-@kui-color-text-success-weakest: ;
-@kui-color-text-warning: ;
-@kui-color-text-warning-strong: ;
-@kui-color-text-warning-stronger: ;
-@kui-color-text-warning-strongest: ;
-@kui-color-text-warning-weak: ;
-@kui-color-text-warning-weaker: ;
-@kui-color-text-warning-weakest: ;
-@kui-animation-duration-20: ;
-@kui-border-radius-0: ;
-@kui-border-radius-10: ;
-@kui-border-radius-20: ;
-@kui-border-radius-30: ;
-@kui-border-radius-40: ;
-@kui-border-radius-50: ;
-@kui-border-radius-circle: ;
-@kui-border-radius-round: ;
-@kui-border-width-0: ;
-@kui-border-width-10: ;
-@kui-border-width-20: ;
-@kui-border-width-30: ;
-@kui-breakpoint-mobile: ;
-@kui-breakpoint-phablet: ;
-@kui-breakpoint-tablet: ;
-@kui-breakpoint-laptop: ;
-@kui-breakpoint-desktop: ;
-@kui-icon-color-danger: ;
-@kui-icon-color-neutral: ;
-@kui-icon-color-primary: ;
-@kui-icon-color-success: ;
-@kui-icon-color-warning: ;
-@kui-icon-size-10: ;
-@kui-icon-size-20: ;
-@kui-icon-size-30: ;
-@kui-icon-size-40: ;
-@kui-icon-size-50: ;
-@kui-icon-size-60: ;
-@kui-icon-size-70: ;
-@kui-icon-size-80: ;
-@kui-method-color-background-connect: ;
-@kui-method-color-background-delete: ;
-@kui-method-color-background-get: ;
-@kui-method-color-background-head: ;
-@kui-method-color-background-options: ;
-@kui-method-color-background-patch: ;
-@kui-method-color-background-post: ;
-@kui-method-color-background-put: ;
-@kui-method-color-background-trace: ;
-@kui-method-color-text-connect: ;
-@kui-method-color-text-connect-strong: ;
-@kui-method-color-text-delete: ;
-@kui-method-color-text-delete-strong: ;
-@kui-method-color-text-get: ;
-@kui-method-color-text-get-strong: ;
-@kui-method-color-text-head: ;
-@kui-method-color-text-head-strong: ;
-@kui-method-color-text-options: ;
-@kui-method-color-text-options-strong: ;
-@kui-method-color-text-patch: ;
-@kui-method-color-text-patch-strong: ;
-@kui-method-color-text-post: ;
-@kui-method-color-text-post-strong: ;
-@kui-method-color-text-put: ;
-@kui-method-color-text-put-strong: ;
-@kui-method-color-text-trace: ;
-@kui-method-color-text-trace-strong: ;
-@kui-navigation-color-background: ;
-@kui-navigation-color-background-selected: ;
-@kui-navigation-color-border: ;
-@kui-navigation-color-border-child: ;
-@kui-navigation-color-border-divider: ;
-@kui-navigation-color-text: ;
-@kui-navigation-color-text-focus: ;
-@kui-navigation-color-text-hover: ;
-@kui-navigation-color-text-selected: ;
-@kui-navigation-shadow-border: ;
-@kui-navigation-shadow-border-child: ;
-@kui-navigation-shadow-focus: ;
-@kui-status-color-100: ;
-@kui-status-color-101: ;
-@kui-status-color-102: ;
-@kui-status-color-103: ;
-@kui-status-color-200: ;
-@kui-status-color-201: ;
-@kui-status-color-202: ;
-@kui-status-color-203: ;
-@kui-status-color-204: ;
-@kui-status-color-205: ;
-@kui-status-color-206: ;
-@kui-status-color-207: ;
-@kui-status-color-208: ;
-@kui-status-color-226: ;
-@kui-status-color-300: ;
-@kui-status-color-301: ;
-@kui-status-color-302: ;
-@kui-status-color-303: ;
-@kui-status-color-304: ;
-@kui-status-color-305: ;
-@kui-status-color-307: ;
-@kui-status-color-308: ;
-@kui-status-color-400: ;
-@kui-status-color-401: ;
-@kui-status-color-402: ;
-@kui-status-color-403: ;
-@kui-status-color-404: ;
-@kui-status-color-405: ;
-@kui-status-color-406: ;
-@kui-status-color-407: ;
-@kui-status-color-408: ;
-@kui-status-color-409: ;
-@kui-status-color-410: ;
-@kui-status-color-411: ;
-@kui-status-color-412: ;
-@kui-status-color-413: ;
-@kui-status-color-414: ;
-@kui-status-color-415: ;
-@kui-status-color-416: ;
-@kui-status-color-417: ;
-@kui-status-color-418: ;
-@kui-status-color-421: ;
-@kui-status-color-422: ;
-@kui-status-color-423: ;
-@kui-status-color-424: ;
-@kui-status-color-425: ;
-@kui-status-color-426: ;
-@kui-status-color-428: ;
-@kui-status-color-429: ;
-@kui-status-color-431: ;
-@kui-status-color-451: ;
-@kui-status-color-500: ;
-@kui-status-color-501: ;
-@kui-status-color-502: ;
-@kui-status-color-503: ;
-@kui-status-color-504: ;
-@kui-status-color-505: ;
-@kui-status-color-506: ;
-@kui-status-color-507: ;
-@kui-status-color-508: ;
-@kui-status-color-510: ;
-@kui-status-color-511: ;
-@kui-status-color-1na: ;
-@kui-status-color-2na: ;
-@kui-status-color-3na: ;
-@kui-status-color-4na: ;
-@kui-status-color-5na: ;
-@kui-status-color-100s: ;
-@kui-status-color-200s: ;
-@kui-status-color-300s: ;
-@kui-status-color-400s: ;
-@kui-status-color-500s: ;
-@kui-status-color-background-100: ;
-@kui-status-color-background-200: ;
-@kui-status-color-background-300: ;
-@kui-status-color-background-400: ;
-@kui-status-color-background-500: ;
-@kui-status-color-text-100: ;
-@kui-status-color-text-200: ;
-@kui-status-color-text-300: ;
-@kui-status-color-text-400: ;
-@kui-status-color-text-500: ;
-@kui-font-family-code: ;
-@kui-font-family-heading: ;
-@kui-font-family-text: ;
-@kui-font-size-10: ;
-@kui-font-size-20: ;
-@kui-font-size-30: ;
-@kui-font-size-40: ;
-@kui-font-size-50: ;
-@kui-font-size-60: ;
-@kui-font-size-70: ;
-@kui-font-size-80: ;
-@kui-font-size-90: ;
-@kui-font-size-100: ;
-@kui-font-weight-bold: ;
-@kui-font-weight-medium: ;
-@kui-font-weight-regular: ;
-@kui-font-weight-semibold: ;
-@kui-letter-spacing-0: ;
-@kui-letter-spacing-minus-10: ;
-@kui-letter-spacing-minus-20: ;
-@kui-letter-spacing-minus-30: ;
-@kui-letter-spacing-minus-40: ;
-@kui-letter-spacing-minus-50: ;
-@kui-letter-spacing-normal: ;
-@kui-line-height-10: ;
-@kui-line-height-20: ;
-@kui-line-height-30: ;
-@kui-line-height-40: ;
-@kui-line-height-50: ;
-@kui-line-height-60: ;
-@kui-line-height-70: ;
-@kui-line-height-80: ;
-@kui-line-height-90: ;
-@kui-line-height-100: ;
-@kui-shadow: ;
-@kui-shadow-border: ;
-@kui-shadow-border-danger: ;
-@kui-shadow-border-danger-strong: ;
-@kui-shadow-border-disabled: ;
-@kui-shadow-border-primary: ;
-@kui-shadow-border-primary-strongest: ;
-@kui-shadow-border-primary-weak: ;
-@kui-shadow-focus: ;
-@kui-space-0: ;
-@kui-space-10: ;
-@kui-space-20: ;
-@kui-space-30: ;
-@kui-space-40: ;
-@kui-space-50: ;
-@kui-space-60: ;
-@kui-space-70: ;
-@kui-space-80: ;
-@kui-space-90: ;
-@kui-space-100: ;
-@kui-space-110: ;
-@kui-space-120: ;
-@kui-space-130: ;
-@kui-space-140: ;
-@kui-space-150: ;
-@kui-space-auto: ;
+/* Default background color for containers (white). */
+@kui-color-background: #ffffff;
+/* Background color for danger actions or messages (red.60). */
+@kui-color-background-danger: #d60027;
+/* Strong background color for danger actions or messages (red.70). */
+@kui-color-background-danger-strong: #ad000e;
+/* Stronger background color for danger actions or messages (red.80). */
+@kui-color-background-danger-stronger: #850000;
+/* Strongest background color for danger actions or messages (red.90). */
+@kui-color-background-danger-strongest: #5c0000;
+/* Weak background color for danger actions or messages (red.40). */
+@kui-color-background-danger-weak: #ff3954;
+/* Weaker background color for danger actions or messages (red.20). */
+@kui-color-background-danger-weaker: #ffabab;
+/* Weakest background color for danger actions or messages (red.10). */
+@kui-color-background-danger-weakest: #ffe5e5;
+/* Weakest background color for decorative purposes (aqua.10). */
+@kui-color-background-decorative-aqua-weakest: #ecfcff;
+/* Background color for decorative purposes (purple.60). */
+@kui-color-background-decorative-purple: #6f28ff;
+/* Weakest background color for decorative purposes (purple.10). */
+@kui-color-background-decorative-purple-weakest: #f1f0ff;
+/* Background color for disabled elements (gray.20). */
+@kui-color-background-disabled: #e0e4ea;
+/* Background color for info elements (blue.60). */
+@kui-color-background-info: #0044f4;
+/* Strong background color for info elements (blue.70). */
+@kui-color-background-info-strong: #0030cc;
+/* Stronger background color for info elements (blue.80). */
+@kui-color-background-info-stronger: #002099;
+/* Strongest background color for info elements (blue.90). */
+@kui-color-background-info-strongest: #001466;
+/* Weak background color for info elements (blue.40). */
+@kui-color-background-info-weak: #5f9aff;
+/* Weaker background color for info elements (blue.20). */
+@kui-color-background-info-weaker: #bee2ff;
+/* Weakest background color for info elements (blue.10). */
+@kui-color-background-info-weakest: #eefaff;
+/* Inverse background color for containers (blue.100) */
+@kui-color-background-inverse: #000933;
+/* Background color for neutral elements (gray.60). */
+@kui-color-background-neutral: #6c7489;
+/* Strong background color for neutral elements (gray.70). */
+@kui-color-background-neutral-strong: #52596e;
+/* Stronger background color for neutral elements (gray.80). */
+@kui-color-background-neutral-stronger: #3a3f51;
+/* Strongest background color for neutral elements (gray.90). */
+@kui-color-background-neutral-strongest: #232633;
+/* Weak background color for neutral elements (gray.40). */
+@kui-color-background-neutral-weak: #afb7c5;
+/* Weaker background color for neutral elements (gray.20). */
+@kui-color-background-neutral-weaker: #e0e4ea;
+/* Weakest background color for neutral elements (gray.10). */
+@kui-color-background-neutral-weakest: #f9fafb;
+/* Overlay background color (rgba(0, 9, 51, 0.6)) */
+@kui-color-background-overlay: rgba(0, 9, 51, 0.6);
+/* Background color for primary actions or messages (blue.60). */
+@kui-color-background-primary: #0044f4;
+/* Strong background color for primary actions or messages (blue.70). */
+@kui-color-background-primary-strong: #0030cc;
+/* Stronger background color for primary actions or messages (blue.80). */
+@kui-color-background-primary-stronger: #002099;
+/* Strongest background color for primary actions or messages (blue.90). */
+@kui-color-background-primary-strongest: #001466;
+/* Weak background color for primary actions or messages (blue.40). */
+@kui-color-background-primary-weak: #5f9aff;
+/* Weaker background color for primary actions or messages (blue.20). */
+@kui-color-background-primary-weaker: #bee2ff;
+/* Weakest background color for primary actions or messages (blue.10) */
+@kui-color-background-primary-weakest: #eefaff;
+/* Background color for success elements (green.60). */
+@kui-color-background-success: #007d60;
+/* Strong background color for success elements (green.70). */
+@kui-color-background-success-strong: #005944;
+/* Stronger background color for success elements (green.80). */
+@kui-color-background-success-stronger: #004737;
+/* Strongest background color for success elements (green.90). */
+@kui-color-background-success-strongest: #003629;
+/* Weak background color for success elements (green.40). */
+@kui-color-background-success-weak: #00d6a4;
+/* Weaker background color for success elements (green.20). */
+@kui-color-background-success-weaker: #b5ffee;
+/* Weakest background color for success elements (green.10). */
+@kui-color-background-success-weakest: #ecfffb;
+/* Transparent background color (transparent). */
+@kui-color-background-transparent: transparent;
+/* Background color for warning elements (yellow.60). */
+@kui-color-background-warning: #995c00;
+/* Strong background color for warning elements (yellow.70). */
+@kui-color-background-warning-strong: #804400;
+/* Stronger background color for warning elements (yellow.80). */
+@kui-color-background-warning-stronger: #662d00;
+/* Strongest background color for warning elements (yellow.90). */
+@kui-color-background-warning-strongest: #4d1b00;
+/* Weak background color for warning elements (yellow.40). */
+@kui-color-background-warning-weak: #ffc400;
+/* Weaker background color for warning elements (yellow.20). */
+@kui-color-background-warning-weaker: #fff296;
+/* Weakest background color for warning elements (yellow.10). */
+@kui-color-background-warning-weakest: #fffce0;
+/* Default border color for containers (gray.20). */
+@kui-color-border: #e0e4ea;
+/* Border color for danger actions or messages (red.60). */
+@kui-color-border-danger: #d60027;
+/* Strong border color for danger actions or messages (red.70). */
+@kui-color-border-danger-strong: #ad000e;
+/* Stronger border color for danger actions or messages (red.80). */
+@kui-color-border-danger-stronger: #850000;
+/* Strongest border color for danger actions or messages (red.90). */
+@kui-color-border-danger-strongest: #5c0000;
+/* Weak border color for danger actions or messages (red.40). */
+@kui-color-border-danger-weak: #ff3954;
+/* Weaker border color for danger actions or messages (red.20). */
+@kui-color-border-danger-weaker: #ffabab;
+/* Weakest border color for danger actions or messages (red.10). */
+@kui-color-border-danger-weakest: #ffe5e5;
+/* Border color for decorative purposes (purple.60). */
+@kui-color-border-decorative-purple: #6f28ff;
+/* Border color for disabled elements (gray.20). */
+@kui-color-border-disabled: #e0e4ea;
+/* Inverse border color (rgba(255, 255, 255, 0.2)). */
+@kui-color-border-inverse: rgba(255, 255, 255, 0.2);
+/* Border color for neutral elements (gray.60) */
+@kui-color-border-neutral: #6c7489;
+/* Strong border color for neutral elements (gray.70) */
+@kui-color-border-neutral-strong: #52596e;
+/* Stronger border color for neutral elements (gray.80) */
+@kui-color-border-neutral-stronger: #3a3f51;
+/* Strongest border color for neutral elements (gray.90) */
+@kui-color-border-neutral-strongest: #232633;
+/* Weak border color for neutral elements (gray.40) */
+@kui-color-border-neutral-weak: #afb7c5;
+/* Weaker border color for neutral elements (gray.20) */
+@kui-color-border-neutral-weaker: #e0e4ea;
+/* Weakest border color for neutral elements (gray.10) */
+@kui-color-border-neutral-weakest: #f9fafb;
+/* Border color for primary actions or messages (blue.60). */
+@kui-color-border-primary: #0044f4;
+/* Strong border color for primary actions or messages (blue.70). */
+@kui-color-border-primary-strong: #0030cc;
+/* Stronger border color for primary actions or messages (blue.80). */
+@kui-color-border-primary-stronger: #002099;
+/* Strongest border color for primary actions or messages (blue.90). */
+@kui-color-border-primary-strongest: #001466;
+/* Weak border color for primary actions or messages (blue.40). */
+@kui-color-border-primary-weak: #5f9aff;
+/* Weaker border color for primary actions or messages (blue.20). */
+@kui-color-border-primary-weaker: #bee2ff;
+/* Weakest border color for primary actions or messages (blue.10). */
+@kui-color-border-primary-weakest: #eefaff;
+/* Transparent border color (transparent). */
+@kui-color-border-transparent: transparent;
+/* Default text color (blue.100). */
+@kui-color-text: #000933;
+/* Text color for danger actions or messages (red.60). */
+@kui-color-text-danger: #d60027;
+/* Strong text color for danger actions or messages (red.70). */
+@kui-color-text-danger-strong: #ad000e;
+/* Stronger text color for danger actions or messages (red.80). */
+@kui-color-text-danger-stronger: #850000;
+/* Strongest text color for danger actions or messages (red.90). */
+@kui-color-text-danger-strongest: #5c0000;
+/* Weak text color for danger actions or messages (red.40). */
+@kui-color-text-danger-weak: #ff3954;
+/* Weaker text color for danger actions or messages (red.20). */
+@kui-color-text-danger-weaker: #ffabab;
+/* Weakest text color for danger actions or messages (red.10). */
+@kui-color-text-danger-weakest: #ffe5e5;
+/* Text color for decorative purposes (aqua.50). */
+@kui-color-text-decorative-aqua: #00abd2;
+/* Text color for decorative purposes (pink.60). */
+@kui-color-text-decorative-pink: #d60067;
+/* Text color for decorative purposes (purple.60). */
+@kui-color-text-decorative-purple: #6f28ff;
+/* Strong text color for decorative purposes (purple.70). */
+@kui-color-text-decorative-purple-strong: #5e00f5;
+/* Text color for disabled elements (gray.40). */
+@kui-color-text-disabled: #afb7c5;
+/* Text color for info elements (blue.60). */
+@kui-color-text-info: #0044f4;
+/* Strong text color for info elements (blue.70). */
+@kui-color-text-info-strong: #0030cc;
+/* Stronger text color for info elements (blue.80). */
+@kui-color-text-info-stronger: #002099;
+/* Strongest text color for info elements (blue.90). */
+@kui-color-text-info-strongest: #001466;
+/* Weak text color for info elements (blue.40). */
+@kui-color-text-info-weak: #5f9aff;
+/* Weaker text color for info elements (blue.20). */
+@kui-color-text-info-weaker: #bee2ff;
+/* Weakest text color for info elements (blue.10). */
+@kui-color-text-info-weakest: #eefaff;
+/* Inverse text color (white). */
+@kui-color-text-inverse: #ffffff;
+/* Text color for neutral elements (gray.60). */
+@kui-color-text-neutral: #6c7489;
+/* Strong text color for neutral elements (gray.70). */
+@kui-color-text-neutral-strong: #52596e;
+/* Stronger text color for neutral elements (gray.80). */
+@kui-color-text-neutral-stronger: #3a3f51;
+/* Strongest text color for neutral elements (gray.90). */
+@kui-color-text-neutral-strongest: #232633;
+/* Weak text color for neutral elements (gray.40). */
+@kui-color-text-neutral-weak: #afb7c5;
+/* Weaker text color for neutral elements (gray.20). */
+@kui-color-text-neutral-weaker: #e0e4ea;
+/* Weakest text color for neutral elements (gray.10). */
+@kui-color-text-neutral-weakest: #f9fafb;
+/* Text color for primary actions or messages (blue.60). */
+@kui-color-text-primary: #0044f4;
+/* Strong text color for primary actions or messages (blue.70). */
+@kui-color-text-primary-strong: #0030cc;
+/* Stronger text color for primary actions or messages (blue.80). */
+@kui-color-text-primary-stronger: #002099;
+/* Strongest text color for primary actions or messages (blue.90). */
+@kui-color-text-primary-strongest: #001466;
+/* Weak text color for primary actions or messages (blue.40). */
+@kui-color-text-primary-weak: #5f9aff;
+/* Weaker text color for primary actions or messages (blue.20). */
+@kui-color-text-primary-weaker: #bee2ff;
+/* Weakest text color for primary actions or messages (blue.10). */
+@kui-color-text-primary-weakest: #eefaff;
+/* Text color for success elements (green.60). */
+@kui-color-text-success: #007d60;
+/* Strong text color for success elements (green.70). */
+@kui-color-text-success-strong: #005944;
+/* Stronger text color for success elements (green.80). */
+@kui-color-text-success-stronger: #004737;
+/* Stronger text color for success elements (green.90). */
+@kui-color-text-success-strongest: #003629;
+/* Weak text color for success elements (green.40). */
+@kui-color-text-success-weak: #00d6a4;
+/* Weaker text color for success elements (green.20). */
+@kui-color-text-success-weaker: #b5ffee;
+/* Weakest text color for success elements (green.10). */
+@kui-color-text-success-weakest: #ecfffb;
+/* Text color for warning elements (yellow.60). */
+@kui-color-text-warning: #995c00;
+/* Strong text color for warning elements (yellow.70). */
+@kui-color-text-warning-strong: #804400;
+/* Stronger text color for warning elements (yellow.80). */
+@kui-color-text-warning-stronger: #662d00;
+/* Strongest text color for warning elements (yellow.90). */
+@kui-color-text-warning-strongest: #4d1b00;
+/* Weak text color for warning elements (yellow.40). */
+@kui-color-text-warning-weak: #ffc400;
+/* Weaker text color for warning elements (yellow.20). */
+@kui-color-text-warning-weaker: #fff296;
+/* Weakest text color for warning elements (yellow.10). */
+@kui-color-text-warning-weakest: #fffce0;
+/* Default transition timing */
+@kui-animation-duration-20: 0.2s;
+/* 0px border radius. */
+@kui-border-radius-0: 0px;
+/* 2px border radius. */
+@kui-border-radius-10: 2px;
+/* 4px border radius. */
+@kui-border-radius-20: 4px;
+/* 6px border radius. */
+@kui-border-radius-30: 6px;
+/* 8px border radius. */
+@kui-border-radius-40: 8px;
+/* 10px border radius. */
+@kui-border-radius-50: 10px;
+/* 50% border radius used to create circles. */
+@kui-border-radius-circle: 50%;
+/* 100px border radius used to create pill shapes. */
+@kui-border-radius-round: 100px;
+/* 0px border width. */
+@kui-border-width-0: 0px;
+/* 1px border width. */
+@kui-border-width-10: 1px;
+/* 2px border width. */
+@kui-border-width-20: 2px;
+/* 4px border width. */
+@kui-border-width-30: 4px;
+/* Used for larger mobile screens. Any viewport width under this value is considered mobile. */
+@kui-breakpoint-mobile: 640px;
+/* Used for tablet screens. */
+@kui-breakpoint-phablet: 768px;
+/* Used for larger tablet screens. Any viewport width less than this value will likely show a mobile layout. Any viewport width this value and greater will likely show a desktop layout. */
+@kui-breakpoint-tablet: 1024px;
+/* Used for standard desktop screens. */
+@kui-breakpoint-laptop: 1280px;
+/* Used for larger desktop screens. */
+@kui-breakpoint-desktop: 1536px;
+/* Danger color for icons. */
+@kui-icon-color-danger: #f50045;
+/* Neutral color for icons. */
+@kui-icon-color-neutral: #828a9e;
+/* Primary color for icons. */
+@kui-icon-color-primary: #306fff;
+/* Success color for icons. */
+@kui-icon-color-success: #00a17b;
+/* Warning color for icons. */
+@kui-icon-color-warning: #ffc400;
+/* 10px icon size. */
+@kui-icon-size-10: 10px;
+/* 12px icon size. */
+@kui-icon-size-20: 12px;
+/* 16px icon size. */
+@kui-icon-size-30: 16px;
+/* 20px icon size. */
+@kui-icon-size-40: 20px;
+/* 24px icon size (default). */
+@kui-icon-size-50: 24px;
+/* 32px icon size. */
+@kui-icon-size-60: 32px;
+/* 40px icon size. */
+@kui-icon-size-70: 40px;
+/* 48px icon size. */
+@kui-icon-size-80: 48px;
+/* Background color for the CONNECT method (purple.10). */
+@kui-method-color-background-connect: #f1f0ff;
+/* Background color for the DELETE method (red.10). */
+@kui-method-color-background-delete: #ffe5e5;
+/* Background color for the GET method (blue.10). */
+@kui-method-color-background-get: #eefaff;
+/* Background color for the HEAD method (gray.70). */
+@kui-method-color-background-head: #52596e;
+/* Background color for the OPTIONS method (gray.20). */
+@kui-method-color-background-options: #e0e4ea;
+/* Background color for the PATCH method (aqua.10). */
+@kui-method-color-background-patch: #ecfcff;
+/* Background color for the POST method (green.10). */
+@kui-method-color-background-post: #ecfffb;
+/* Background color for the PUT method (yellow.10). */
+@kui-method-color-background-put: #fffce0;
+/* Background color for the TRACE method (pink.10). */
+@kui-method-color-background-trace: #fff0f7;
+/* Text color for the CONNECT method (purple.60). */
+@kui-method-color-text-connect: #6f28ff;
+/* Strong text color for the CONNECT method (purple.70). */
+@kui-method-color-text-connect-strong: #5e00f5;
+/* Text color for the DELETE method (red.60). */
+@kui-method-color-text-delete: #d60027;
+/* Strong text color for the DELETE method (red.70). */
+@kui-method-color-text-delete-strong: #ad000e;
+/* Text color for the GET method (blue.60). */
+@kui-method-color-text-get: #0044f4;
+/* Strong text color for the GET method (blue.70). */
+@kui-method-color-text-get-strong: #0030cc;
+/* Text color for the HEAD method (gray.20). */
+@kui-method-color-text-head: #e0e4ea;
+/* Strong text color for the HEAD method (gray.40). */
+@kui-method-color-text-head-strong: #afb7c5;
+/* Text color for the OPTIONS method (gray.70). */
+@kui-method-color-text-options: #52596e;
+/* Strong text color for the OPTIONS method (gray.80). */
+@kui-method-color-text-options-strong: #3a3f51;
+/* Text color for the PATCH method (aqua.60). */
+@kui-method-color-text-patch: #00819d;
+/* Strong text color for the PATCH method (aqua.70). */
+@kui-method-color-text-patch-strong: #00647a;
+/* Text color for the POST method (green.60). */
+@kui-method-color-text-post: #007d60;
+/* Strong text color for the POST method (green.70). */
+@kui-method-color-text-post-strong: #005944;
+/* Text color for the PUT method (yellow.60). */
+@kui-method-color-text-put: #995c00;
+/* Strong text color for the PUT method (yellow.70). */
+@kui-method-color-text-put-strong: #804400;
+/* Text color for the TRACE method (pink.60). */
+@kui-method-color-text-trace: #d60067;
+/* Strong text color for the TRACE method (pink.70). */
+@kui-method-color-text-trace-strong: #ad0053;
+/* blue.100 */
+@kui-navigation-color-background: #000933;
+/* The background color of a selected navigation item. */
+@kui-navigation-color-background-selected: rgba(255, 255, 255, 0.12);
+/* rgba(255, 255, 255, 0.12) */
+@kui-navigation-color-border: rgba(255, 255, 255, 0.12);
+/* The border color for a selected child navigation item. */
+@kui-navigation-color-border-child: #00fabe;
+/* The color of the navigation section divider. */
+@kui-navigation-color-border-divider: rgba(255, 255, 255, 0.24);
+/* Navigation link and icon color. */
+@kui-navigation-color-text: #bee2ff;
+/* Navigation link and icon focus-visible color. */
+@kui-navigation-color-text-focus: #ffffff;
+/* Navigation link and icon hover color. */
+@kui-navigation-color-text-hover: #eefaff;
+/* Navigation link and icon selected color. */
+@kui-navigation-color-text-selected: #00fabe;
+/* The box-shadow for a focus-visible navigation link. */
+@kui-navigation-shadow-border: 0 0 0 1px rgba(255, 255, 255, 0.12) inset;
+/* The left box-shadow for an active child navigation link. */
+@kui-navigation-shadow-border-child: 4px 0 0 0 #00fabe inset;
+/* Navigation link focus-visible box-shadow. */
+@kui-navigation-shadow-focus: 0 0 0 1px rgba(255, 255, 255, 0.60) inset;
+/* Color representing response status code 100 (blue.20). */
+@kui-status-color-100: #bee2ff;
+/* Color representing response status code 101 (blue.30). */
+@kui-status-color-101: #8fc1ff;
+/* Color representing response status code 102 (blue.40). */
+@kui-status-color-102: #5f9aff;
+/* Color representing response status code 103 (blue.50). */
+@kui-status-color-103: #306fff;
+/* Color representing response status code 200 (green.20). */
+@kui-status-color-200: #b5ffee;
+/* Color representing response status code 201 (green.30). */
+@kui-status-color-201: #00fabe;
+/* Color representing response status code 202 (green.40). */
+@kui-status-color-202: #00d6a4;
+/* Color representing response status code 203 (green.50). */
+@kui-status-color-203: #00a17b;
+/* Color representing response status code 204 (green.60). */
+@kui-status-color-204: #007d60;
+/* Color representing response status code 205 (green.70). */
+@kui-status-color-205: #005944;
+/* Color representing response status code 206 (green.20). */
+@kui-status-color-206: #b5ffee;
+/* Color representing response status code 207 (green.30). */
+@kui-status-color-207: #00fabe;
+/* Color representing response status code 208 (green.40). */
+@kui-status-color-208: #b5ffee;
+/* Color representing response status code 226 (green.50). */
+@kui-status-color-226: #00a17b;
+/* Color representing response status code 100 (yellow.20). */
+@kui-status-color-300: #fff296;
+/* Color representing response status code 101 (yellow.30). */
+@kui-status-color-301: #ffe04b;
+/* Color representing response status code 102 (yellow.40). */
+@kui-status-color-302: #ffc400;
+/* Color representing response status code 103 (yellow.50). */
+@kui-status-color-303: #b37600;
+/* Color representing response status code 103 (yellow.60). */
+@kui-status-color-304: #995c00;
+/* Color representing response status code 103 (yellow.70). */
+@kui-status-color-305: #804400;
+/* Color representing response status code 103 (yellow.20). */
+@kui-status-color-307: #fff296;
+/* Color representing response status code 103 (yellow.30). */
+@kui-status-color-308: #ffe04b;
+/* Color representing response status code 400 (orange.20). */
+@kui-status-color-400: #FFC2B3;
+/* Color representing response status code 401 (orange.30). */
+@kui-status-color-401: #FF9877;
+/* Color representing response status code 402 (orange.40). */
+@kui-status-color-402: #FF723C;
+/* Color representing response status code 403 (orange.50). */
+@kui-status-color-403: #F75008;
+/* Color representing response status code 404 (orange.60). */
+@kui-status-color-404: #D13500;
+/* Color representing response status code 405 (orange.70). */
+@kui-status-color-405: #A31F00;
+/* Color representing response status code 406 (orange.20). */
+@kui-status-color-406: #FFC2B3;
+/* Color representing response status code 407 (orange.30). */
+@kui-status-color-407: #FF9877;
+/* Color representing response status code 408 (orange.40). */
+@kui-status-color-408: #FF723C;
+/* Color representing response status code 409 (orange.50). */
+@kui-status-color-409: #F75008;
+/* Color representing response status code 410 (orange.60). */
+@kui-status-color-410: #D13500;
+/* Color representing response status code 411 (orange.70). */
+@kui-status-color-411: #A31F00;
+/* Color representing response status code 412 (orange.20). */
+@kui-status-color-412: #FFC2B3;
+/* Color representing response status code 413 (orange.30). */
+@kui-status-color-413: #FF9877;
+/* Color representing response status code 414 (orange.40). */
+@kui-status-color-414: #FF723C;
+/* Color representing response status code 415 (orange.50). */
+@kui-status-color-415: #F75008;
+/* Color representing response status code 416 (orange.60). */
+@kui-status-color-416: #D13500;
+/* Color representing response status code 417 (orange.70). */
+@kui-status-color-417: #A31F00;
+/* Color representing response status code 418 (orange.20). */
+@kui-status-color-418: #FFC2B3;
+/* Color representing response status code 421 (orange.30). */
+@kui-status-color-421: #FF9877;
+/* Color representing response status code 422 (orange.40). */
+@kui-status-color-422: #FF723C;
+/* Color representing response status code 423 (orange.50). */
+@kui-status-color-423: #F75008;
+/* Color representing response status code 424 (orange.60). */
+@kui-status-color-424: #D13500;
+/* Color representing response status code 425 (orange.70). */
+@kui-status-color-425: #A31F00;
+/* Color representing response status code 426 (orange.20). */
+@kui-status-color-426: #FFC2B3;
+/* Color representing response status code 428 (orange.30). */
+@kui-status-color-428: #FF9877;
+/* Color representing response status code 429 (orange.40). */
+@kui-status-color-429: #FF723C;
+/* Color representing response status code 431 (orange.50). */
+@kui-status-color-431: #F75008;
+/* Color representing response status code 451 (orange.60). */
+@kui-status-color-451: #D13500;
+/* Color representing response status code 500 (red.20). */
+@kui-status-color-500: #ffabab;
+/* Color representing response status code 501 (red.30). */
+@kui-status-color-501: #ff7272;
+/* Color representing response status code 502 (red.40). */
+@kui-status-color-502: #ff3954;
+/* Color representing response status code 503 (red.50). */
+@kui-status-color-503: #f50045;
+/* Color representing response status code 504 (red.60). */
+@kui-status-color-504: #d60027;
+/* Color representing response status code 505 (red.70). */
+@kui-status-color-505: #ad000e;
+/* Color representing response status code 506 (red.20). */
+@kui-status-color-506: #ffabab;
+/* Color representing response status code 507 (red.30). */
+@kui-status-color-507: #ff7272;
+/* Color representing response status code 508 (red.40). */
+@kui-status-color-508: #ff3954;
+/* Color representing response status code 510 (red.50). */
+@kui-status-color-510: #f50045;
+/* Color representing response status code 511 (red.60). */
+@kui-status-color-511: #d60027;
+/* Color for unknown response status codes in the 100-199 range (blue.10). */
+@kui-status-color-1na: #eefaff;
+/* Color for unknown response status codes in the 200-299 range (green.10). */
+@kui-status-color-2na: #ecfffb;
+/* Color for unknown response status codes in the 300-399 range (yellow.10). */
+@kui-status-color-3na: #fffce0;
+/* Color for unknown response status codes in the 400-499 range (orange.10). */
+@kui-status-color-4na: #FFF1EF;
+/* Color for unknown response status codes in the 500-599 range (red.10). */
+@kui-status-color-5na: #ffe5e5;
+/* Color for a group of response status codes in the 100-199 range (blue.40). */
+@kui-status-color-100s: #5f9aff;
+/* Color for a group of response status codes in the 200-299 range (green.40). */
+@kui-status-color-200s: #00d6a4;
+/* Color for a group of response status codes in the 300-399 range (yellow.40). */
+@kui-status-color-300s: #ffc400;
+/* Color for a group of response status codes in the 400-499 range (orange.40). */
+@kui-status-color-400s: #FF723C;
+/* Color for a group of response status codes in the 500-599 range (red.40). */
+@kui-status-color-500s: #ff3954;
+/* Background color for http status 100 elements (blue.10). */
+@kui-status-color-background-100: #eefaff;
+/* Background color for http status 200 elements (green.10). */
+@kui-status-color-background-200: #ecfffb;
+/* Background color for http status 300 elements (yellow.10). */
+@kui-status-color-background-300: #fffce0;
+/* Background color for http status 400 elements (orange.10). */
+@kui-status-color-background-400: #FFF1EF;
+/* Background color for http status 500 elements (red.10). */
+@kui-status-color-background-500: #ffe5e5;
+/* Text color for http status 100 elements (blue.60). */
+@kui-status-color-text-100: #0044f4;
+/* Text color for http status 200 elements (green.60). */
+@kui-status-color-text-200: #007d60;
+/* Text color for http status 300 elements (yellow.60). */
+@kui-status-color-text-300: #995c00;
+/* Text color for http status 400 elements (orange.60). */
+@kui-status-color-text-400: #D13500;
+/* Text color for http status 500 elements (red.60). */
+@kui-status-color-text-500: #d60027;
+/* The standard monospace text font family. Typically used for code blocks, inline code, and copyable text. */
+@kui-font-family-code: 'JetBrains Mono', Consolas, monospace;
+/* The standard heading text font family. */
+@kui-font-family-heading: 'Inter', Roboto, Helvetica, sans-serif;
+/* The standard text font family. */
+@kui-font-family-text: 'Inter', Roboto, Helvetica, sans-serif;
+@kui-font-size-10: 10px;
+@kui-font-size-20: 12px;
+@kui-font-size-30: 14px;
+@kui-font-size-40: 16px;
+@kui-font-size-50: 18px;
+@kui-font-size-60: 20px;
+@kui-font-size-70: 24px;
+@kui-font-size-80: 32px;
+@kui-font-size-90: 40px;
+@kui-font-size-100: 48px;
+/* 700: The bold font weight. */
+@kui-font-weight-bold: 700;
+/* 500: The medium font weight. */
+@kui-font-weight-medium: 500;
+/* 400: The normal font weight. */
+@kui-font-weight-regular: 400;
+/* 600: The semibold font weight. */
+@kui-font-weight-semibold: 600;
+/* Alias for letter-spacing-normal */
+@kui-letter-spacing-0: normal;
+/* -0.12px */
+@kui-letter-spacing-minus-10: -0.12px;
+/* -0.24px */
+@kui-letter-spacing-minus-20: -0.24px;
+/* -0.32px */
+@kui-letter-spacing-minus-30: -0.32px;
+/* -0.4px */
+@kui-letter-spacing-minus-40: -0.4px;
+/* -0.48px */
+@kui-letter-spacing-minus-50: -0.48px;
+/* normal */
+@kui-letter-spacing-normal: normal;
+/* 12px */
+@kui-line-height-10: 12px;
+/* 16px */
+@kui-line-height-20: 16px;
+/* 20px */
+@kui-line-height-30: 20px;
+/* 24px */
+@kui-line-height-40: 24px;
+/* 28px */
+@kui-line-height-50: 28px;
+/* 32px */
+@kui-line-height-60: 32px;
+/* 36px */
+@kui-line-height-70: 36px;
+/* 40px */
+@kui-line-height-80: 40px;
+/* 48px */
+@kui-line-height-90: 48px;
+/* 56px */
+@kui-line-height-100: 56px;
+/* 0px 4px 20px 0px rgba(0, 0, 0, 0.08) */
+@kui-shadow: 0px 4px 20px 0px rgba(0, 0, 0, 0.08);
+/* 0px 0px 0px 1px gray.20 inset */
+@kui-shadow-border: 0px 0px 0px 1px #e0e4ea inset;
+/* 0px 0px 0px 1px red.60 inset */
+@kui-shadow-border-danger: 0px 0px 0px 1px #d60027 inset;
+/* 0px 0px 0px 1px red.70 inset */
+@kui-shadow-border-danger-strong: 0px 0px 0px 1px #ad000e inset;
+/* 0px 0px 0px 1px gray.20 inset */
+@kui-shadow-border-disabled: 0px 0px 0px 1px #e0e4ea inset;
+/* 0px 0px 0px 1px blue.60 inset */
+@kui-shadow-border-primary: 0px 0px 0px 1px #0044f4 inset;
+/* 0px 0px 0px 1px blue.90 inset */
+@kui-shadow-border-primary-strongest: 0px 0px 0px 1px #001466 inset;
+/* 0px 0px 0px 1px blue.40 inset */
+@kui-shadow-border-primary-weak: 0px 0px 0px 1px #5f9aff inset;
+/* 0px 0px 0px 4px rgba(0, 68, 244, 0.2) */
+@kui-shadow-focus: 0px 0px 0px 4px rgba(0, 68, 244, 0.2);
+/* 0px value for gaps, margin, or padding. */
+@kui-space-0: 0px;
+/* 2px value for gaps, margin, or padding. */
+@kui-space-10: 2px;
+/* 4px value for gaps, margin, or padding. */
+@kui-space-20: 4px;
+/* 6px value for gaps, margin, or padding. */
+@kui-space-30: 6px;
+/* 8px value for gaps, margin, or padding. */
+@kui-space-40: 8px;
+/* 12px value for gaps, margin, or padding. */
+@kui-space-50: 12px;
+/* 16px value for gaps, margin, or padding. */
+@kui-space-60: 16px;
+/* 20px value for gaps, margin, or padding. */
+@kui-space-70: 20px;
+/* 24px value for gaps, margin, or padding. */
+@kui-space-80: 24px;
+/* 32px value for gaps, margin, or padding. */
+@kui-space-90: 32px;
+/* 40px value for gaps, margin, or padding. */
+@kui-space-100: 40px;
+/* 48px value for gaps, margin, or padding. */
+@kui-space-110: 48px;
+/* 56px value for gaps, margin, or padding. */
+@kui-space-120: 56px;
+/* 64px value for gaps, margin, or padding. */
+@kui-space-130: 64px;
+/* 80px value for gaps, margin, or padding. */
+@kui-space-140: 80px;
+/* 96px value for gaps, margin, or padding. */
+@kui-space-150: 96px;
+/* auto */
+@kui-space-auto: auto;
 ```
 
 </details>
@@ -1070,343 +2051,670 @@ You may scope your CSS custom property overrides inside the `:root` selector as 
 <summary>Click to view the list of CSS custom properties</summary>
 
 ```scss
---kui-color-background: ;
---kui-color-background-danger: ;
---kui-color-background-danger-strong: ;
---kui-color-background-danger-stronger: ;
---kui-color-background-danger-strongest: ;
---kui-color-background-danger-weak: ;
---kui-color-background-danger-weaker: ;
---kui-color-background-danger-weakest: ;
---kui-color-background-decorative-aqua-weakest: ;
---kui-color-background-decorative-purple: ;
---kui-color-background-decorative-purple-weakest: ;
---kui-color-background-disabled: ;
---kui-color-background-info: ;
---kui-color-background-info-strong: ;
---kui-color-background-info-stronger: ;
---kui-color-background-info-strongest: ;
---kui-color-background-info-weak: ;
---kui-color-background-info-weaker: ;
---kui-color-background-info-weakest: ;
---kui-color-background-inverse: ;
---kui-color-background-neutral: ;
---kui-color-background-neutral-strong: ;
---kui-color-background-neutral-stronger: ;
---kui-color-background-neutral-strongest: ;
---kui-color-background-neutral-weak: ;
---kui-color-background-neutral-weaker: ;
---kui-color-background-neutral-weakest: ;
---kui-color-background-overlay: ;
---kui-color-background-primary: ;
---kui-color-background-primary-strong: ;
---kui-color-background-primary-stronger: ;
---kui-color-background-primary-strongest: ;
---kui-color-background-primary-weak: ;
---kui-color-background-primary-weaker: ;
---kui-color-background-primary-weakest: ;
---kui-color-background-success: ;
---kui-color-background-success-strong: ;
---kui-color-background-success-stronger: ;
---kui-color-background-success-strongest: ;
---kui-color-background-success-weak: ;
---kui-color-background-success-weaker: ;
---kui-color-background-success-weakest: ;
---kui-color-background-transparent: ;
---kui-color-background-warning: ;
---kui-color-background-warning-strong: ;
---kui-color-background-warning-stronger: ;
---kui-color-background-warning-strongest: ;
---kui-color-background-warning-weak: ;
---kui-color-background-warning-weaker: ;
---kui-color-background-warning-weakest: ;
---kui-color-border: ;
---kui-color-border-danger: ;
---kui-color-border-danger-strong: ;
---kui-color-border-danger-stronger: ;
---kui-color-border-danger-strongest: ;
---kui-color-border-danger-weak: ;
---kui-color-border-danger-weaker: ;
---kui-color-border-danger-weakest: ;
---kui-color-border-decorative-purple: ;
---kui-color-border-disabled: ;
---kui-color-border-inverse: ;
---kui-color-border-neutral: ;
---kui-color-border-neutral-strong: ;
---kui-color-border-neutral-stronger: ;
---kui-color-border-neutral-strongest: ;
---kui-color-border-neutral-weak: ;
---kui-color-border-neutral-weaker: ;
---kui-color-border-neutral-weakest: ;
---kui-color-border-primary: ;
---kui-color-border-primary-strong: ;
---kui-color-border-primary-stronger: ;
---kui-color-border-primary-strongest: ;
---kui-color-border-primary-weak: ;
---kui-color-border-primary-weaker: ;
---kui-color-border-primary-weakest: ;
---kui-color-border-transparent: ;
---kui-color-text: ;
---kui-color-text-danger: ;
---kui-color-text-danger-strong: ;
---kui-color-text-danger-stronger: ;
---kui-color-text-danger-strongest: ;
---kui-color-text-danger-weak: ;
---kui-color-text-danger-weaker: ;
---kui-color-text-danger-weakest: ;
---kui-color-text-decorative-aqua: ;
---kui-color-text-decorative-pink: ;
---kui-color-text-decorative-purple: ;
---kui-color-text-decorative-purple-strong: ;
---kui-color-text-disabled: ;
---kui-color-text-info: ;
---kui-color-text-info-strong: ;
---kui-color-text-info-stronger: ;
---kui-color-text-info-strongest: ;
---kui-color-text-info-weak: ;
---kui-color-text-info-weaker: ;
---kui-color-text-info-weakest: ;
---kui-color-text-inverse: ;
---kui-color-text-neutral: ;
---kui-color-text-neutral-strong: ;
---kui-color-text-neutral-stronger: ;
---kui-color-text-neutral-strongest: ;
---kui-color-text-neutral-weak: ;
---kui-color-text-neutral-weaker: ;
---kui-color-text-neutral-weakest: ;
---kui-color-text-primary: ;
---kui-color-text-primary-strong: ;
---kui-color-text-primary-stronger: ;
---kui-color-text-primary-strongest: ;
---kui-color-text-primary-weak: ;
---kui-color-text-primary-weaker: ;
---kui-color-text-primary-weakest: ;
---kui-color-text-success: ;
---kui-color-text-success-strong: ;
---kui-color-text-success-stronger: ;
---kui-color-text-success-strongest: ;
---kui-color-text-success-weak: ;
---kui-color-text-success-weaker: ;
---kui-color-text-success-weakest: ;
---kui-color-text-warning: ;
---kui-color-text-warning-strong: ;
---kui-color-text-warning-stronger: ;
---kui-color-text-warning-strongest: ;
---kui-color-text-warning-weak: ;
---kui-color-text-warning-weaker: ;
---kui-color-text-warning-weakest: ;
---kui-animation-duration-20: ;
---kui-border-radius-0: ;
---kui-border-radius-10: ;
---kui-border-radius-20: ;
---kui-border-radius-30: ;
---kui-border-radius-40: ;
---kui-border-radius-50: ;
---kui-border-radius-circle: ;
---kui-border-radius-round: ;
---kui-border-width-0: ;
---kui-border-width-10: ;
---kui-border-width-20: ;
---kui-border-width-30: ;
---kui-breakpoint-mobile: ;
---kui-breakpoint-phablet: ;
---kui-breakpoint-tablet: ;
---kui-breakpoint-laptop: ;
---kui-breakpoint-desktop: ;
---kui-icon-color-danger: ;
---kui-icon-color-neutral: ;
---kui-icon-color-primary: ;
---kui-icon-color-success: ;
---kui-icon-color-warning: ;
---kui-icon-size-10: ;
---kui-icon-size-20: ;
---kui-icon-size-30: ;
---kui-icon-size-40: ;
---kui-icon-size-50: ;
---kui-icon-size-60: ;
---kui-icon-size-70: ;
---kui-icon-size-80: ;
---kui-method-color-background-connect: ;
---kui-method-color-background-delete: ;
---kui-method-color-background-get: ;
---kui-method-color-background-head: ;
---kui-method-color-background-options: ;
---kui-method-color-background-patch: ;
---kui-method-color-background-post: ;
---kui-method-color-background-put: ;
---kui-method-color-background-trace: ;
---kui-method-color-text-connect: ;
---kui-method-color-text-connect-strong: ;
---kui-method-color-text-delete: ;
---kui-method-color-text-delete-strong: ;
---kui-method-color-text-get: ;
---kui-method-color-text-get-strong: ;
---kui-method-color-text-head: ;
---kui-method-color-text-head-strong: ;
---kui-method-color-text-options: ;
---kui-method-color-text-options-strong: ;
---kui-method-color-text-patch: ;
---kui-method-color-text-patch-strong: ;
---kui-method-color-text-post: ;
---kui-method-color-text-post-strong: ;
---kui-method-color-text-put: ;
---kui-method-color-text-put-strong: ;
---kui-method-color-text-trace: ;
---kui-method-color-text-trace-strong: ;
---kui-navigation-color-background: ;
---kui-navigation-color-background-selected: ;
---kui-navigation-color-border: ;
---kui-navigation-color-border-child: ;
---kui-navigation-color-border-divider: ;
---kui-navigation-color-text: ;
---kui-navigation-color-text-focus: ;
---kui-navigation-color-text-hover: ;
---kui-navigation-color-text-selected: ;
---kui-navigation-shadow-border: ;
---kui-navigation-shadow-border-child: ;
---kui-navigation-shadow-focus: ;
---kui-status-color-100: ;
---kui-status-color-101: ;
---kui-status-color-102: ;
---kui-status-color-103: ;
---kui-status-color-200: ;
---kui-status-color-201: ;
---kui-status-color-202: ;
---kui-status-color-203: ;
---kui-status-color-204: ;
---kui-status-color-205: ;
---kui-status-color-206: ;
---kui-status-color-207: ;
---kui-status-color-208: ;
---kui-status-color-226: ;
---kui-status-color-300: ;
---kui-status-color-301: ;
---kui-status-color-302: ;
---kui-status-color-303: ;
---kui-status-color-304: ;
---kui-status-color-305: ;
---kui-status-color-307: ;
---kui-status-color-308: ;
---kui-status-color-400: ;
---kui-status-color-401: ;
---kui-status-color-402: ;
---kui-status-color-403: ;
---kui-status-color-404: ;
---kui-status-color-405: ;
---kui-status-color-406: ;
---kui-status-color-407: ;
---kui-status-color-408: ;
---kui-status-color-409: ;
---kui-status-color-410: ;
---kui-status-color-411: ;
---kui-status-color-412: ;
---kui-status-color-413: ;
---kui-status-color-414: ;
---kui-status-color-415: ;
---kui-status-color-416: ;
---kui-status-color-417: ;
---kui-status-color-418: ;
---kui-status-color-421: ;
---kui-status-color-422: ;
---kui-status-color-423: ;
---kui-status-color-424: ;
---kui-status-color-425: ;
---kui-status-color-426: ;
---kui-status-color-428: ;
---kui-status-color-429: ;
---kui-status-color-431: ;
---kui-status-color-451: ;
---kui-status-color-500: ;
---kui-status-color-501: ;
---kui-status-color-502: ;
---kui-status-color-503: ;
---kui-status-color-504: ;
---kui-status-color-505: ;
---kui-status-color-506: ;
---kui-status-color-507: ;
---kui-status-color-508: ;
---kui-status-color-510: ;
---kui-status-color-511: ;
---kui-status-color-1na: ;
---kui-status-color-2na: ;
---kui-status-color-3na: ;
---kui-status-color-4na: ;
---kui-status-color-5na: ;
---kui-status-color-100s: ;
---kui-status-color-200s: ;
---kui-status-color-300s: ;
---kui-status-color-400s: ;
---kui-status-color-500s: ;
---kui-status-color-background-100: ;
---kui-status-color-background-200: ;
---kui-status-color-background-300: ;
---kui-status-color-background-400: ;
---kui-status-color-background-500: ;
---kui-status-color-text-100: ;
---kui-status-color-text-200: ;
---kui-status-color-text-300: ;
---kui-status-color-text-400: ;
---kui-status-color-text-500: ;
---kui-font-family-code: ;
---kui-font-family-heading: ;
---kui-font-family-text: ;
---kui-font-size-10: ;
---kui-font-size-20: ;
---kui-font-size-30: ;
---kui-font-size-40: ;
---kui-font-size-50: ;
---kui-font-size-60: ;
---kui-font-size-70: ;
---kui-font-size-80: ;
---kui-font-size-90: ;
---kui-font-size-100: ;
---kui-font-weight-bold: ;
---kui-font-weight-medium: ;
---kui-font-weight-regular: ;
---kui-font-weight-semibold: ;
---kui-letter-spacing-0: ;
---kui-letter-spacing-minus-10: ;
---kui-letter-spacing-minus-20: ;
---kui-letter-spacing-minus-30: ;
---kui-letter-spacing-minus-40: ;
---kui-letter-spacing-minus-50: ;
---kui-letter-spacing-normal: ;
---kui-line-height-10: ;
---kui-line-height-20: ;
---kui-line-height-30: ;
---kui-line-height-40: ;
---kui-line-height-50: ;
---kui-line-height-60: ;
---kui-line-height-70: ;
---kui-line-height-80: ;
---kui-line-height-90: ;
---kui-line-height-100: ;
---kui-shadow: ;
---kui-shadow-border: ;
---kui-shadow-border-danger: ;
---kui-shadow-border-danger-strong: ;
---kui-shadow-border-disabled: ;
---kui-shadow-border-primary: ;
---kui-shadow-border-primary-strongest: ;
---kui-shadow-border-primary-weak: ;
---kui-shadow-focus: ;
---kui-space-0: ;
---kui-space-10: ;
---kui-space-20: ;
---kui-space-30: ;
---kui-space-40: ;
---kui-space-50: ;
---kui-space-60: ;
---kui-space-70: ;
---kui-space-80: ;
---kui-space-90: ;
---kui-space-100: ;
---kui-space-110: ;
---kui-space-120: ;
---kui-space-130: ;
---kui-space-140: ;
---kui-space-150: ;
---kui-space-auto: ;
+/* Default background color for containers (white). */
+--kui-color-background: #ffffff;
+/* Background color for danger actions or messages (red.60). */
+--kui-color-background-danger: #d60027;
+/* Strong background color for danger actions or messages (red.70). */
+--kui-color-background-danger-strong: #ad000e;
+/* Stronger background color for danger actions or messages (red.80). */
+--kui-color-background-danger-stronger: #850000;
+/* Strongest background color for danger actions or messages (red.90). */
+--kui-color-background-danger-strongest: #5c0000;
+/* Weak background color for danger actions or messages (red.40). */
+--kui-color-background-danger-weak: #ff3954;
+/* Weaker background color for danger actions or messages (red.20). */
+--kui-color-background-danger-weaker: #ffabab;
+/* Weakest background color for danger actions or messages (red.10). */
+--kui-color-background-danger-weakest: #ffe5e5;
+/* Weakest background color for decorative purposes (aqua.10). */
+--kui-color-background-decorative-aqua-weakest: #ecfcff;
+/* Background color for decorative purposes (purple.60). */
+--kui-color-background-decorative-purple: #6f28ff;
+/* Weakest background color for decorative purposes (purple.10). */
+--kui-color-background-decorative-purple-weakest: #f1f0ff;
+/* Background color for disabled elements (gray.20). */
+--kui-color-background-disabled: #e0e4ea;
+/* Background color for info elements (blue.60). */
+--kui-color-background-info: #0044f4;
+/* Strong background color for info elements (blue.70). */
+--kui-color-background-info-strong: #0030cc;
+/* Stronger background color for info elements (blue.80). */
+--kui-color-background-info-stronger: #002099;
+/* Strongest background color for info elements (blue.90). */
+--kui-color-background-info-strongest: #001466;
+/* Weak background color for info elements (blue.40). */
+--kui-color-background-info-weak: #5f9aff;
+/* Weaker background color for info elements (blue.20). */
+--kui-color-background-info-weaker: #bee2ff;
+/* Weakest background color for info elements (blue.10). */
+--kui-color-background-info-weakest: #eefaff;
+/* Inverse background color for containers (blue.100) */
+--kui-color-background-inverse: #000933;
+/* Background color for neutral elements (gray.60). */
+--kui-color-background-neutral: #6c7489;
+/* Strong background color for neutral elements (gray.70). */
+--kui-color-background-neutral-strong: #52596e;
+/* Stronger background color for neutral elements (gray.80). */
+--kui-color-background-neutral-stronger: #3a3f51;
+/* Strongest background color for neutral elements (gray.90). */
+--kui-color-background-neutral-strongest: #232633;
+/* Weak background color for neutral elements (gray.40). */
+--kui-color-background-neutral-weak: #afb7c5;
+/* Weaker background color for neutral elements (gray.20). */
+--kui-color-background-neutral-weaker: #e0e4ea;
+/* Weakest background color for neutral elements (gray.10). */
+--kui-color-background-neutral-weakest: #f9fafb;
+/* Overlay background color (rgba(0, 9, 51, 0.6)) */
+--kui-color-background-overlay: rgba(0, 9, 51, 0.6);
+/* Background color for primary actions or messages (blue.60). */
+--kui-color-background-primary: #0044f4;
+/* Strong background color for primary actions or messages (blue.70). */
+--kui-color-background-primary-strong: #0030cc;
+/* Stronger background color for primary actions or messages (blue.80). */
+--kui-color-background-primary-stronger: #002099;
+/* Strongest background color for primary actions or messages (blue.90). */
+--kui-color-background-primary-strongest: #001466;
+/* Weak background color for primary actions or messages (blue.40). */
+--kui-color-background-primary-weak: #5f9aff;
+/* Weaker background color for primary actions or messages (blue.20). */
+--kui-color-background-primary-weaker: #bee2ff;
+/* Weakest background color for primary actions or messages (blue.10) */
+--kui-color-background-primary-weakest: #eefaff;
+/* Background color for success elements (green.60). */
+--kui-color-background-success: #007d60;
+/* Strong background color for success elements (green.70). */
+--kui-color-background-success-strong: #005944;
+/* Stronger background color for success elements (green.80). */
+--kui-color-background-success-stronger: #004737;
+/* Strongest background color for success elements (green.90). */
+--kui-color-background-success-strongest: #003629;
+/* Weak background color for success elements (green.40). */
+--kui-color-background-success-weak: #00d6a4;
+/* Weaker background color for success elements (green.20). */
+--kui-color-background-success-weaker: #b5ffee;
+/* Weakest background color for success elements (green.10). */
+--kui-color-background-success-weakest: #ecfffb;
+/* Transparent background color (transparent). */
+--kui-color-background-transparent: transparent;
+/* Background color for warning elements (yellow.60). */
+--kui-color-background-warning: #995c00;
+/* Strong background color for warning elements (yellow.70). */
+--kui-color-background-warning-strong: #804400;
+/* Stronger background color for warning elements (yellow.80). */
+--kui-color-background-warning-stronger: #662d00;
+/* Strongest background color for warning elements (yellow.90). */
+--kui-color-background-warning-strongest: #4d1b00;
+/* Weak background color for warning elements (yellow.40). */
+--kui-color-background-warning-weak: #ffc400;
+/* Weaker background color for warning elements (yellow.20). */
+--kui-color-background-warning-weaker: #fff296;
+/* Weakest background color for warning elements (yellow.10). */
+--kui-color-background-warning-weakest: #fffce0;
+/* Default border color for containers (gray.20). */
+--kui-color-border: #e0e4ea;
+/* Border color for danger actions or messages (red.60). */
+--kui-color-border-danger: #d60027;
+/* Strong border color for danger actions or messages (red.70). */
+--kui-color-border-danger-strong: #ad000e;
+/* Stronger border color for danger actions or messages (red.80). */
+--kui-color-border-danger-stronger: #850000;
+/* Strongest border color for danger actions or messages (red.90). */
+--kui-color-border-danger-strongest: #5c0000;
+/* Weak border color for danger actions or messages (red.40). */
+--kui-color-border-danger-weak: #ff3954;
+/* Weaker border color for danger actions or messages (red.20). */
+--kui-color-border-danger-weaker: #ffabab;
+/* Weakest border color for danger actions or messages (red.10). */
+--kui-color-border-danger-weakest: #ffe5e5;
+/* Border color for decorative purposes (purple.60). */
+--kui-color-border-decorative-purple: #6f28ff;
+/* Border color for disabled elements (gray.20). */
+--kui-color-border-disabled: #e0e4ea;
+/* Inverse border color (rgba(255, 255, 255, 0.2)). */
+--kui-color-border-inverse: rgba(255, 255, 255, 0.2);
+/* Border color for neutral elements (gray.60) */
+--kui-color-border-neutral: #6c7489;
+/* Strong border color for neutral elements (gray.70) */
+--kui-color-border-neutral-strong: #52596e;
+/* Stronger border color for neutral elements (gray.80) */
+--kui-color-border-neutral-stronger: #3a3f51;
+/* Strongest border color for neutral elements (gray.90) */
+--kui-color-border-neutral-strongest: #232633;
+/* Weak border color for neutral elements (gray.40) */
+--kui-color-border-neutral-weak: #afb7c5;
+/* Weaker border color for neutral elements (gray.20) */
+--kui-color-border-neutral-weaker: #e0e4ea;
+/* Weakest border color for neutral elements (gray.10) */
+--kui-color-border-neutral-weakest: #f9fafb;
+/* Border color for primary actions or messages (blue.60). */
+--kui-color-border-primary: #0044f4;
+/* Strong border color for primary actions or messages (blue.70). */
+--kui-color-border-primary-strong: #0030cc;
+/* Stronger border color for primary actions or messages (blue.80). */
+--kui-color-border-primary-stronger: #002099;
+/* Strongest border color for primary actions or messages (blue.90). */
+--kui-color-border-primary-strongest: #001466;
+/* Weak border color for primary actions or messages (blue.40). */
+--kui-color-border-primary-weak: #5f9aff;
+/* Weaker border color for primary actions or messages (blue.20). */
+--kui-color-border-primary-weaker: #bee2ff;
+/* Weakest border color for primary actions or messages (blue.10). */
+--kui-color-border-primary-weakest: #eefaff;
+/* Transparent border color (transparent). */
+--kui-color-border-transparent: transparent;
+/* Default text color (blue.100). */
+--kui-color-text: #000933;
+/* Text color for danger actions or messages (red.60). */
+--kui-color-text-danger: #d60027;
+/* Strong text color for danger actions or messages (red.70). */
+--kui-color-text-danger-strong: #ad000e;
+/* Stronger text color for danger actions or messages (red.80). */
+--kui-color-text-danger-stronger: #850000;
+/* Strongest text color for danger actions or messages (red.90). */
+--kui-color-text-danger-strongest: #5c0000;
+/* Weak text color for danger actions or messages (red.40). */
+--kui-color-text-danger-weak: #ff3954;
+/* Weaker text color for danger actions or messages (red.20). */
+--kui-color-text-danger-weaker: #ffabab;
+/* Weakest text color for danger actions or messages (red.10). */
+--kui-color-text-danger-weakest: #ffe5e5;
+/* Text color for decorative purposes (aqua.50). */
+--kui-color-text-decorative-aqua: #00abd2;
+/* Text color for decorative purposes (pink.60). */
+--kui-color-text-decorative-pink: #d60067;
+/* Text color for decorative purposes (purple.60). */
+--kui-color-text-decorative-purple: #6f28ff;
+/* Strong text color for decorative purposes (purple.70). */
+--kui-color-text-decorative-purple-strong: #5e00f5;
+/* Text color for disabled elements (gray.40). */
+--kui-color-text-disabled: #afb7c5;
+/* Text color for info elements (blue.60). */
+--kui-color-text-info: #0044f4;
+/* Strong text color for info elements (blue.70). */
+--kui-color-text-info-strong: #0030cc;
+/* Stronger text color for info elements (blue.80). */
+--kui-color-text-info-stronger: #002099;
+/* Strongest text color for info elements (blue.90). */
+--kui-color-text-info-strongest: #001466;
+/* Weak text color for info elements (blue.40). */
+--kui-color-text-info-weak: #5f9aff;
+/* Weaker text color for info elements (blue.20). */
+--kui-color-text-info-weaker: #bee2ff;
+/* Weakest text color for info elements (blue.10). */
+--kui-color-text-info-weakest: #eefaff;
+/* Inverse text color (white). */
+--kui-color-text-inverse: #ffffff;
+/* Text color for neutral elements (gray.60). */
+--kui-color-text-neutral: #6c7489;
+/* Strong text color for neutral elements (gray.70). */
+--kui-color-text-neutral-strong: #52596e;
+/* Stronger text color for neutral elements (gray.80). */
+--kui-color-text-neutral-stronger: #3a3f51;
+/* Strongest text color for neutral elements (gray.90). */
+--kui-color-text-neutral-strongest: #232633;
+/* Weak text color for neutral elements (gray.40). */
+--kui-color-text-neutral-weak: #afb7c5;
+/* Weaker text color for neutral elements (gray.20). */
+--kui-color-text-neutral-weaker: #e0e4ea;
+/* Weakest text color for neutral elements (gray.10). */
+--kui-color-text-neutral-weakest: #f9fafb;
+/* Text color for primary actions or messages (blue.60). */
+--kui-color-text-primary: #0044f4;
+/* Strong text color for primary actions or messages (blue.70). */
+--kui-color-text-primary-strong: #0030cc;
+/* Stronger text color for primary actions or messages (blue.80). */
+--kui-color-text-primary-stronger: #002099;
+/* Strongest text color for primary actions or messages (blue.90). */
+--kui-color-text-primary-strongest: #001466;
+/* Weak text color for primary actions or messages (blue.40). */
+--kui-color-text-primary-weak: #5f9aff;
+/* Weaker text color for primary actions or messages (blue.20). */
+--kui-color-text-primary-weaker: #bee2ff;
+/* Weakest text color for primary actions or messages (blue.10). */
+--kui-color-text-primary-weakest: #eefaff;
+/* Text color for success elements (green.60). */
+--kui-color-text-success: #007d60;
+/* Strong text color for success elements (green.70). */
+--kui-color-text-success-strong: #005944;
+/* Stronger text color for success elements (green.80). */
+--kui-color-text-success-stronger: #004737;
+/* Stronger text color for success elements (green.90). */
+--kui-color-text-success-strongest: #003629;
+/* Weak text color for success elements (green.40). */
+--kui-color-text-success-weak: #00d6a4;
+/* Weaker text color for success elements (green.20). */
+--kui-color-text-success-weaker: #b5ffee;
+/* Weakest text color for success elements (green.10). */
+--kui-color-text-success-weakest: #ecfffb;
+/* Text color for warning elements (yellow.60). */
+--kui-color-text-warning: #995c00;
+/* Strong text color for warning elements (yellow.70). */
+--kui-color-text-warning-strong: #804400;
+/* Stronger text color for warning elements (yellow.80). */
+--kui-color-text-warning-stronger: #662d00;
+/* Strongest text color for warning elements (yellow.90). */
+--kui-color-text-warning-strongest: #4d1b00;
+/* Weak text color for warning elements (yellow.40). */
+--kui-color-text-warning-weak: #ffc400;
+/* Weaker text color for warning elements (yellow.20). */
+--kui-color-text-warning-weaker: #fff296;
+/* Weakest text color for warning elements (yellow.10). */
+--kui-color-text-warning-weakest: #fffce0;
+/* Default transition timing */
+--kui-animation-duration-20: 0.2s;
+/* 0px border radius. */
+--kui-border-radius-0: 0px;
+/* 2px border radius. */
+--kui-border-radius-10: 2px;
+/* 4px border radius. */
+--kui-border-radius-20: 4px;
+/* 6px border radius. */
+--kui-border-radius-30: 6px;
+/* 8px border radius. */
+--kui-border-radius-40: 8px;
+/* 10px border radius. */
+--kui-border-radius-50: 10px;
+/* 50% border radius used to create circles. */
+--kui-border-radius-circle: 50%;
+/* 100px border radius used to create pill shapes. */
+--kui-border-radius-round: 100px;
+/* 0px border width. */
+--kui-border-width-0: 0px;
+/* 1px border width. */
+--kui-border-width-10: 1px;
+/* 2px border width. */
+--kui-border-width-20: 2px;
+/* 4px border width. */
+--kui-border-width-30: 4px;
+/* Used for larger mobile screens. Any viewport width under this value is considered mobile. */
+--kui-breakpoint-mobile: 640px;
+/* Used for tablet screens. */
+--kui-breakpoint-phablet: 768px;
+/* Used for larger tablet screens. Any viewport width less than this value will likely show a mobile layout. Any viewport width this value and greater will likely show a desktop layout. */
+--kui-breakpoint-tablet: 1024px;
+/* Used for standard desktop screens. */
+--kui-breakpoint-laptop: 1280px;
+/* Used for larger desktop screens. */
+--kui-breakpoint-desktop: 1536px;
+/* Danger color for icons. */
+--kui-icon-color-danger: #f50045;
+/* Neutral color for icons. */
+--kui-icon-color-neutral: #828a9e;
+/* Primary color for icons. */
+--kui-icon-color-primary: #306fff;
+/* Success color for icons. */
+--kui-icon-color-success: #00a17b;
+/* Warning color for icons. */
+--kui-icon-color-warning: #ffc400;
+/* 10px icon size. */
+--kui-icon-size-10: 10px;
+/* 12px icon size. */
+--kui-icon-size-20: 12px;
+/* 16px icon size. */
+--kui-icon-size-30: 16px;
+/* 20px icon size. */
+--kui-icon-size-40: 20px;
+/* 24px icon size (default). */
+--kui-icon-size-50: 24px;
+/* 32px icon size. */
+--kui-icon-size-60: 32px;
+/* 40px icon size. */
+--kui-icon-size-70: 40px;
+/* 48px icon size. */
+--kui-icon-size-80: 48px;
+/* Background color for the CONNECT method (purple.10). */
+--kui-method-color-background-connect: #f1f0ff;
+/* Background color for the DELETE method (red.10). */
+--kui-method-color-background-delete: #ffe5e5;
+/* Background color for the GET method (blue.10). */
+--kui-method-color-background-get: #eefaff;
+/* Background color for the HEAD method (gray.70). */
+--kui-method-color-background-head: #52596e;
+/* Background color for the OPTIONS method (gray.20). */
+--kui-method-color-background-options: #e0e4ea;
+/* Background color for the PATCH method (aqua.10). */
+--kui-method-color-background-patch: #ecfcff;
+/* Background color for the POST method (green.10). */
+--kui-method-color-background-post: #ecfffb;
+/* Background color for the PUT method (yellow.10). */
+--kui-method-color-background-put: #fffce0;
+/* Background color for the TRACE method (pink.10). */
+--kui-method-color-background-trace: #fff0f7;
+/* Text color for the CONNECT method (purple.60). */
+--kui-method-color-text-connect: #6f28ff;
+/* Strong text color for the CONNECT method (purple.70). */
+--kui-method-color-text-connect-strong: #5e00f5;
+/* Text color for the DELETE method (red.60). */
+--kui-method-color-text-delete: #d60027;
+/* Strong text color for the DELETE method (red.70). */
+--kui-method-color-text-delete-strong: #ad000e;
+/* Text color for the GET method (blue.60). */
+--kui-method-color-text-get: #0044f4;
+/* Strong text color for the GET method (blue.70). */
+--kui-method-color-text-get-strong: #0030cc;
+/* Text color for the HEAD method (gray.20). */
+--kui-method-color-text-head: #e0e4ea;
+/* Strong text color for the HEAD method (gray.40). */
+--kui-method-color-text-head-strong: #afb7c5;
+/* Text color for the OPTIONS method (gray.70). */
+--kui-method-color-text-options: #52596e;
+/* Strong text color for the OPTIONS method (gray.80). */
+--kui-method-color-text-options-strong: #3a3f51;
+/* Text color for the PATCH method (aqua.60). */
+--kui-method-color-text-patch: #00819d;
+/* Strong text color for the PATCH method (aqua.70). */
+--kui-method-color-text-patch-strong: #00647a;
+/* Text color for the POST method (green.60). */
+--kui-method-color-text-post: #007d60;
+/* Strong text color for the POST method (green.70). */
+--kui-method-color-text-post-strong: #005944;
+/* Text color for the PUT method (yellow.60). */
+--kui-method-color-text-put: #995c00;
+/* Strong text color for the PUT method (yellow.70). */
+--kui-method-color-text-put-strong: #804400;
+/* Text color for the TRACE method (pink.60). */
+--kui-method-color-text-trace: #d60067;
+/* Strong text color for the TRACE method (pink.70). */
+--kui-method-color-text-trace-strong: #ad0053;
+/* blue.100 */
+--kui-navigation-color-background: #000933;
+/* The background color of a selected navigation item. */
+--kui-navigation-color-background-selected: rgba(255, 255, 255, 0.12);
+/* rgba(255, 255, 255, 0.12) */
+--kui-navigation-color-border: rgba(255, 255, 255, 0.12);
+/* The border color for a selected child navigation item. */
+--kui-navigation-color-border-child: #00fabe;
+/* The color of the navigation section divider. */
+--kui-navigation-color-border-divider: rgba(255, 255, 255, 0.24);
+/* Navigation link and icon color. */
+--kui-navigation-color-text: #bee2ff;
+/* Navigation link and icon focus-visible color. */
+--kui-navigation-color-text-focus: #ffffff;
+/* Navigation link and icon hover color. */
+--kui-navigation-color-text-hover: #eefaff;
+/* Navigation link and icon selected color. */
+--kui-navigation-color-text-selected: #00fabe;
+/* The box-shadow for a focus-visible navigation link. */
+--kui-navigation-shadow-border: 0 0 0 1px rgba(255, 255, 255, 0.12) inset;
+/* The left box-shadow for an active child navigation link. */
+--kui-navigation-shadow-border-child: 4px 0 0 0 #00fabe inset;
+/* Navigation link focus-visible box-shadow. */
+--kui-navigation-shadow-focus: 0 0 0 1px rgba(255, 255, 255, 0.60) inset;
+/* Color representing response status code 100 (blue.20). */
+--kui-status-color-100: #bee2ff;
+/* Color representing response status code 101 (blue.30). */
+--kui-status-color-101: #8fc1ff;
+/* Color representing response status code 102 (blue.40). */
+--kui-status-color-102: #5f9aff;
+/* Color representing response status code 103 (blue.50). */
+--kui-status-color-103: #306fff;
+/* Color representing response status code 200 (green.20). */
+--kui-status-color-200: #b5ffee;
+/* Color representing response status code 201 (green.30). */
+--kui-status-color-201: #00fabe;
+/* Color representing response status code 202 (green.40). */
+--kui-status-color-202: #00d6a4;
+/* Color representing response status code 203 (green.50). */
+--kui-status-color-203: #00a17b;
+/* Color representing response status code 204 (green.60). */
+--kui-status-color-204: #007d60;
+/* Color representing response status code 205 (green.70). */
+--kui-status-color-205: #005944;
+/* Color representing response status code 206 (green.20). */
+--kui-status-color-206: #b5ffee;
+/* Color representing response status code 207 (green.30). */
+--kui-status-color-207: #00fabe;
+/* Color representing response status code 208 (green.40). */
+--kui-status-color-208: #b5ffee;
+/* Color representing response status code 226 (green.50). */
+--kui-status-color-226: #00a17b;
+/* Color representing response status code 100 (yellow.20). */
+--kui-status-color-300: #fff296;
+/* Color representing response status code 101 (yellow.30). */
+--kui-status-color-301: #ffe04b;
+/* Color representing response status code 102 (yellow.40). */
+--kui-status-color-302: #ffc400;
+/* Color representing response status code 103 (yellow.50). */
+--kui-status-color-303: #b37600;
+/* Color representing response status code 103 (yellow.60). */
+--kui-status-color-304: #995c00;
+/* Color representing response status code 103 (yellow.70). */
+--kui-status-color-305: #804400;
+/* Color representing response status code 103 (yellow.20). */
+--kui-status-color-307: #fff296;
+/* Color representing response status code 103 (yellow.30). */
+--kui-status-color-308: #ffe04b;
+/* Color representing response status code 400 (orange.20). */
+--kui-status-color-400: #FFC2B3;
+/* Color representing response status code 401 (orange.30). */
+--kui-status-color-401: #FF9877;
+/* Color representing response status code 402 (orange.40). */
+--kui-status-color-402: #FF723C;
+/* Color representing response status code 403 (orange.50). */
+--kui-status-color-403: #F75008;
+/* Color representing response status code 404 (orange.60). */
+--kui-status-color-404: #D13500;
+/* Color representing response status code 405 (orange.70). */
+--kui-status-color-405: #A31F00;
+/* Color representing response status code 406 (orange.20). */
+--kui-status-color-406: #FFC2B3;
+/* Color representing response status code 407 (orange.30). */
+--kui-status-color-407: #FF9877;
+/* Color representing response status code 408 (orange.40). */
+--kui-status-color-408: #FF723C;
+/* Color representing response status code 409 (orange.50). */
+--kui-status-color-409: #F75008;
+/* Color representing response status code 410 (orange.60). */
+--kui-status-color-410: #D13500;
+/* Color representing response status code 411 (orange.70). */
+--kui-status-color-411: #A31F00;
+/* Color representing response status code 412 (orange.20). */
+--kui-status-color-412: #FFC2B3;
+/* Color representing response status code 413 (orange.30). */
+--kui-status-color-413: #FF9877;
+/* Color representing response status code 414 (orange.40). */
+--kui-status-color-414: #FF723C;
+/* Color representing response status code 415 (orange.50). */
+--kui-status-color-415: #F75008;
+/* Color representing response status code 416 (orange.60). */
+--kui-status-color-416: #D13500;
+/* Color representing response status code 417 (orange.70). */
+--kui-status-color-417: #A31F00;
+/* Color representing response status code 418 (orange.20). */
+--kui-status-color-418: #FFC2B3;
+/* Color representing response status code 421 (orange.30). */
+--kui-status-color-421: #FF9877;
+/* Color representing response status code 422 (orange.40). */
+--kui-status-color-422: #FF723C;
+/* Color representing response status code 423 (orange.50). */
+--kui-status-color-423: #F75008;
+/* Color representing response status code 424 (orange.60). */
+--kui-status-color-424: #D13500;
+/* Color representing response status code 425 (orange.70). */
+--kui-status-color-425: #A31F00;
+/* Color representing response status code 426 (orange.20). */
+--kui-status-color-426: #FFC2B3;
+/* Color representing response status code 428 (orange.30). */
+--kui-status-color-428: #FF9877;
+/* Color representing response status code 429 (orange.40). */
+--kui-status-color-429: #FF723C;
+/* Color representing response status code 431 (orange.50). */
+--kui-status-color-431: #F75008;
+/* Color representing response status code 451 (orange.60). */
+--kui-status-color-451: #D13500;
+/* Color representing response status code 500 (red.20). */
+--kui-status-color-500: #ffabab;
+/* Color representing response status code 501 (red.30). */
+--kui-status-color-501: #ff7272;
+/* Color representing response status code 502 (red.40). */
+--kui-status-color-502: #ff3954;
+/* Color representing response status code 503 (red.50). */
+--kui-status-color-503: #f50045;
+/* Color representing response status code 504 (red.60). */
+--kui-status-color-504: #d60027;
+/* Color representing response status code 505 (red.70). */
+--kui-status-color-505: #ad000e;
+/* Color representing response status code 506 (red.20). */
+--kui-status-color-506: #ffabab;
+/* Color representing response status code 507 (red.30). */
+--kui-status-color-507: #ff7272;
+/* Color representing response status code 508 (red.40). */
+--kui-status-color-508: #ff3954;
+/* Color representing response status code 510 (red.50). */
+--kui-status-color-510: #f50045;
+/* Color representing response status code 511 (red.60). */
+--kui-status-color-511: #d60027;
+/* Color for unknown response status codes in the 100-199 range (blue.10). */
+--kui-status-color-1na: #eefaff;
+/* Color for unknown response status codes in the 200-299 range (green.10). */
+--kui-status-color-2na: #ecfffb;
+/* Color for unknown response status codes in the 300-399 range (yellow.10). */
+--kui-status-color-3na: #fffce0;
+/* Color for unknown response status codes in the 400-499 range (orange.10). */
+--kui-status-color-4na: #FFF1EF;
+/* Color for unknown response status codes in the 500-599 range (red.10). */
+--kui-status-color-5na: #ffe5e5;
+/* Color for a group of response status codes in the 100-199 range (blue.40). */
+--kui-status-color-100s: #5f9aff;
+/* Color for a group of response status codes in the 200-299 range (green.40). */
+--kui-status-color-200s: #00d6a4;
+/* Color for a group of response status codes in the 300-399 range (yellow.40). */
+--kui-status-color-300s: #ffc400;
+/* Color for a group of response status codes in the 400-499 range (orange.40). */
+--kui-status-color-400s: #FF723C;
+/* Color for a group of response status codes in the 500-599 range (red.40). */
+--kui-status-color-500s: #ff3954;
+/* Background color for http status 100 elements (blue.10). */
+--kui-status-color-background-100: #eefaff;
+/* Background color for http status 200 elements (green.10). */
+--kui-status-color-background-200: #ecfffb;
+/* Background color for http status 300 elements (yellow.10). */
+--kui-status-color-background-300: #fffce0;
+/* Background color for http status 400 elements (orange.10). */
+--kui-status-color-background-400: #FFF1EF;
+/* Background color for http status 500 elements (red.10). */
+--kui-status-color-background-500: #ffe5e5;
+/* Text color for http status 100 elements (blue.60). */
+--kui-status-color-text-100: #0044f4;
+/* Text color for http status 200 elements (green.60). */
+--kui-status-color-text-200: #007d60;
+/* Text color for http status 300 elements (yellow.60). */
+--kui-status-color-text-300: #995c00;
+/* Text color for http status 400 elements (orange.60). */
+--kui-status-color-text-400: #D13500;
+/* Text color for http status 500 elements (red.60). */
+--kui-status-color-text-500: #d60027;
+/* The standard monospace text font family. Typically used for code blocks, inline code, and copyable text. */
+--kui-font-family-code: 'JetBrains Mono', Consolas, monospace;
+/* The standard heading text font family. */
+--kui-font-family-heading: 'Inter', Roboto, Helvetica, sans-serif;
+/* The standard text font family. */
+--kui-font-family-text: 'Inter', Roboto, Helvetica, sans-serif;
+--kui-font-size-10: 10px;
+--kui-font-size-20: 12px;
+--kui-font-size-30: 14px;
+--kui-font-size-40: 16px;
+--kui-font-size-50: 18px;
+--kui-font-size-60: 20px;
+--kui-font-size-70: 24px;
+--kui-font-size-80: 32px;
+--kui-font-size-90: 40px;
+--kui-font-size-100: 48px;
+/* 700: The bold font weight. */
+--kui-font-weight-bold: 700;
+/* 500: The medium font weight. */
+--kui-font-weight-medium: 500;
+/* 400: The normal font weight. */
+--kui-font-weight-regular: 400;
+/* 600: The semibold font weight. */
+--kui-font-weight-semibold: 600;
+/* Alias for letter-spacing-normal */
+--kui-letter-spacing-0: normal;
+/* -0.12px */
+--kui-letter-spacing-minus-10: -0.12px;
+/* -0.24px */
+--kui-letter-spacing-minus-20: -0.24px;
+/* -0.32px */
+--kui-letter-spacing-minus-30: -0.32px;
+/* -0.4px */
+--kui-letter-spacing-minus-40: -0.4px;
+/* -0.48px */
+--kui-letter-spacing-minus-50: -0.48px;
+/* normal */
+--kui-letter-spacing-normal: normal;
+/* 12px */
+--kui-line-height-10: 12px;
+/* 16px */
+--kui-line-height-20: 16px;
+/* 20px */
+--kui-line-height-30: 20px;
+/* 24px */
+--kui-line-height-40: 24px;
+/* 28px */
+--kui-line-height-50: 28px;
+/* 32px */
+--kui-line-height-60: 32px;
+/* 36px */
+--kui-line-height-70: 36px;
+/* 40px */
+--kui-line-height-80: 40px;
+/* 48px */
+--kui-line-height-90: 48px;
+/* 56px */
+--kui-line-height-100: 56px;
+/* 0px 4px 20px 0px rgba(0, 0, 0, 0.08) */
+--kui-shadow: 0px 4px 20px 0px rgba(0, 0, 0, 0.08);
+/* 0px 0px 0px 1px gray.20 inset */
+--kui-shadow-border: 0px 0px 0px 1px #e0e4ea inset;
+/* 0px 0px 0px 1px red.60 inset */
+--kui-shadow-border-danger: 0px 0px 0px 1px #d60027 inset;
+/* 0px 0px 0px 1px red.70 inset */
+--kui-shadow-border-danger-strong: 0px 0px 0px 1px #ad000e inset;
+/* 0px 0px 0px 1px gray.20 inset */
+--kui-shadow-border-disabled: 0px 0px 0px 1px #e0e4ea inset;
+/* 0px 0px 0px 1px blue.60 inset */
+--kui-shadow-border-primary: 0px 0px 0px 1px #0044f4 inset;
+/* 0px 0px 0px 1px blue.90 inset */
+--kui-shadow-border-primary-strongest: 0px 0px 0px 1px #001466 inset;
+/* 0px 0px 0px 1px blue.40 inset */
+--kui-shadow-border-primary-weak: 0px 0px 0px 1px #5f9aff inset;
+/* 0px 0px 0px 4px rgba(0, 68, 244, 0.2) */
+--kui-shadow-focus: 0px 0px 0px 4px rgba(0, 68, 244, 0.2);
+/* 0px value for gaps, margin, or padding. */
+--kui-space-0: 0px;
+/* 2px value for gaps, margin, or padding. */
+--kui-space-10: 2px;
+/* 4px value for gaps, margin, or padding. */
+--kui-space-20: 4px;
+/* 6px value for gaps, margin, or padding. */
+--kui-space-30: 6px;
+/* 8px value for gaps, margin, or padding. */
+--kui-space-40: 8px;
+/* 12px value for gaps, margin, or padding. */
+--kui-space-50: 12px;
+/* 16px value for gaps, margin, or padding. */
+--kui-space-60: 16px;
+/* 20px value for gaps, margin, or padding. */
+--kui-space-70: 20px;
+/* 24px value for gaps, margin, or padding. */
+--kui-space-80: 24px;
+/* 32px value for gaps, margin, or padding. */
+--kui-space-90: 32px;
+/* 40px value for gaps, margin, or padding. */
+--kui-space-100: 40px;
+/* 48px value for gaps, margin, or padding. */
+--kui-space-110: 48px;
+/* 56px value for gaps, margin, or padding. */
+--kui-space-120: 56px;
+/* 64px value for gaps, margin, or padding. */
+--kui-space-130: 64px;
+/* 80px value for gaps, margin, or padding. */
+--kui-space-140: 80px;
+/* 96px value for gaps, margin, or padding. */
+--kui-space-150: 96px;
+/* auto */
+--kui-space-auto: auto;
 ```
 
 </details>
@@ -1420,343 +2728,670 @@ You may scope your CSS custom property overrides inside the `:root` selector as 
 <summary>Click to view the list of JavaScript variables</summary>
 
 ```javascript
-export const KUI_COLOR_BACKGROUND = undefined;
-export const KUI_COLOR_BACKGROUND_DANGER = undefined;
-export const KUI_COLOR_BACKGROUND_DANGER_STRONG = undefined;
-export const KUI_COLOR_BACKGROUND_DANGER_STRONGER = undefined;
-export const KUI_COLOR_BACKGROUND_DANGER_STRONGEST = undefined;
-export const KUI_COLOR_BACKGROUND_DANGER_WEAK = undefined;
-export const KUI_COLOR_BACKGROUND_DANGER_WEAKER = undefined;
-export const KUI_COLOR_BACKGROUND_DANGER_WEAKEST = undefined;
-export const KUI_COLOR_BACKGROUND_DECORATIVE_AQUA_WEAKEST = undefined;
-export const KUI_COLOR_BACKGROUND_DECORATIVE_PURPLE = undefined;
-export const KUI_COLOR_BACKGROUND_DECORATIVE_PURPLE_WEAKEST = undefined;
-export const KUI_COLOR_BACKGROUND_DISABLED = undefined;
-export const KUI_COLOR_BACKGROUND_INFO = undefined;
-export const KUI_COLOR_BACKGROUND_INFO_STRONG = undefined;
-export const KUI_COLOR_BACKGROUND_INFO_STRONGER = undefined;
-export const KUI_COLOR_BACKGROUND_INFO_STRONGEST = undefined;
-export const KUI_COLOR_BACKGROUND_INFO_WEAK = undefined;
-export const KUI_COLOR_BACKGROUND_INFO_WEAKER = undefined;
-export const KUI_COLOR_BACKGROUND_INFO_WEAKEST = undefined;
-export const KUI_COLOR_BACKGROUND_INVERSE = undefined;
-export const KUI_COLOR_BACKGROUND_NEUTRAL = undefined;
-export const KUI_COLOR_BACKGROUND_NEUTRAL_STRONG = undefined;
-export const KUI_COLOR_BACKGROUND_NEUTRAL_STRONGER = undefined;
-export const KUI_COLOR_BACKGROUND_NEUTRAL_STRONGEST = undefined;
-export const KUI_COLOR_BACKGROUND_NEUTRAL_WEAK = undefined;
-export const KUI_COLOR_BACKGROUND_NEUTRAL_WEAKER = undefined;
-export const KUI_COLOR_BACKGROUND_NEUTRAL_WEAKEST = undefined;
-export const KUI_COLOR_BACKGROUND_OVERLAY = undefined;
-export const KUI_COLOR_BACKGROUND_PRIMARY = undefined;
-export const KUI_COLOR_BACKGROUND_PRIMARY_STRONG = undefined;
-export const KUI_COLOR_BACKGROUND_PRIMARY_STRONGER = undefined;
-export const KUI_COLOR_BACKGROUND_PRIMARY_STRONGEST = undefined;
-export const KUI_COLOR_BACKGROUND_PRIMARY_WEAK = undefined;
-export const KUI_COLOR_BACKGROUND_PRIMARY_WEAKER = undefined;
-export const KUI_COLOR_BACKGROUND_PRIMARY_WEAKEST = undefined;
-export const KUI_COLOR_BACKGROUND_SUCCESS = undefined;
-export const KUI_COLOR_BACKGROUND_SUCCESS_STRONG = undefined;
-export const KUI_COLOR_BACKGROUND_SUCCESS_STRONGER = undefined;
-export const KUI_COLOR_BACKGROUND_SUCCESS_STRONGEST = undefined;
-export const KUI_COLOR_BACKGROUND_SUCCESS_WEAK = undefined;
-export const KUI_COLOR_BACKGROUND_SUCCESS_WEAKER = undefined;
-export const KUI_COLOR_BACKGROUND_SUCCESS_WEAKEST = undefined;
-export const KUI_COLOR_BACKGROUND_TRANSPARENT = undefined;
-export const KUI_COLOR_BACKGROUND_WARNING = undefined;
-export const KUI_COLOR_BACKGROUND_WARNING_STRONG = undefined;
-export const KUI_COLOR_BACKGROUND_WARNING_STRONGER = undefined;
-export const KUI_COLOR_BACKGROUND_WARNING_STRONGEST = undefined;
-export const KUI_COLOR_BACKGROUND_WARNING_WEAK = undefined;
-export const KUI_COLOR_BACKGROUND_WARNING_WEAKER = undefined;
-export const KUI_COLOR_BACKGROUND_WARNING_WEAKEST = undefined;
-export const KUI_COLOR_BORDER = undefined;
-export const KUI_COLOR_BORDER_DANGER = undefined;
-export const KUI_COLOR_BORDER_DANGER_STRONG = undefined;
-export const KUI_COLOR_BORDER_DANGER_STRONGER = undefined;
-export const KUI_COLOR_BORDER_DANGER_STRONGEST = undefined;
-export const KUI_COLOR_BORDER_DANGER_WEAK = undefined;
-export const KUI_COLOR_BORDER_DANGER_WEAKER = undefined;
-export const KUI_COLOR_BORDER_DANGER_WEAKEST = undefined;
-export const KUI_COLOR_BORDER_DECORATIVE_PURPLE = undefined;
-export const KUI_COLOR_BORDER_DISABLED = undefined;
-export const KUI_COLOR_BORDER_INVERSE = undefined;
-export const KUI_COLOR_BORDER_NEUTRAL = undefined;
-export const KUI_COLOR_BORDER_NEUTRAL_STRONG = undefined;
-export const KUI_COLOR_BORDER_NEUTRAL_STRONGER = undefined;
-export const KUI_COLOR_BORDER_NEUTRAL_STRONGEST = undefined;
-export const KUI_COLOR_BORDER_NEUTRAL_WEAK = undefined;
-export const KUI_COLOR_BORDER_NEUTRAL_WEAKER = undefined;
-export const KUI_COLOR_BORDER_NEUTRAL_WEAKEST = undefined;
-export const KUI_COLOR_BORDER_PRIMARY = undefined;
-export const KUI_COLOR_BORDER_PRIMARY_STRONG = undefined;
-export const KUI_COLOR_BORDER_PRIMARY_STRONGER = undefined;
-export const KUI_COLOR_BORDER_PRIMARY_STRONGEST = undefined;
-export const KUI_COLOR_BORDER_PRIMARY_WEAK = undefined;
-export const KUI_COLOR_BORDER_PRIMARY_WEAKER = undefined;
-export const KUI_COLOR_BORDER_PRIMARY_WEAKEST = undefined;
-export const KUI_COLOR_BORDER_TRANSPARENT = undefined;
-export const KUI_COLOR_TEXT = undefined;
-export const KUI_COLOR_TEXT_DANGER = undefined;
-export const KUI_COLOR_TEXT_DANGER_STRONG = undefined;
-export const KUI_COLOR_TEXT_DANGER_STRONGER = undefined;
-export const KUI_COLOR_TEXT_DANGER_STRONGEST = undefined;
-export const KUI_COLOR_TEXT_DANGER_WEAK = undefined;
-export const KUI_COLOR_TEXT_DANGER_WEAKER = undefined;
-export const KUI_COLOR_TEXT_DANGER_WEAKEST = undefined;
-export const KUI_COLOR_TEXT_DECORATIVE_AQUA = undefined;
-export const KUI_COLOR_TEXT_DECORATIVE_PINK = undefined;
-export const KUI_COLOR_TEXT_DECORATIVE_PURPLE = undefined;
-export const KUI_COLOR_TEXT_DECORATIVE_PURPLE_STRONG = undefined;
-export const KUI_COLOR_TEXT_DISABLED = undefined;
-export const KUI_COLOR_TEXT_INFO = undefined;
-export const KUI_COLOR_TEXT_INFO_STRONG = undefined;
-export const KUI_COLOR_TEXT_INFO_STRONGER = undefined;
-export const KUI_COLOR_TEXT_INFO_STRONGEST = undefined;
-export const KUI_COLOR_TEXT_INFO_WEAK = undefined;
-export const KUI_COLOR_TEXT_INFO_WEAKER = undefined;
-export const KUI_COLOR_TEXT_INFO_WEAKEST = undefined;
-export const KUI_COLOR_TEXT_INVERSE = undefined;
-export const KUI_COLOR_TEXT_NEUTRAL = undefined;
-export const KUI_COLOR_TEXT_NEUTRAL_STRONG = undefined;
-export const KUI_COLOR_TEXT_NEUTRAL_STRONGER = undefined;
-export const KUI_COLOR_TEXT_NEUTRAL_STRONGEST = undefined;
-export const KUI_COLOR_TEXT_NEUTRAL_WEAK = undefined;
-export const KUI_COLOR_TEXT_NEUTRAL_WEAKER = undefined;
-export const KUI_COLOR_TEXT_NEUTRAL_WEAKEST = undefined;
-export const KUI_COLOR_TEXT_PRIMARY = undefined;
-export const KUI_COLOR_TEXT_PRIMARY_STRONG = undefined;
-export const KUI_COLOR_TEXT_PRIMARY_STRONGER = undefined;
-export const KUI_COLOR_TEXT_PRIMARY_STRONGEST = undefined;
-export const KUI_COLOR_TEXT_PRIMARY_WEAK = undefined;
-export const KUI_COLOR_TEXT_PRIMARY_WEAKER = undefined;
-export const KUI_COLOR_TEXT_PRIMARY_WEAKEST = undefined;
-export const KUI_COLOR_TEXT_SUCCESS = undefined;
-export const KUI_COLOR_TEXT_SUCCESS_STRONG = undefined;
-export const KUI_COLOR_TEXT_SUCCESS_STRONGER = undefined;
-export const KUI_COLOR_TEXT_SUCCESS_STRONGEST = undefined;
-export const KUI_COLOR_TEXT_SUCCESS_WEAK = undefined;
-export const KUI_COLOR_TEXT_SUCCESS_WEAKER = undefined;
-export const KUI_COLOR_TEXT_SUCCESS_WEAKEST = undefined;
-export const KUI_COLOR_TEXT_WARNING = undefined;
-export const KUI_COLOR_TEXT_WARNING_STRONG = undefined;
-export const KUI_COLOR_TEXT_WARNING_STRONGER = undefined;
-export const KUI_COLOR_TEXT_WARNING_STRONGEST = undefined;
-export const KUI_COLOR_TEXT_WARNING_WEAK = undefined;
-export const KUI_COLOR_TEXT_WARNING_WEAKER = undefined;
-export const KUI_COLOR_TEXT_WARNING_WEAKEST = undefined;
-export const KUI_ANIMATION_DURATION_20 = undefined;
-export const KUI_BORDER_RADIUS_0 = undefined;
-export const KUI_BORDER_RADIUS_10 = undefined;
-export const KUI_BORDER_RADIUS_20 = undefined;
-export const KUI_BORDER_RADIUS_30 = undefined;
-export const KUI_BORDER_RADIUS_40 = undefined;
-export const KUI_BORDER_RADIUS_50 = undefined;
-export const KUI_BORDER_RADIUS_CIRCLE = undefined;
-export const KUI_BORDER_RADIUS_ROUND = undefined;
-export const KUI_BORDER_WIDTH_0 = undefined;
-export const KUI_BORDER_WIDTH_10 = undefined;
-export const KUI_BORDER_WIDTH_20 = undefined;
-export const KUI_BORDER_WIDTH_30 = undefined;
-export const KUI_BREAKPOINT_MOBILE = undefined;
-export const KUI_BREAKPOINT_PHABLET = undefined;
-export const KUI_BREAKPOINT_TABLET = undefined;
-export const KUI_BREAKPOINT_LAPTOP = undefined;
-export const KUI_BREAKPOINT_DESKTOP = undefined;
-export const KUI_ICON_COLOR_DANGER = undefined;
-export const KUI_ICON_COLOR_NEUTRAL = undefined;
-export const KUI_ICON_COLOR_PRIMARY = undefined;
-export const KUI_ICON_COLOR_SUCCESS = undefined;
-export const KUI_ICON_COLOR_WARNING = undefined;
-export const KUI_ICON_SIZE_10 = undefined;
-export const KUI_ICON_SIZE_20 = undefined;
-export const KUI_ICON_SIZE_30 = undefined;
-export const KUI_ICON_SIZE_40 = undefined;
-export const KUI_ICON_SIZE_50 = undefined;
-export const KUI_ICON_SIZE_60 = undefined;
-export const KUI_ICON_SIZE_70 = undefined;
-export const KUI_ICON_SIZE_80 = undefined;
-export const KUI_METHOD_COLOR_BACKGROUND_CONNECT = undefined;
-export const KUI_METHOD_COLOR_BACKGROUND_DELETE = undefined;
-export const KUI_METHOD_COLOR_BACKGROUND_GET = undefined;
-export const KUI_METHOD_COLOR_BACKGROUND_HEAD = undefined;
-export const KUI_METHOD_COLOR_BACKGROUND_OPTIONS = undefined;
-export const KUI_METHOD_COLOR_BACKGROUND_PATCH = undefined;
-export const KUI_METHOD_COLOR_BACKGROUND_POST = undefined;
-export const KUI_METHOD_COLOR_BACKGROUND_PUT = undefined;
-export const KUI_METHOD_COLOR_BACKGROUND_TRACE = undefined;
-export const KUI_METHOD_COLOR_TEXT_CONNECT = undefined;
-export const KUI_METHOD_COLOR_TEXT_CONNECT_STRONG = undefined;
-export const KUI_METHOD_COLOR_TEXT_DELETE = undefined;
-export const KUI_METHOD_COLOR_TEXT_DELETE_STRONG = undefined;
-export const KUI_METHOD_COLOR_TEXT_GET = undefined;
-export const KUI_METHOD_COLOR_TEXT_GET_STRONG = undefined;
-export const KUI_METHOD_COLOR_TEXT_HEAD = undefined;
-export const KUI_METHOD_COLOR_TEXT_HEAD_STRONG = undefined;
-export const KUI_METHOD_COLOR_TEXT_OPTIONS = undefined;
-export const KUI_METHOD_COLOR_TEXT_OPTIONS_STRONG = undefined;
-export const KUI_METHOD_COLOR_TEXT_PATCH = undefined;
-export const KUI_METHOD_COLOR_TEXT_PATCH_STRONG = undefined;
-export const KUI_METHOD_COLOR_TEXT_POST = undefined;
-export const KUI_METHOD_COLOR_TEXT_POST_STRONG = undefined;
-export const KUI_METHOD_COLOR_TEXT_PUT = undefined;
-export const KUI_METHOD_COLOR_TEXT_PUT_STRONG = undefined;
-export const KUI_METHOD_COLOR_TEXT_TRACE = undefined;
-export const KUI_METHOD_COLOR_TEXT_TRACE_STRONG = undefined;
-export const KUI_NAVIGATION_COLOR_BACKGROUND = undefined;
-export const KUI_NAVIGATION_COLOR_BACKGROUND_SELECTED = undefined;
-export const KUI_NAVIGATION_COLOR_BORDER = undefined;
-export const KUI_NAVIGATION_COLOR_BORDER_CHILD = undefined;
-export const KUI_NAVIGATION_COLOR_BORDER_DIVIDER = undefined;
-export const KUI_NAVIGATION_COLOR_TEXT = undefined;
-export const KUI_NAVIGATION_COLOR_TEXT_FOCUS = undefined;
-export const KUI_NAVIGATION_COLOR_TEXT_HOVER = undefined;
-export const KUI_NAVIGATION_COLOR_TEXT_SELECTED = undefined;
-export const KUI_NAVIGATION_SHADOW_BORDER = undefined;
-export const KUI_NAVIGATION_SHADOW_BORDER_CHILD = undefined;
-export const KUI_NAVIGATION_SHADOW_FOCUS = undefined;
-export const KUI_STATUS_COLOR_100 = undefined;
-export const KUI_STATUS_COLOR_101 = undefined;
-export const KUI_STATUS_COLOR_102 = undefined;
-export const KUI_STATUS_COLOR_103 = undefined;
-export const KUI_STATUS_COLOR_200 = undefined;
-export const KUI_STATUS_COLOR_201 = undefined;
-export const KUI_STATUS_COLOR_202 = undefined;
-export const KUI_STATUS_COLOR_203 = undefined;
-export const KUI_STATUS_COLOR_204 = undefined;
-export const KUI_STATUS_COLOR_205 = undefined;
-export const KUI_STATUS_COLOR_206 = undefined;
-export const KUI_STATUS_COLOR_207 = undefined;
-export const KUI_STATUS_COLOR_208 = undefined;
-export const KUI_STATUS_COLOR_226 = undefined;
-export const KUI_STATUS_COLOR_300 = undefined;
-export const KUI_STATUS_COLOR_301 = undefined;
-export const KUI_STATUS_COLOR_302 = undefined;
-export const KUI_STATUS_COLOR_303 = undefined;
-export const KUI_STATUS_COLOR_304 = undefined;
-export const KUI_STATUS_COLOR_305 = undefined;
-export const KUI_STATUS_COLOR_307 = undefined;
-export const KUI_STATUS_COLOR_308 = undefined;
-export const KUI_STATUS_COLOR_400 = undefined;
-export const KUI_STATUS_COLOR_401 = undefined;
-export const KUI_STATUS_COLOR_402 = undefined;
-export const KUI_STATUS_COLOR_403 = undefined;
-export const KUI_STATUS_COLOR_404 = undefined;
-export const KUI_STATUS_COLOR_405 = undefined;
-export const KUI_STATUS_COLOR_406 = undefined;
-export const KUI_STATUS_COLOR_407 = undefined;
-export const KUI_STATUS_COLOR_408 = undefined;
-export const KUI_STATUS_COLOR_409 = undefined;
-export const KUI_STATUS_COLOR_410 = undefined;
-export const KUI_STATUS_COLOR_411 = undefined;
-export const KUI_STATUS_COLOR_412 = undefined;
-export const KUI_STATUS_COLOR_413 = undefined;
-export const KUI_STATUS_COLOR_414 = undefined;
-export const KUI_STATUS_COLOR_415 = undefined;
-export const KUI_STATUS_COLOR_416 = undefined;
-export const KUI_STATUS_COLOR_417 = undefined;
-export const KUI_STATUS_COLOR_418 = undefined;
-export const KUI_STATUS_COLOR_421 = undefined;
-export const KUI_STATUS_COLOR_422 = undefined;
-export const KUI_STATUS_COLOR_423 = undefined;
-export const KUI_STATUS_COLOR_424 = undefined;
-export const KUI_STATUS_COLOR_425 = undefined;
-export const KUI_STATUS_COLOR_426 = undefined;
-export const KUI_STATUS_COLOR_428 = undefined;
-export const KUI_STATUS_COLOR_429 = undefined;
-export const KUI_STATUS_COLOR_431 = undefined;
-export const KUI_STATUS_COLOR_451 = undefined;
-export const KUI_STATUS_COLOR_500 = undefined;
-export const KUI_STATUS_COLOR_501 = undefined;
-export const KUI_STATUS_COLOR_502 = undefined;
-export const KUI_STATUS_COLOR_503 = undefined;
-export const KUI_STATUS_COLOR_504 = undefined;
-export const KUI_STATUS_COLOR_505 = undefined;
-export const KUI_STATUS_COLOR_506 = undefined;
-export const KUI_STATUS_COLOR_507 = undefined;
-export const KUI_STATUS_COLOR_508 = undefined;
-export const KUI_STATUS_COLOR_510 = undefined;
-export const KUI_STATUS_COLOR_511 = undefined;
-export const KUI_STATUS_COLOR_1NA = undefined;
-export const KUI_STATUS_COLOR_2NA = undefined;
-export const KUI_STATUS_COLOR_3NA = undefined;
-export const KUI_STATUS_COLOR_4NA = undefined;
-export const KUI_STATUS_COLOR_5NA = undefined;
-export const KUI_STATUS_COLOR_100S = undefined;
-export const KUI_STATUS_COLOR_200S = undefined;
-export const KUI_STATUS_COLOR_300S = undefined;
-export const KUI_STATUS_COLOR_400S = undefined;
-export const KUI_STATUS_COLOR_500S = undefined;
-export const KUI_STATUS_COLOR_BACKGROUND_100 = undefined;
-export const KUI_STATUS_COLOR_BACKGROUND_200 = undefined;
-export const KUI_STATUS_COLOR_BACKGROUND_300 = undefined;
-export const KUI_STATUS_COLOR_BACKGROUND_400 = undefined;
-export const KUI_STATUS_COLOR_BACKGROUND_500 = undefined;
-export const KUI_STATUS_COLOR_TEXT_100 = undefined;
-export const KUI_STATUS_COLOR_TEXT_200 = undefined;
-export const KUI_STATUS_COLOR_TEXT_300 = undefined;
-export const KUI_STATUS_COLOR_TEXT_400 = undefined;
-export const KUI_STATUS_COLOR_TEXT_500 = undefined;
-export const KUI_FONT_FAMILY_CODE = undefined;
-export const KUI_FONT_FAMILY_HEADING = undefined;
-export const KUI_FONT_FAMILY_TEXT = undefined;
-export const KUI_FONT_SIZE_10 = undefined;
-export const KUI_FONT_SIZE_20 = undefined;
-export const KUI_FONT_SIZE_30 = undefined;
-export const KUI_FONT_SIZE_40 = undefined;
-export const KUI_FONT_SIZE_50 = undefined;
-export const KUI_FONT_SIZE_60 = undefined;
-export const KUI_FONT_SIZE_70 = undefined;
-export const KUI_FONT_SIZE_80 = undefined;
-export const KUI_FONT_SIZE_90 = undefined;
-export const KUI_FONT_SIZE_100 = undefined;
-export const KUI_FONT_WEIGHT_BOLD = undefined;
-export const KUI_FONT_WEIGHT_MEDIUM = undefined;
-export const KUI_FONT_WEIGHT_REGULAR = undefined;
-export const KUI_FONT_WEIGHT_SEMIBOLD = undefined;
-export const KUI_LETTER_SPACING_0 = undefined;
-export const KUI_LETTER_SPACING_MINUS_10 = undefined;
-export const KUI_LETTER_SPACING_MINUS_20 = undefined;
-export const KUI_LETTER_SPACING_MINUS_30 = undefined;
-export const KUI_LETTER_SPACING_MINUS_40 = undefined;
-export const KUI_LETTER_SPACING_MINUS_50 = undefined;
-export const KUI_LETTER_SPACING_NORMAL = undefined;
-export const KUI_LINE_HEIGHT_10 = undefined;
-export const KUI_LINE_HEIGHT_20 = undefined;
-export const KUI_LINE_HEIGHT_30 = undefined;
-export const KUI_LINE_HEIGHT_40 = undefined;
-export const KUI_LINE_HEIGHT_50 = undefined;
-export const KUI_LINE_HEIGHT_60 = undefined;
-export const KUI_LINE_HEIGHT_70 = undefined;
-export const KUI_LINE_HEIGHT_80 = undefined;
-export const KUI_LINE_HEIGHT_90 = undefined;
-export const KUI_LINE_HEIGHT_100 = undefined;
-export const KUI_SHADOW = undefined;
-export const KUI_SHADOW_BORDER = undefined;
-export const KUI_SHADOW_BORDER_DANGER = undefined;
-export const KUI_SHADOW_BORDER_DANGER_STRONG = undefined;
-export const KUI_SHADOW_BORDER_DISABLED = undefined;
-export const KUI_SHADOW_BORDER_PRIMARY = undefined;
-export const KUI_SHADOW_BORDER_PRIMARY_STRONGEST = undefined;
-export const KUI_SHADOW_BORDER_PRIMARY_WEAK = undefined;
-export const KUI_SHADOW_FOCUS = undefined;
-export const KUI_SPACE_0 = undefined;
-export const KUI_SPACE_10 = undefined;
-export const KUI_SPACE_20 = undefined;
-export const KUI_SPACE_30 = undefined;
-export const KUI_SPACE_40 = undefined;
-export const KUI_SPACE_50 = undefined;
-export const KUI_SPACE_60 = undefined;
-export const KUI_SPACE_70 = undefined;
-export const KUI_SPACE_80 = undefined;
-export const KUI_SPACE_90 = undefined;
-export const KUI_SPACE_100 = undefined;
-export const KUI_SPACE_110 = undefined;
-export const KUI_SPACE_120 = undefined;
-export const KUI_SPACE_130 = undefined;
-export const KUI_SPACE_140 = undefined;
-export const KUI_SPACE_150 = undefined;
-export const KUI_SPACE_AUTO = undefined;
+/* Default background color for containers (white). */
+export const KUI_COLOR_BACKGROUND = "#ffffff";
+/* Background color for danger actions or messages (red.60). */
+export const KUI_COLOR_BACKGROUND_DANGER = "#d60027";
+/* Strong background color for danger actions or messages (red.70). */
+export const KUI_COLOR_BACKGROUND_DANGER_STRONG = "#ad000e";
+/* Stronger background color for danger actions or messages (red.80). */
+export const KUI_COLOR_BACKGROUND_DANGER_STRONGER = "#850000";
+/* Strongest background color for danger actions or messages (red.90). */
+export const KUI_COLOR_BACKGROUND_DANGER_STRONGEST = "#5c0000";
+/* Weak background color for danger actions or messages (red.40). */
+export const KUI_COLOR_BACKGROUND_DANGER_WEAK = "#ff3954";
+/* Weaker background color for danger actions or messages (red.20). */
+export const KUI_COLOR_BACKGROUND_DANGER_WEAKER = "#ffabab";
+/* Weakest background color for danger actions or messages (red.10). */
+export const KUI_COLOR_BACKGROUND_DANGER_WEAKEST = "#ffe5e5";
+/* Weakest background color for decorative purposes (aqua.10). */
+export const KUI_COLOR_BACKGROUND_DECORATIVE_AQUA_WEAKEST = "#ecfcff";
+/* Background color for decorative purposes (purple.60). */
+export const KUI_COLOR_BACKGROUND_DECORATIVE_PURPLE = "#6f28ff";
+/* Weakest background color for decorative purposes (purple.10). */
+export const KUI_COLOR_BACKGROUND_DECORATIVE_PURPLE_WEAKEST = "#f1f0ff";
+/* Background color for disabled elements (gray.20). */
+export const KUI_COLOR_BACKGROUND_DISABLED = "#e0e4ea";
+/* Background color for info elements (blue.60). */
+export const KUI_COLOR_BACKGROUND_INFO = "#0044f4";
+/* Strong background color for info elements (blue.70). */
+export const KUI_COLOR_BACKGROUND_INFO_STRONG = "#0030cc";
+/* Stronger background color for info elements (blue.80). */
+export const KUI_COLOR_BACKGROUND_INFO_STRONGER = "#002099";
+/* Strongest background color for info elements (blue.90). */
+export const KUI_COLOR_BACKGROUND_INFO_STRONGEST = "#001466";
+/* Weak background color for info elements (blue.40). */
+export const KUI_COLOR_BACKGROUND_INFO_WEAK = "#5f9aff";
+/* Weaker background color for info elements (blue.20). */
+export const KUI_COLOR_BACKGROUND_INFO_WEAKER = "#bee2ff";
+/* Weakest background color for info elements (blue.10). */
+export const KUI_COLOR_BACKGROUND_INFO_WEAKEST = "#eefaff";
+/* Inverse background color for containers (blue.100) */
+export const KUI_COLOR_BACKGROUND_INVERSE = "#000933";
+/* Background color for neutral elements (gray.60). */
+export const KUI_COLOR_BACKGROUND_NEUTRAL = "#6c7489";
+/* Strong background color for neutral elements (gray.70). */
+export const KUI_COLOR_BACKGROUND_NEUTRAL_STRONG = "#52596e";
+/* Stronger background color for neutral elements (gray.80). */
+export const KUI_COLOR_BACKGROUND_NEUTRAL_STRONGER = "#3a3f51";
+/* Strongest background color for neutral elements (gray.90). */
+export const KUI_COLOR_BACKGROUND_NEUTRAL_STRONGEST = "#232633";
+/* Weak background color for neutral elements (gray.40). */
+export const KUI_COLOR_BACKGROUND_NEUTRAL_WEAK = "#afb7c5";
+/* Weaker background color for neutral elements (gray.20). */
+export const KUI_COLOR_BACKGROUND_NEUTRAL_WEAKER = "#e0e4ea";
+/* Weakest background color for neutral elements (gray.10). */
+export const KUI_COLOR_BACKGROUND_NEUTRAL_WEAKEST = "#f9fafb";
+/* Overlay background color (rgba(0, 9, 51, 0.6)) */
+export const KUI_COLOR_BACKGROUND_OVERLAY = "rgba(0, 9, 51, 0.6)";
+/* Background color for primary actions or messages (blue.60). */
+export const KUI_COLOR_BACKGROUND_PRIMARY = "#0044f4";
+/* Strong background color for primary actions or messages (blue.70). */
+export const KUI_COLOR_BACKGROUND_PRIMARY_STRONG = "#0030cc";
+/* Stronger background color for primary actions or messages (blue.80). */
+export const KUI_COLOR_BACKGROUND_PRIMARY_STRONGER = "#002099";
+/* Strongest background color for primary actions or messages (blue.90). */
+export const KUI_COLOR_BACKGROUND_PRIMARY_STRONGEST = "#001466";
+/* Weak background color for primary actions or messages (blue.40). */
+export const KUI_COLOR_BACKGROUND_PRIMARY_WEAK = "#5f9aff";
+/* Weaker background color for primary actions or messages (blue.20). */
+export const KUI_COLOR_BACKGROUND_PRIMARY_WEAKER = "#bee2ff";
+/* Weakest background color for primary actions or messages (blue.10) */
+export const KUI_COLOR_BACKGROUND_PRIMARY_WEAKEST = "#eefaff";
+/* Background color for success elements (green.60). */
+export const KUI_COLOR_BACKGROUND_SUCCESS = "#007d60";
+/* Strong background color for success elements (green.70). */
+export const KUI_COLOR_BACKGROUND_SUCCESS_STRONG = "#005944";
+/* Stronger background color for success elements (green.80). */
+export const KUI_COLOR_BACKGROUND_SUCCESS_STRONGER = "#004737";
+/* Strongest background color for success elements (green.90). */
+export const KUI_COLOR_BACKGROUND_SUCCESS_STRONGEST = "#003629";
+/* Weak background color for success elements (green.40). */
+export const KUI_COLOR_BACKGROUND_SUCCESS_WEAK = "#00d6a4";
+/* Weaker background color for success elements (green.20). */
+export const KUI_COLOR_BACKGROUND_SUCCESS_WEAKER = "#b5ffee";
+/* Weakest background color for success elements (green.10). */
+export const KUI_COLOR_BACKGROUND_SUCCESS_WEAKEST = "#ecfffb";
+/* Transparent background color (transparent). */
+export const KUI_COLOR_BACKGROUND_TRANSPARENT = "transparent";
+/* Background color for warning elements (yellow.60). */
+export const KUI_COLOR_BACKGROUND_WARNING = "#995c00";
+/* Strong background color for warning elements (yellow.70). */
+export const KUI_COLOR_BACKGROUND_WARNING_STRONG = "#804400";
+/* Stronger background color for warning elements (yellow.80). */
+export const KUI_COLOR_BACKGROUND_WARNING_STRONGER = "#662d00";
+/* Strongest background color for warning elements (yellow.90). */
+export const KUI_COLOR_BACKGROUND_WARNING_STRONGEST = "#4d1b00";
+/* Weak background color for warning elements (yellow.40). */
+export const KUI_COLOR_BACKGROUND_WARNING_WEAK = "#ffc400";
+/* Weaker background color for warning elements (yellow.20). */
+export const KUI_COLOR_BACKGROUND_WARNING_WEAKER = "#fff296";
+/* Weakest background color for warning elements (yellow.10). */
+export const KUI_COLOR_BACKGROUND_WARNING_WEAKEST = "#fffce0";
+/* Default border color for containers (gray.20). */
+export const KUI_COLOR_BORDER = "#e0e4ea";
+/* Border color for danger actions or messages (red.60). */
+export const KUI_COLOR_BORDER_DANGER = "#d60027";
+/* Strong border color for danger actions or messages (red.70). */
+export const KUI_COLOR_BORDER_DANGER_STRONG = "#ad000e";
+/* Stronger border color for danger actions or messages (red.80). */
+export const KUI_COLOR_BORDER_DANGER_STRONGER = "#850000";
+/* Strongest border color for danger actions or messages (red.90). */
+export const KUI_COLOR_BORDER_DANGER_STRONGEST = "#5c0000";
+/* Weak border color for danger actions or messages (red.40). */
+export const KUI_COLOR_BORDER_DANGER_WEAK = "#ff3954";
+/* Weaker border color for danger actions or messages (red.20). */
+export const KUI_COLOR_BORDER_DANGER_WEAKER = "#ffabab";
+/* Weakest border color for danger actions or messages (red.10). */
+export const KUI_COLOR_BORDER_DANGER_WEAKEST = "#ffe5e5";
+/* Border color for decorative purposes (purple.60). */
+export const KUI_COLOR_BORDER_DECORATIVE_PURPLE = "#6f28ff";
+/* Border color for disabled elements (gray.20). */
+export const KUI_COLOR_BORDER_DISABLED = "#e0e4ea";
+/* Inverse border color (rgba(255, 255, 255, 0.2)). */
+export const KUI_COLOR_BORDER_INVERSE = "rgba(255, 255, 255, 0.2)";
+/* Border color for neutral elements (gray.60) */
+export const KUI_COLOR_BORDER_NEUTRAL = "#6c7489";
+/* Strong border color for neutral elements (gray.70) */
+export const KUI_COLOR_BORDER_NEUTRAL_STRONG = "#52596e";
+/* Stronger border color for neutral elements (gray.80) */
+export const KUI_COLOR_BORDER_NEUTRAL_STRONGER = "#3a3f51";
+/* Strongest border color for neutral elements (gray.90) */
+export const KUI_COLOR_BORDER_NEUTRAL_STRONGEST = "#232633";
+/* Weak border color for neutral elements (gray.40) */
+export const KUI_COLOR_BORDER_NEUTRAL_WEAK = "#afb7c5";
+/* Weaker border color for neutral elements (gray.20) */
+export const KUI_COLOR_BORDER_NEUTRAL_WEAKER = "#e0e4ea";
+/* Weakest border color for neutral elements (gray.10) */
+export const KUI_COLOR_BORDER_NEUTRAL_WEAKEST = "#f9fafb";
+/* Border color for primary actions or messages (blue.60). */
+export const KUI_COLOR_BORDER_PRIMARY = "#0044f4";
+/* Strong border color for primary actions or messages (blue.70). */
+export const KUI_COLOR_BORDER_PRIMARY_STRONG = "#0030cc";
+/* Stronger border color for primary actions or messages (blue.80). */
+export const KUI_COLOR_BORDER_PRIMARY_STRONGER = "#002099";
+/* Strongest border color for primary actions or messages (blue.90). */
+export const KUI_COLOR_BORDER_PRIMARY_STRONGEST = "#001466";
+/* Weak border color for primary actions or messages (blue.40). */
+export const KUI_COLOR_BORDER_PRIMARY_WEAK = "#5f9aff";
+/* Weaker border color for primary actions or messages (blue.20). */
+export const KUI_COLOR_BORDER_PRIMARY_WEAKER = "#bee2ff";
+/* Weakest border color for primary actions or messages (blue.10). */
+export const KUI_COLOR_BORDER_PRIMARY_WEAKEST = "#eefaff";
+/* Transparent border color (transparent). */
+export const KUI_COLOR_BORDER_TRANSPARENT = "transparent";
+/* Default text color (blue.100). */
+export const KUI_COLOR_TEXT = "#000933";
+/* Text color for danger actions or messages (red.60). */
+export const KUI_COLOR_TEXT_DANGER = "#d60027";
+/* Strong text color for danger actions or messages (red.70). */
+export const KUI_COLOR_TEXT_DANGER_STRONG = "#ad000e";
+/* Stronger text color for danger actions or messages (red.80). */
+export const KUI_COLOR_TEXT_DANGER_STRONGER = "#850000";
+/* Strongest text color for danger actions or messages (red.90). */
+export const KUI_COLOR_TEXT_DANGER_STRONGEST = "#5c0000";
+/* Weak text color for danger actions or messages (red.40). */
+export const KUI_COLOR_TEXT_DANGER_WEAK = "#ff3954";
+/* Weaker text color for danger actions or messages (red.20). */
+export const KUI_COLOR_TEXT_DANGER_WEAKER = "#ffabab";
+/* Weakest text color for danger actions or messages (red.10). */
+export const KUI_COLOR_TEXT_DANGER_WEAKEST = "#ffe5e5";
+/* Text color for decorative purposes (aqua.50). */
+export const KUI_COLOR_TEXT_DECORATIVE_AQUA = "#00abd2";
+/* Text color for decorative purposes (pink.60). */
+export const KUI_COLOR_TEXT_DECORATIVE_PINK = "#d60067";
+/* Text color for decorative purposes (purple.60). */
+export const KUI_COLOR_TEXT_DECORATIVE_PURPLE = "#6f28ff";
+/* Strong text color for decorative purposes (purple.70). */
+export const KUI_COLOR_TEXT_DECORATIVE_PURPLE_STRONG = "#5e00f5";
+/* Text color for disabled elements (gray.40). */
+export const KUI_COLOR_TEXT_DISABLED = "#afb7c5";
+/* Text color for info elements (blue.60). */
+export const KUI_COLOR_TEXT_INFO = "#0044f4";
+/* Strong text color for info elements (blue.70). */
+export const KUI_COLOR_TEXT_INFO_STRONG = "#0030cc";
+/* Stronger text color for info elements (blue.80). */
+export const KUI_COLOR_TEXT_INFO_STRONGER = "#002099";
+/* Strongest text color for info elements (blue.90). */
+export const KUI_COLOR_TEXT_INFO_STRONGEST = "#001466";
+/* Weak text color for info elements (blue.40). */
+export const KUI_COLOR_TEXT_INFO_WEAK = "#5f9aff";
+/* Weaker text color for info elements (blue.20). */
+export const KUI_COLOR_TEXT_INFO_WEAKER = "#bee2ff";
+/* Weakest text color for info elements (blue.10). */
+export const KUI_COLOR_TEXT_INFO_WEAKEST = "#eefaff";
+/* Inverse text color (white). */
+export const KUI_COLOR_TEXT_INVERSE = "#ffffff";
+/* Text color for neutral elements (gray.60). */
+export const KUI_COLOR_TEXT_NEUTRAL = "#6c7489";
+/* Strong text color for neutral elements (gray.70). */
+export const KUI_COLOR_TEXT_NEUTRAL_STRONG = "#52596e";
+/* Stronger text color for neutral elements (gray.80). */
+export const KUI_COLOR_TEXT_NEUTRAL_STRONGER = "#3a3f51";
+/* Strongest text color for neutral elements (gray.90). */
+export const KUI_COLOR_TEXT_NEUTRAL_STRONGEST = "#232633";
+/* Weak text color for neutral elements (gray.40). */
+export const KUI_COLOR_TEXT_NEUTRAL_WEAK = "#afb7c5";
+/* Weaker text color for neutral elements (gray.20). */
+export const KUI_COLOR_TEXT_NEUTRAL_WEAKER = "#e0e4ea";
+/* Weakest text color for neutral elements (gray.10). */
+export const KUI_COLOR_TEXT_NEUTRAL_WEAKEST = "#f9fafb";
+/* Text color for primary actions or messages (blue.60). */
+export const KUI_COLOR_TEXT_PRIMARY = "#0044f4";
+/* Strong text color for primary actions or messages (blue.70). */
+export const KUI_COLOR_TEXT_PRIMARY_STRONG = "#0030cc";
+/* Stronger text color for primary actions or messages (blue.80). */
+export const KUI_COLOR_TEXT_PRIMARY_STRONGER = "#002099";
+/* Strongest text color for primary actions or messages (blue.90). */
+export const KUI_COLOR_TEXT_PRIMARY_STRONGEST = "#001466";
+/* Weak text color for primary actions or messages (blue.40). */
+export const KUI_COLOR_TEXT_PRIMARY_WEAK = "#5f9aff";
+/* Weaker text color for primary actions or messages (blue.20). */
+export const KUI_COLOR_TEXT_PRIMARY_WEAKER = "#bee2ff";
+/* Weakest text color for primary actions or messages (blue.10). */
+export const KUI_COLOR_TEXT_PRIMARY_WEAKEST = "#eefaff";
+/* Text color for success elements (green.60). */
+export const KUI_COLOR_TEXT_SUCCESS = "#007d60";
+/* Strong text color for success elements (green.70). */
+export const KUI_COLOR_TEXT_SUCCESS_STRONG = "#005944";
+/* Stronger text color for success elements (green.80). */
+export const KUI_COLOR_TEXT_SUCCESS_STRONGER = "#004737";
+/* Stronger text color for success elements (green.90). */
+export const KUI_COLOR_TEXT_SUCCESS_STRONGEST = "#003629";
+/* Weak text color for success elements (green.40). */
+export const KUI_COLOR_TEXT_SUCCESS_WEAK = "#00d6a4";
+/* Weaker text color for success elements (green.20). */
+export const KUI_COLOR_TEXT_SUCCESS_WEAKER = "#b5ffee";
+/* Weakest text color for success elements (green.10). */
+export const KUI_COLOR_TEXT_SUCCESS_WEAKEST = "#ecfffb";
+/* Text color for warning elements (yellow.60). */
+export const KUI_COLOR_TEXT_WARNING = "#995c00";
+/* Strong text color for warning elements (yellow.70). */
+export const KUI_COLOR_TEXT_WARNING_STRONG = "#804400";
+/* Stronger text color for warning elements (yellow.80). */
+export const KUI_COLOR_TEXT_WARNING_STRONGER = "#662d00";
+/* Strongest text color for warning elements (yellow.90). */
+export const KUI_COLOR_TEXT_WARNING_STRONGEST = "#4d1b00";
+/* Weak text color for warning elements (yellow.40). */
+export const KUI_COLOR_TEXT_WARNING_WEAK = "#ffc400";
+/* Weaker text color for warning elements (yellow.20). */
+export const KUI_COLOR_TEXT_WARNING_WEAKER = "#fff296";
+/* Weakest text color for warning elements (yellow.10). */
+export const KUI_COLOR_TEXT_WARNING_WEAKEST = "#fffce0";
+/* Default transition timing */
+export const KUI_ANIMATION_DURATION_20 = "0.2s";
+/* 0px border radius. */
+export const KUI_BORDER_RADIUS_0 = "0px";
+/* 2px border radius. */
+export const KUI_BORDER_RADIUS_10 = "2px";
+/* 4px border radius. */
+export const KUI_BORDER_RADIUS_20 = "4px";
+/* 6px border radius. */
+export const KUI_BORDER_RADIUS_30 = "6px";
+/* 8px border radius. */
+export const KUI_BORDER_RADIUS_40 = "8px";
+/* 10px border radius. */
+export const KUI_BORDER_RADIUS_50 = "10px";
+/* 50% border radius used to create circles. */
+export const KUI_BORDER_RADIUS_CIRCLE = "50%";
+/* 100px border radius used to create pill shapes. */
+export const KUI_BORDER_RADIUS_ROUND = "100px";
+/* 0px border width. */
+export const KUI_BORDER_WIDTH_0 = "0px";
+/* 1px border width. */
+export const KUI_BORDER_WIDTH_10 = "1px";
+/* 2px border width. */
+export const KUI_BORDER_WIDTH_20 = "2px";
+/* 4px border width. */
+export const KUI_BORDER_WIDTH_30 = "4px";
+/* Used for larger mobile screens. Any viewport width under this value is considered mobile. */
+export const KUI_BREAKPOINT_MOBILE = "640px";
+/* Used for tablet screens. */
+export const KUI_BREAKPOINT_PHABLET = "768px";
+/* Used for larger tablet screens. Any viewport width less than this value will likely show a mobile layout. Any viewport width this value and greater will likely show a desktop layout. */
+export const KUI_BREAKPOINT_TABLET = "1024px";
+/* Used for standard desktop screens. */
+export const KUI_BREAKPOINT_LAPTOP = "1280px";
+/* Used for larger desktop screens. */
+export const KUI_BREAKPOINT_DESKTOP = "1536px";
+/* Danger color for icons. */
+export const KUI_ICON_COLOR_DANGER = "#f50045";
+/* Neutral color for icons. */
+export const KUI_ICON_COLOR_NEUTRAL = "#828a9e";
+/* Primary color for icons. */
+export const KUI_ICON_COLOR_PRIMARY = "#306fff";
+/* Success color for icons. */
+export const KUI_ICON_COLOR_SUCCESS = "#00a17b";
+/* Warning color for icons. */
+export const KUI_ICON_COLOR_WARNING = "#ffc400";
+/* 10px icon size. */
+export const KUI_ICON_SIZE_10 = "10px";
+/* 12px icon size. */
+export const KUI_ICON_SIZE_20 = "12px";
+/* 16px icon size. */
+export const KUI_ICON_SIZE_30 = "16px";
+/* 20px icon size. */
+export const KUI_ICON_SIZE_40 = "20px";
+/* 24px icon size (default). */
+export const KUI_ICON_SIZE_50 = "24px";
+/* 32px icon size. */
+export const KUI_ICON_SIZE_60 = "32px";
+/* 40px icon size. */
+export const KUI_ICON_SIZE_70 = "40px";
+/* 48px icon size. */
+export const KUI_ICON_SIZE_80 = "48px";
+/* Background color for the CONNECT method (purple.10). */
+export const KUI_METHOD_COLOR_BACKGROUND_CONNECT = "#f1f0ff";
+/* Background color for the DELETE method (red.10). */
+export const KUI_METHOD_COLOR_BACKGROUND_DELETE = "#ffe5e5";
+/* Background color for the GET method (blue.10). */
+export const KUI_METHOD_COLOR_BACKGROUND_GET = "#eefaff";
+/* Background color for the HEAD method (gray.70). */
+export const KUI_METHOD_COLOR_BACKGROUND_HEAD = "#52596e";
+/* Background color for the OPTIONS method (gray.20). */
+export const KUI_METHOD_COLOR_BACKGROUND_OPTIONS = "#e0e4ea";
+/* Background color for the PATCH method (aqua.10). */
+export const KUI_METHOD_COLOR_BACKGROUND_PATCH = "#ecfcff";
+/* Background color for the POST method (green.10). */
+export const KUI_METHOD_COLOR_BACKGROUND_POST = "#ecfffb";
+/* Background color for the PUT method (yellow.10). */
+export const KUI_METHOD_COLOR_BACKGROUND_PUT = "#fffce0";
+/* Background color for the TRACE method (pink.10). */
+export const KUI_METHOD_COLOR_BACKGROUND_TRACE = "#fff0f7";
+/* Text color for the CONNECT method (purple.60). */
+export const KUI_METHOD_COLOR_TEXT_CONNECT = "#6f28ff";
+/* Strong text color for the CONNECT method (purple.70). */
+export const KUI_METHOD_COLOR_TEXT_CONNECT_STRONG = "#5e00f5";
+/* Text color for the DELETE method (red.60). */
+export const KUI_METHOD_COLOR_TEXT_DELETE = "#d60027";
+/* Strong text color for the DELETE method (red.70). */
+export const KUI_METHOD_COLOR_TEXT_DELETE_STRONG = "#ad000e";
+/* Text color for the GET method (blue.60). */
+export const KUI_METHOD_COLOR_TEXT_GET = "#0044f4";
+/* Strong text color for the GET method (blue.70). */
+export const KUI_METHOD_COLOR_TEXT_GET_STRONG = "#0030cc";
+/* Text color for the HEAD method (gray.20). */
+export const KUI_METHOD_COLOR_TEXT_HEAD = "#e0e4ea";
+/* Strong text color for the HEAD method (gray.40). */
+export const KUI_METHOD_COLOR_TEXT_HEAD_STRONG = "#afb7c5";
+/* Text color for the OPTIONS method (gray.70). */
+export const KUI_METHOD_COLOR_TEXT_OPTIONS = "#52596e";
+/* Strong text color for the OPTIONS method (gray.80). */
+export const KUI_METHOD_COLOR_TEXT_OPTIONS_STRONG = "#3a3f51";
+/* Text color for the PATCH method (aqua.60). */
+export const KUI_METHOD_COLOR_TEXT_PATCH = "#00819d";
+/* Strong text color for the PATCH method (aqua.70). */
+export const KUI_METHOD_COLOR_TEXT_PATCH_STRONG = "#00647a";
+/* Text color for the POST method (green.60). */
+export const KUI_METHOD_COLOR_TEXT_POST = "#007d60";
+/* Strong text color for the POST method (green.70). */
+export const KUI_METHOD_COLOR_TEXT_POST_STRONG = "#005944";
+/* Text color for the PUT method (yellow.60). */
+export const KUI_METHOD_COLOR_TEXT_PUT = "#995c00";
+/* Strong text color for the PUT method (yellow.70). */
+export const KUI_METHOD_COLOR_TEXT_PUT_STRONG = "#804400";
+/* Text color for the TRACE method (pink.60). */
+export const KUI_METHOD_COLOR_TEXT_TRACE = "#d60067";
+/* Strong text color for the TRACE method (pink.70). */
+export const KUI_METHOD_COLOR_TEXT_TRACE_STRONG = "#ad0053";
+/* blue.100 */
+export const KUI_NAVIGATION_COLOR_BACKGROUND = "#000933";
+/* The background color of a selected navigation item. */
+export const KUI_NAVIGATION_COLOR_BACKGROUND_SELECTED = "rgba(255, 255, 255, 0.12)";
+/* rgba(255, 255, 255, 0.12) */
+export const KUI_NAVIGATION_COLOR_BORDER = "rgba(255, 255, 255, 0.12)";
+/* The border color for a selected child navigation item. */
+export const KUI_NAVIGATION_COLOR_BORDER_CHILD = "#00fabe";
+/* The color of the navigation section divider. */
+export const KUI_NAVIGATION_COLOR_BORDER_DIVIDER = "rgba(255, 255, 255, 0.24)";
+/* Navigation link and icon color. */
+export const KUI_NAVIGATION_COLOR_TEXT = "#bee2ff";
+/* Navigation link and icon focus-visible color. */
+export const KUI_NAVIGATION_COLOR_TEXT_FOCUS = "#ffffff";
+/* Navigation link and icon hover color. */
+export const KUI_NAVIGATION_COLOR_TEXT_HOVER = "#eefaff";
+/* Navigation link and icon selected color. */
+export const KUI_NAVIGATION_COLOR_TEXT_SELECTED = "#00fabe";
+/* The box-shadow for a focus-visible navigation link. */
+export const KUI_NAVIGATION_SHADOW_BORDER = "0 0 0 1px rgba(255, 255, 255, 0.12) inset";
+/* The left box-shadow for an active child navigation link. */
+export const KUI_NAVIGATION_SHADOW_BORDER_CHILD = "4px 0 0 0 #00fabe inset";
+/* Navigation link focus-visible box-shadow. */
+export const KUI_NAVIGATION_SHADOW_FOCUS = "0 0 0 1px rgba(255, 255, 255, 0.60) inset";
+/* Color representing response status code 100 (blue.20). */
+export const KUI_STATUS_COLOR_100 = "#bee2ff";
+/* Color representing response status code 101 (blue.30). */
+export const KUI_STATUS_COLOR_101 = "#8fc1ff";
+/* Color representing response status code 102 (blue.40). */
+export const KUI_STATUS_COLOR_102 = "#5f9aff";
+/* Color representing response status code 103 (blue.50). */
+export const KUI_STATUS_COLOR_103 = "#306fff";
+/* Color representing response status code 200 (green.20). */
+export const KUI_STATUS_COLOR_200 = "#b5ffee";
+/* Color representing response status code 201 (green.30). */
+export const KUI_STATUS_COLOR_201 = "#00fabe";
+/* Color representing response status code 202 (green.40). */
+export const KUI_STATUS_COLOR_202 = "#00d6a4";
+/* Color representing response status code 203 (green.50). */
+export const KUI_STATUS_COLOR_203 = "#00a17b";
+/* Color representing response status code 204 (green.60). */
+export const KUI_STATUS_COLOR_204 = "#007d60";
+/* Color representing response status code 205 (green.70). */
+export const KUI_STATUS_COLOR_205 = "#005944";
+/* Color representing response status code 206 (green.20). */
+export const KUI_STATUS_COLOR_206 = "#b5ffee";
+/* Color representing response status code 207 (green.30). */
+export const KUI_STATUS_COLOR_207 = "#00fabe";
+/* Color representing response status code 208 (green.40). */
+export const KUI_STATUS_COLOR_208 = "#b5ffee";
+/* Color representing response status code 226 (green.50). */
+export const KUI_STATUS_COLOR_226 = "#00a17b";
+/* Color representing response status code 100 (yellow.20). */
+export const KUI_STATUS_COLOR_300 = "#fff296";
+/* Color representing response status code 101 (yellow.30). */
+export const KUI_STATUS_COLOR_301 = "#ffe04b";
+/* Color representing response status code 102 (yellow.40). */
+export const KUI_STATUS_COLOR_302 = "#ffc400";
+/* Color representing response status code 103 (yellow.50). */
+export const KUI_STATUS_COLOR_303 = "#b37600";
+/* Color representing response status code 103 (yellow.60). */
+export const KUI_STATUS_COLOR_304 = "#995c00";
+/* Color representing response status code 103 (yellow.70). */
+export const KUI_STATUS_COLOR_305 = "#804400";
+/* Color representing response status code 103 (yellow.20). */
+export const KUI_STATUS_COLOR_307 = "#fff296";
+/* Color representing response status code 103 (yellow.30). */
+export const KUI_STATUS_COLOR_308 = "#ffe04b";
+/* Color representing response status code 400 (orange.20). */
+export const KUI_STATUS_COLOR_400 = "#FFC2B3";
+/* Color representing response status code 401 (orange.30). */
+export const KUI_STATUS_COLOR_401 = "#FF9877";
+/* Color representing response status code 402 (orange.40). */
+export const KUI_STATUS_COLOR_402 = "#FF723C";
+/* Color representing response status code 403 (orange.50). */
+export const KUI_STATUS_COLOR_403 = "#F75008";
+/* Color representing response status code 404 (orange.60). */
+export const KUI_STATUS_COLOR_404 = "#D13500";
+/* Color representing response status code 405 (orange.70). */
+export const KUI_STATUS_COLOR_405 = "#A31F00";
+/* Color representing response status code 406 (orange.20). */
+export const KUI_STATUS_COLOR_406 = "#FFC2B3";
+/* Color representing response status code 407 (orange.30). */
+export const KUI_STATUS_COLOR_407 = "#FF9877";
+/* Color representing response status code 408 (orange.40). */
+export const KUI_STATUS_COLOR_408 = "#FF723C";
+/* Color representing response status code 409 (orange.50). */
+export const KUI_STATUS_COLOR_409 = "#F75008";
+/* Color representing response status code 410 (orange.60). */
+export const KUI_STATUS_COLOR_410 = "#D13500";
+/* Color representing response status code 411 (orange.70). */
+export const KUI_STATUS_COLOR_411 = "#A31F00";
+/* Color representing response status code 412 (orange.20). */
+export const KUI_STATUS_COLOR_412 = "#FFC2B3";
+/* Color representing response status code 413 (orange.30). */
+export const KUI_STATUS_COLOR_413 = "#FF9877";
+/* Color representing response status code 414 (orange.40). */
+export const KUI_STATUS_COLOR_414 = "#FF723C";
+/* Color representing response status code 415 (orange.50). */
+export const KUI_STATUS_COLOR_415 = "#F75008";
+/* Color representing response status code 416 (orange.60). */
+export const KUI_STATUS_COLOR_416 = "#D13500";
+/* Color representing response status code 417 (orange.70). */
+export const KUI_STATUS_COLOR_417 = "#A31F00";
+/* Color representing response status code 418 (orange.20). */
+export const KUI_STATUS_COLOR_418 = "#FFC2B3";
+/* Color representing response status code 421 (orange.30). */
+export const KUI_STATUS_COLOR_421 = "#FF9877";
+/* Color representing response status code 422 (orange.40). */
+export const KUI_STATUS_COLOR_422 = "#FF723C";
+/* Color representing response status code 423 (orange.50). */
+export const KUI_STATUS_COLOR_423 = "#F75008";
+/* Color representing response status code 424 (orange.60). */
+export const KUI_STATUS_COLOR_424 = "#D13500";
+/* Color representing response status code 425 (orange.70). */
+export const KUI_STATUS_COLOR_425 = "#A31F00";
+/* Color representing response status code 426 (orange.20). */
+export const KUI_STATUS_COLOR_426 = "#FFC2B3";
+/* Color representing response status code 428 (orange.30). */
+export const KUI_STATUS_COLOR_428 = "#FF9877";
+/* Color representing response status code 429 (orange.40). */
+export const KUI_STATUS_COLOR_429 = "#FF723C";
+/* Color representing response status code 431 (orange.50). */
+export const KUI_STATUS_COLOR_431 = "#F75008";
+/* Color representing response status code 451 (orange.60). */
+export const KUI_STATUS_COLOR_451 = "#D13500";
+/* Color representing response status code 500 (red.20). */
+export const KUI_STATUS_COLOR_500 = "#ffabab";
+/* Color representing response status code 501 (red.30). */
+export const KUI_STATUS_COLOR_501 = "#ff7272";
+/* Color representing response status code 502 (red.40). */
+export const KUI_STATUS_COLOR_502 = "#ff3954";
+/* Color representing response status code 503 (red.50). */
+export const KUI_STATUS_COLOR_503 = "#f50045";
+/* Color representing response status code 504 (red.60). */
+export const KUI_STATUS_COLOR_504 = "#d60027";
+/* Color representing response status code 505 (red.70). */
+export const KUI_STATUS_COLOR_505 = "#ad000e";
+/* Color representing response status code 506 (red.20). */
+export const KUI_STATUS_COLOR_506 = "#ffabab";
+/* Color representing response status code 507 (red.30). */
+export const KUI_STATUS_COLOR_507 = "#ff7272";
+/* Color representing response status code 508 (red.40). */
+export const KUI_STATUS_COLOR_508 = "#ff3954";
+/* Color representing response status code 510 (red.50). */
+export const KUI_STATUS_COLOR_510 = "#f50045";
+/* Color representing response status code 511 (red.60). */
+export const KUI_STATUS_COLOR_511 = "#d60027";
+/* Color for unknown response status codes in the 100-199 range (blue.10). */
+export const KUI_STATUS_COLOR_1NA = "#eefaff";
+/* Color for unknown response status codes in the 200-299 range (green.10). */
+export const KUI_STATUS_COLOR_2NA = "#ecfffb";
+/* Color for unknown response status codes in the 300-399 range (yellow.10). */
+export const KUI_STATUS_COLOR_3NA = "#fffce0";
+/* Color for unknown response status codes in the 400-499 range (orange.10). */
+export const KUI_STATUS_COLOR_4NA = "#FFF1EF";
+/* Color for unknown response status codes in the 500-599 range (red.10). */
+export const KUI_STATUS_COLOR_5NA = "#ffe5e5";
+/* Color for a group of response status codes in the 100-199 range (blue.40). */
+export const KUI_STATUS_COLOR_100S = "#5f9aff";
+/* Color for a group of response status codes in the 200-299 range (green.40). */
+export const KUI_STATUS_COLOR_200S = "#00d6a4";
+/* Color for a group of response status codes in the 300-399 range (yellow.40). */
+export const KUI_STATUS_COLOR_300S = "#ffc400";
+/* Color for a group of response status codes in the 400-499 range (orange.40). */
+export const KUI_STATUS_COLOR_400S = "#FF723C";
+/* Color for a group of response status codes in the 500-599 range (red.40). */
+export const KUI_STATUS_COLOR_500S = "#ff3954";
+/* Background color for http status 100 elements (blue.10). */
+export const KUI_STATUS_COLOR_BACKGROUND_100 = "#eefaff";
+/* Background color for http status 200 elements (green.10). */
+export const KUI_STATUS_COLOR_BACKGROUND_200 = "#ecfffb";
+/* Background color for http status 300 elements (yellow.10). */
+export const KUI_STATUS_COLOR_BACKGROUND_300 = "#fffce0";
+/* Background color for http status 400 elements (orange.10). */
+export const KUI_STATUS_COLOR_BACKGROUND_400 = "#FFF1EF";
+/* Background color for http status 500 elements (red.10). */
+export const KUI_STATUS_COLOR_BACKGROUND_500 = "#ffe5e5";
+/* Text color for http status 100 elements (blue.60). */
+export const KUI_STATUS_COLOR_TEXT_100 = "#0044f4";
+/* Text color for http status 200 elements (green.60). */
+export const KUI_STATUS_COLOR_TEXT_200 = "#007d60";
+/* Text color for http status 300 elements (yellow.60). */
+export const KUI_STATUS_COLOR_TEXT_300 = "#995c00";
+/* Text color for http status 400 elements (orange.60). */
+export const KUI_STATUS_COLOR_TEXT_400 = "#D13500";
+/* Text color for http status 500 elements (red.60). */
+export const KUI_STATUS_COLOR_TEXT_500 = "#d60027";
+/* The standard monospace text font family. Typically used for code blocks, inline code, and copyable text. */
+export const KUI_FONT_FAMILY_CODE = "'JetBrains Mono', Consolas, monospace";
+/* The standard heading text font family. */
+export const KUI_FONT_FAMILY_HEADING = "'Inter', Roboto, Helvetica, sans-serif";
+/* The standard text font family. */
+export const KUI_FONT_FAMILY_TEXT = "'Inter', Roboto, Helvetica, sans-serif";
+export const KUI_FONT_SIZE_10 = "10px";
+export const KUI_FONT_SIZE_20 = "12px";
+export const KUI_FONT_SIZE_30 = "14px";
+export const KUI_FONT_SIZE_40 = "16px";
+export const KUI_FONT_SIZE_50 = "18px";
+export const KUI_FONT_SIZE_60 = "20px";
+export const KUI_FONT_SIZE_70 = "24px";
+export const KUI_FONT_SIZE_80 = "32px";
+export const KUI_FONT_SIZE_90 = "40px";
+export const KUI_FONT_SIZE_100 = "48px";
+/* 700: The bold font weight. */
+export const KUI_FONT_WEIGHT_BOLD = "700";
+/* 500: The medium font weight. */
+export const KUI_FONT_WEIGHT_MEDIUM = "500";
+/* 400: The normal font weight. */
+export const KUI_FONT_WEIGHT_REGULAR = "400";
+/* 600: The semibold font weight. */
+export const KUI_FONT_WEIGHT_SEMIBOLD = "600";
+/* Alias for letter-spacing-normal */
+export const KUI_LETTER_SPACING_0 = "normal";
+/* -0.12px */
+export const KUI_LETTER_SPACING_MINUS_10 = "-0.12px";
+/* -0.24px */
+export const KUI_LETTER_SPACING_MINUS_20 = "-0.24px";
+/* -0.32px */
+export const KUI_LETTER_SPACING_MINUS_30 = "-0.32px";
+/* -0.4px */
+export const KUI_LETTER_SPACING_MINUS_40 = "-0.4px";
+/* -0.48px */
+export const KUI_LETTER_SPACING_MINUS_50 = "-0.48px";
+/* normal */
+export const KUI_LETTER_SPACING_NORMAL = "normal";
+/* 12px */
+export const KUI_LINE_HEIGHT_10 = "12px";
+/* 16px */
+export const KUI_LINE_HEIGHT_20 = "16px";
+/* 20px */
+export const KUI_LINE_HEIGHT_30 = "20px";
+/* 24px */
+export const KUI_LINE_HEIGHT_40 = "24px";
+/* 28px */
+export const KUI_LINE_HEIGHT_50 = "28px";
+/* 32px */
+export const KUI_LINE_HEIGHT_60 = "32px";
+/* 36px */
+export const KUI_LINE_HEIGHT_70 = "36px";
+/* 40px */
+export const KUI_LINE_HEIGHT_80 = "40px";
+/* 48px */
+export const KUI_LINE_HEIGHT_90 = "48px";
+/* 56px */
+export const KUI_LINE_HEIGHT_100 = "56px";
+/* 0px 4px 20px 0px rgba(0, 0, 0, 0.08) */
+export const KUI_SHADOW = "0px 4px 20px 0px rgba(0, 0, 0, 0.08)";
+/* 0px 0px 0px 1px gray.20 inset */
+export const KUI_SHADOW_BORDER = "0px 0px 0px 1px #e0e4ea inset";
+/* 0px 0px 0px 1px red.60 inset */
+export const KUI_SHADOW_BORDER_DANGER = "0px 0px 0px 1px #d60027 inset";
+/* 0px 0px 0px 1px red.70 inset */
+export const KUI_SHADOW_BORDER_DANGER_STRONG = "0px 0px 0px 1px #ad000e inset";
+/* 0px 0px 0px 1px gray.20 inset */
+export const KUI_SHADOW_BORDER_DISABLED = "0px 0px 0px 1px #e0e4ea inset";
+/* 0px 0px 0px 1px blue.60 inset */
+export const KUI_SHADOW_BORDER_PRIMARY = "0px 0px 0px 1px #0044f4 inset";
+/* 0px 0px 0px 1px blue.90 inset */
+export const KUI_SHADOW_BORDER_PRIMARY_STRONGEST = "0px 0px 0px 1px #001466 inset";
+/* 0px 0px 0px 1px blue.40 inset */
+export const KUI_SHADOW_BORDER_PRIMARY_WEAK = "0px 0px 0px 1px #5f9aff inset";
+/* 0px 0px 0px 4px rgba(0, 68, 244, 0.2) */
+export const KUI_SHADOW_FOCUS = "0px 0px 0px 4px rgba(0, 68, 244, 0.2)";
+/* 0px value for gaps, margin, or padding. */
+export const KUI_SPACE_0 = "0px";
+/* 2px value for gaps, margin, or padding. */
+export const KUI_SPACE_10 = "2px";
+/* 4px value for gaps, margin, or padding. */
+export const KUI_SPACE_20 = "4px";
+/* 6px value for gaps, margin, or padding. */
+export const KUI_SPACE_30 = "6px";
+/* 8px value for gaps, margin, or padding. */
+export const KUI_SPACE_40 = "8px";
+/* 12px value for gaps, margin, or padding. */
+export const KUI_SPACE_50 = "12px";
+/* 16px value for gaps, margin, or padding. */
+export const KUI_SPACE_60 = "16px";
+/* 20px value for gaps, margin, or padding. */
+export const KUI_SPACE_70 = "20px";
+/* 24px value for gaps, margin, or padding. */
+export const KUI_SPACE_80 = "24px";
+/* 32px value for gaps, margin, or padding. */
+export const KUI_SPACE_90 = "32px";
+/* 40px value for gaps, margin, or padding. */
+export const KUI_SPACE_100 = "40px";
+/* 48px value for gaps, margin, or padding. */
+export const KUI_SPACE_110 = "48px";
+/* 56px value for gaps, margin, or padding. */
+export const KUI_SPACE_120 = "56px";
+/* 64px value for gaps, margin, or padding. */
+export const KUI_SPACE_130 = "64px";
+/* 80px value for gaps, margin, or padding. */
+export const KUI_SPACE_140 = "80px";
+/* 96px value for gaps, margin, or padding. */
+export const KUI_SPACE_150 = "96px";
+/* auto */
+export const KUI_SPACE_AUTO = "auto";
 ```
 
 </details>
@@ -1769,343 +3404,343 @@ export const KUI_SPACE_AUTO = undefined;
 
 ```json
 {
-  "kui_color_background": undefined,
-  "kui_color_background_danger": undefined,
-  "kui_color_background_danger_strong": undefined,
-  "kui_color_background_danger_stronger": undefined,
-  "kui_color_background_danger_strongest": undefined,
-  "kui_color_background_danger_weak": undefined,
-  "kui_color_background_danger_weaker": undefined,
-  "kui_color_background_danger_weakest": undefined,
-  "kui_color_background_decorative_aqua_weakest": undefined,
-  "kui_color_background_decorative_purple": undefined,
-  "kui_color_background_decorative_purple_weakest": undefined,
-  "kui_color_background_disabled": undefined,
-  "kui_color_background_info": undefined,
-  "kui_color_background_info_strong": undefined,
-  "kui_color_background_info_stronger": undefined,
-  "kui_color_background_info_strongest": undefined,
-  "kui_color_background_info_weak": undefined,
-  "kui_color_background_info_weaker": undefined,
-  "kui_color_background_info_weakest": undefined,
-  "kui_color_background_inverse": undefined,
-  "kui_color_background_neutral": undefined,
-  "kui_color_background_neutral_strong": undefined,
-  "kui_color_background_neutral_stronger": undefined,
-  "kui_color_background_neutral_strongest": undefined,
-  "kui_color_background_neutral_weak": undefined,
-  "kui_color_background_neutral_weaker": undefined,
-  "kui_color_background_neutral_weakest": undefined,
-  "kui_color_background_overlay": undefined,
-  "kui_color_background_primary": undefined,
-  "kui_color_background_primary_strong": undefined,
-  "kui_color_background_primary_stronger": undefined,
-  "kui_color_background_primary_strongest": undefined,
-  "kui_color_background_primary_weak": undefined,
-  "kui_color_background_primary_weaker": undefined,
-  "kui_color_background_primary_weakest": undefined,
-  "kui_color_background_success": undefined,
-  "kui_color_background_success_strong": undefined,
-  "kui_color_background_success_stronger": undefined,
-  "kui_color_background_success_strongest": undefined,
-  "kui_color_background_success_weak": undefined,
-  "kui_color_background_success_weaker": undefined,
-  "kui_color_background_success_weakest": undefined,
-  "kui_color_background_transparent": undefined,
-  "kui_color_background_warning": undefined,
-  "kui_color_background_warning_strong": undefined,
-  "kui_color_background_warning_stronger": undefined,
-  "kui_color_background_warning_strongest": undefined,
-  "kui_color_background_warning_weak": undefined,
-  "kui_color_background_warning_weaker": undefined,
-  "kui_color_background_warning_weakest": undefined,
-  "kui_color_border": undefined,
-  "kui_color_border_danger": undefined,
-  "kui_color_border_danger_strong": undefined,
-  "kui_color_border_danger_stronger": undefined,
-  "kui_color_border_danger_strongest": undefined,
-  "kui_color_border_danger_weak": undefined,
-  "kui_color_border_danger_weaker": undefined,
-  "kui_color_border_danger_weakest": undefined,
-  "kui_color_border_decorative_purple": undefined,
-  "kui_color_border_disabled": undefined,
-  "kui_color_border_inverse": undefined,
-  "kui_color_border_neutral": undefined,
-  "kui_color_border_neutral_strong": undefined,
-  "kui_color_border_neutral_stronger": undefined,
-  "kui_color_border_neutral_strongest": undefined,
-  "kui_color_border_neutral_weak": undefined,
-  "kui_color_border_neutral_weaker": undefined,
-  "kui_color_border_neutral_weakest": undefined,
-  "kui_color_border_primary": undefined,
-  "kui_color_border_primary_strong": undefined,
-  "kui_color_border_primary_stronger": undefined,
-  "kui_color_border_primary_strongest": undefined,
-  "kui_color_border_primary_weak": undefined,
-  "kui_color_border_primary_weaker": undefined,
-  "kui_color_border_primary_weakest": undefined,
-  "kui_color_border_transparent": undefined,
-  "kui_color_text": undefined,
-  "kui_color_text_danger": undefined,
-  "kui_color_text_danger_strong": undefined,
-  "kui_color_text_danger_stronger": undefined,
-  "kui_color_text_danger_strongest": undefined,
-  "kui_color_text_danger_weak": undefined,
-  "kui_color_text_danger_weaker": undefined,
-  "kui_color_text_danger_weakest": undefined,
-  "kui_color_text_decorative_aqua": undefined,
-  "kui_color_text_decorative_pink": undefined,
-  "kui_color_text_decorative_purple": undefined,
-  "kui_color_text_decorative_purple_strong": undefined,
-  "kui_color_text_disabled": undefined,
-  "kui_color_text_info": undefined,
-  "kui_color_text_info_strong": undefined,
-  "kui_color_text_info_stronger": undefined,
-  "kui_color_text_info_strongest": undefined,
-  "kui_color_text_info_weak": undefined,
-  "kui_color_text_info_weaker": undefined,
-  "kui_color_text_info_weakest": undefined,
-  "kui_color_text_inverse": undefined,
-  "kui_color_text_neutral": undefined,
-  "kui_color_text_neutral_strong": undefined,
-  "kui_color_text_neutral_stronger": undefined,
-  "kui_color_text_neutral_strongest": undefined,
-  "kui_color_text_neutral_weak": undefined,
-  "kui_color_text_neutral_weaker": undefined,
-  "kui_color_text_neutral_weakest": undefined,
-  "kui_color_text_primary": undefined,
-  "kui_color_text_primary_strong": undefined,
-  "kui_color_text_primary_stronger": undefined,
-  "kui_color_text_primary_strongest": undefined,
-  "kui_color_text_primary_weak": undefined,
-  "kui_color_text_primary_weaker": undefined,
-  "kui_color_text_primary_weakest": undefined,
-  "kui_color_text_success": undefined,
-  "kui_color_text_success_strong": undefined,
-  "kui_color_text_success_stronger": undefined,
-  "kui_color_text_success_strongest": undefined,
-  "kui_color_text_success_weak": undefined,
-  "kui_color_text_success_weaker": undefined,
-  "kui_color_text_success_weakest": undefined,
-  "kui_color_text_warning": undefined,
-  "kui_color_text_warning_strong": undefined,
-  "kui_color_text_warning_stronger": undefined,
-  "kui_color_text_warning_strongest": undefined,
-  "kui_color_text_warning_weak": undefined,
-  "kui_color_text_warning_weaker": undefined,
-  "kui_color_text_warning_weakest": undefined,
-  "kui_animation_duration_20": undefined,
-  "kui_border_radius_0": undefined,
-  "kui_border_radius_10": undefined,
-  "kui_border_radius_20": undefined,
-  "kui_border_radius_30": undefined,
-  "kui_border_radius_40": undefined,
-  "kui_border_radius_50": undefined,
-  "kui_border_radius_circle": undefined,
-  "kui_border_radius_round": undefined,
-  "kui_border_width_0": undefined,
-  "kui_border_width_10": undefined,
-  "kui_border_width_20": undefined,
-  "kui_border_width_30": undefined,
-  "kui_breakpoint_mobile": undefined,
-  "kui_breakpoint_phablet": undefined,
-  "kui_breakpoint_tablet": undefined,
-  "kui_breakpoint_laptop": undefined,
-  "kui_breakpoint_desktop": undefined,
-  "kui_icon_color_danger": undefined,
-  "kui_icon_color_neutral": undefined,
-  "kui_icon_color_primary": undefined,
-  "kui_icon_color_success": undefined,
-  "kui_icon_color_warning": undefined,
-  "kui_icon_size_10": undefined,
-  "kui_icon_size_20": undefined,
-  "kui_icon_size_30": undefined,
-  "kui_icon_size_40": undefined,
-  "kui_icon_size_50": undefined,
-  "kui_icon_size_60": undefined,
-  "kui_icon_size_70": undefined,
-  "kui_icon_size_80": undefined,
-  "kui_method_color_background_connect": undefined,
-  "kui_method_color_background_delete": undefined,
-  "kui_method_color_background_get": undefined,
-  "kui_method_color_background_head": undefined,
-  "kui_method_color_background_options": undefined,
-  "kui_method_color_background_patch": undefined,
-  "kui_method_color_background_post": undefined,
-  "kui_method_color_background_put": undefined,
-  "kui_method_color_background_trace": undefined,
-  "kui_method_color_text_connect": undefined,
-  "kui_method_color_text_connect_strong": undefined,
-  "kui_method_color_text_delete": undefined,
-  "kui_method_color_text_delete_strong": undefined,
-  "kui_method_color_text_get": undefined,
-  "kui_method_color_text_get_strong": undefined,
-  "kui_method_color_text_head": undefined,
-  "kui_method_color_text_head_strong": undefined,
-  "kui_method_color_text_options": undefined,
-  "kui_method_color_text_options_strong": undefined,
-  "kui_method_color_text_patch": undefined,
-  "kui_method_color_text_patch_strong": undefined,
-  "kui_method_color_text_post": undefined,
-  "kui_method_color_text_post_strong": undefined,
-  "kui_method_color_text_put": undefined,
-  "kui_method_color_text_put_strong": undefined,
-  "kui_method_color_text_trace": undefined,
-  "kui_method_color_text_trace_strong": undefined,
-  "kui_navigation_color_background": undefined,
-  "kui_navigation_color_background_selected": undefined,
-  "kui_navigation_color_border": undefined,
-  "kui_navigation_color_border_child": undefined,
-  "kui_navigation_color_border_divider": undefined,
-  "kui_navigation_color_text": undefined,
-  "kui_navigation_color_text_focus": undefined,
-  "kui_navigation_color_text_hover": undefined,
-  "kui_navigation_color_text_selected": undefined,
-  "kui_navigation_shadow_border": undefined,
-  "kui_navigation_shadow_border_child": undefined,
-  "kui_navigation_shadow_focus": undefined,
-  "kui_status_color_100": undefined,
-  "kui_status_color_101": undefined,
-  "kui_status_color_102": undefined,
-  "kui_status_color_103": undefined,
-  "kui_status_color_200": undefined,
-  "kui_status_color_201": undefined,
-  "kui_status_color_202": undefined,
-  "kui_status_color_203": undefined,
-  "kui_status_color_204": undefined,
-  "kui_status_color_205": undefined,
-  "kui_status_color_206": undefined,
-  "kui_status_color_207": undefined,
-  "kui_status_color_208": undefined,
-  "kui_status_color_226": undefined,
-  "kui_status_color_300": undefined,
-  "kui_status_color_301": undefined,
-  "kui_status_color_302": undefined,
-  "kui_status_color_303": undefined,
-  "kui_status_color_304": undefined,
-  "kui_status_color_305": undefined,
-  "kui_status_color_307": undefined,
-  "kui_status_color_308": undefined,
-  "kui_status_color_400": undefined,
-  "kui_status_color_401": undefined,
-  "kui_status_color_402": undefined,
-  "kui_status_color_403": undefined,
-  "kui_status_color_404": undefined,
-  "kui_status_color_405": undefined,
-  "kui_status_color_406": undefined,
-  "kui_status_color_407": undefined,
-  "kui_status_color_408": undefined,
-  "kui_status_color_409": undefined,
-  "kui_status_color_410": undefined,
-  "kui_status_color_411": undefined,
-  "kui_status_color_412": undefined,
-  "kui_status_color_413": undefined,
-  "kui_status_color_414": undefined,
-  "kui_status_color_415": undefined,
-  "kui_status_color_416": undefined,
-  "kui_status_color_417": undefined,
-  "kui_status_color_418": undefined,
-  "kui_status_color_421": undefined,
-  "kui_status_color_422": undefined,
-  "kui_status_color_423": undefined,
-  "kui_status_color_424": undefined,
-  "kui_status_color_425": undefined,
-  "kui_status_color_426": undefined,
-  "kui_status_color_428": undefined,
-  "kui_status_color_429": undefined,
-  "kui_status_color_431": undefined,
-  "kui_status_color_451": undefined,
-  "kui_status_color_500": undefined,
-  "kui_status_color_501": undefined,
-  "kui_status_color_502": undefined,
-  "kui_status_color_503": undefined,
-  "kui_status_color_504": undefined,
-  "kui_status_color_505": undefined,
-  "kui_status_color_506": undefined,
-  "kui_status_color_507": undefined,
-  "kui_status_color_508": undefined,
-  "kui_status_color_510": undefined,
-  "kui_status_color_511": undefined,
-  "kui_status_color_1na": undefined,
-  "kui_status_color_2na": undefined,
-  "kui_status_color_3na": undefined,
-  "kui_status_color_4na": undefined,
-  "kui_status_color_5na": undefined,
-  "kui_status_color_100s": undefined,
-  "kui_status_color_200s": undefined,
-  "kui_status_color_300s": undefined,
-  "kui_status_color_400s": undefined,
-  "kui_status_color_500s": undefined,
-  "kui_status_color_background_100": undefined,
-  "kui_status_color_background_200": undefined,
-  "kui_status_color_background_300": undefined,
-  "kui_status_color_background_400": undefined,
-  "kui_status_color_background_500": undefined,
-  "kui_status_color_text_100": undefined,
-  "kui_status_color_text_200": undefined,
-  "kui_status_color_text_300": undefined,
-  "kui_status_color_text_400": undefined,
-  "kui_status_color_text_500": undefined,
-  "kui_font_family_code": undefined,
-  "kui_font_family_heading": undefined,
-  "kui_font_family_text": undefined,
-  "kui_font_size_10": undefined,
-  "kui_font_size_20": undefined,
-  "kui_font_size_30": undefined,
-  "kui_font_size_40": undefined,
-  "kui_font_size_50": undefined,
-  "kui_font_size_60": undefined,
-  "kui_font_size_70": undefined,
-  "kui_font_size_80": undefined,
-  "kui_font_size_90": undefined,
-  "kui_font_size_100": undefined,
-  "kui_font_weight_bold": undefined,
-  "kui_font_weight_medium": undefined,
-  "kui_font_weight_regular": undefined,
-  "kui_font_weight_semibold": undefined,
-  "kui_letter_spacing_0": undefined,
-  "kui_letter_spacing_minus_10": undefined,
-  "kui_letter_spacing_minus_20": undefined,
-  "kui_letter_spacing_minus_30": undefined,
-  "kui_letter_spacing_minus_40": undefined,
-  "kui_letter_spacing_minus_50": undefined,
-  "kui_letter_spacing_normal": undefined,
-  "kui_line_height_10": undefined,
-  "kui_line_height_20": undefined,
-  "kui_line_height_30": undefined,
-  "kui_line_height_40": undefined,
-  "kui_line_height_50": undefined,
-  "kui_line_height_60": undefined,
-  "kui_line_height_70": undefined,
-  "kui_line_height_80": undefined,
-  "kui_line_height_90": undefined,
-  "kui_line_height_100": undefined,
-  "kui_shadow": undefined,
-  "kui_shadow_border": undefined,
-  "kui_shadow_border_danger": undefined,
-  "kui_shadow_border_danger_strong": undefined,
-  "kui_shadow_border_disabled": undefined,
-  "kui_shadow_border_primary": undefined,
-  "kui_shadow_border_primary_strongest": undefined,
-  "kui_shadow_border_primary_weak": undefined,
-  "kui_shadow_focus": undefined,
-  "kui_space_0": undefined,
-  "kui_space_10": undefined,
-  "kui_space_20": undefined,
-  "kui_space_30": undefined,
-  "kui_space_40": undefined,
-  "kui_space_50": undefined,
-  "kui_space_60": undefined,
-  "kui_space_70": undefined,
-  "kui_space_80": undefined,
-  "kui_space_90": undefined,
-  "kui_space_100": undefined,
-  "kui_space_110": undefined,
-  "kui_space_120": undefined,
-  "kui_space_130": undefined,
-  "kui_space_140": undefined,
-  "kui_space_150": undefined,
-  "kui_space_auto": undefined
+  "kui_color_background": "#ffffff",
+  "kui_color_background_danger": "#d60027",
+  "kui_color_background_danger_strong": "#ad000e",
+  "kui_color_background_danger_stronger": "#850000",
+  "kui_color_background_danger_strongest": "#5c0000",
+  "kui_color_background_danger_weak": "#ff3954",
+  "kui_color_background_danger_weaker": "#ffabab",
+  "kui_color_background_danger_weakest": "#ffe5e5",
+  "kui_color_background_decorative_aqua_weakest": "#ecfcff",
+  "kui_color_background_decorative_purple": "#6f28ff",
+  "kui_color_background_decorative_purple_weakest": "#f1f0ff",
+  "kui_color_background_disabled": "#e0e4ea",
+  "kui_color_background_info": "#0044f4",
+  "kui_color_background_info_strong": "#0030cc",
+  "kui_color_background_info_stronger": "#002099",
+  "kui_color_background_info_strongest": "#001466",
+  "kui_color_background_info_weak": "#5f9aff",
+  "kui_color_background_info_weaker": "#bee2ff",
+  "kui_color_background_info_weakest": "#eefaff",
+  "kui_color_background_inverse": "#000933",
+  "kui_color_background_neutral": "#6c7489",
+  "kui_color_background_neutral_strong": "#52596e",
+  "kui_color_background_neutral_stronger": "#3a3f51",
+  "kui_color_background_neutral_strongest": "#232633",
+  "kui_color_background_neutral_weak": "#afb7c5",
+  "kui_color_background_neutral_weaker": "#e0e4ea",
+  "kui_color_background_neutral_weakest": "#f9fafb",
+  "kui_color_background_overlay": "rgba(0, 9, 51, 0.6)",
+  "kui_color_background_primary": "#0044f4",
+  "kui_color_background_primary_strong": "#0030cc",
+  "kui_color_background_primary_stronger": "#002099",
+  "kui_color_background_primary_strongest": "#001466",
+  "kui_color_background_primary_weak": "#5f9aff",
+  "kui_color_background_primary_weaker": "#bee2ff",
+  "kui_color_background_primary_weakest": "#eefaff",
+  "kui_color_background_success": "#007d60",
+  "kui_color_background_success_strong": "#005944",
+  "kui_color_background_success_stronger": "#004737",
+  "kui_color_background_success_strongest": "#003629",
+  "kui_color_background_success_weak": "#00d6a4",
+  "kui_color_background_success_weaker": "#b5ffee",
+  "kui_color_background_success_weakest": "#ecfffb",
+  "kui_color_background_transparent": "transparent",
+  "kui_color_background_warning": "#995c00",
+  "kui_color_background_warning_strong": "#804400",
+  "kui_color_background_warning_stronger": "#662d00",
+  "kui_color_background_warning_strongest": "#4d1b00",
+  "kui_color_background_warning_weak": "#ffc400",
+  "kui_color_background_warning_weaker": "#fff296",
+  "kui_color_background_warning_weakest": "#fffce0",
+  "kui_color_border": "#e0e4ea",
+  "kui_color_border_danger": "#d60027",
+  "kui_color_border_danger_strong": "#ad000e",
+  "kui_color_border_danger_stronger": "#850000",
+  "kui_color_border_danger_strongest": "#5c0000",
+  "kui_color_border_danger_weak": "#ff3954",
+  "kui_color_border_danger_weaker": "#ffabab",
+  "kui_color_border_danger_weakest": "#ffe5e5",
+  "kui_color_border_decorative_purple": "#6f28ff",
+  "kui_color_border_disabled": "#e0e4ea",
+  "kui_color_border_inverse": "rgba(255, 255, 255, 0.2)",
+  "kui_color_border_neutral": "#6c7489",
+  "kui_color_border_neutral_strong": "#52596e",
+  "kui_color_border_neutral_stronger": "#3a3f51",
+  "kui_color_border_neutral_strongest": "#232633",
+  "kui_color_border_neutral_weak": "#afb7c5",
+  "kui_color_border_neutral_weaker": "#e0e4ea",
+  "kui_color_border_neutral_weakest": "#f9fafb",
+  "kui_color_border_primary": "#0044f4",
+  "kui_color_border_primary_strong": "#0030cc",
+  "kui_color_border_primary_stronger": "#002099",
+  "kui_color_border_primary_strongest": "#001466",
+  "kui_color_border_primary_weak": "#5f9aff",
+  "kui_color_border_primary_weaker": "#bee2ff",
+  "kui_color_border_primary_weakest": "#eefaff",
+  "kui_color_border_transparent": "transparent",
+  "kui_color_text": "#000933",
+  "kui_color_text_danger": "#d60027",
+  "kui_color_text_danger_strong": "#ad000e",
+  "kui_color_text_danger_stronger": "#850000",
+  "kui_color_text_danger_strongest": "#5c0000",
+  "kui_color_text_danger_weak": "#ff3954",
+  "kui_color_text_danger_weaker": "#ffabab",
+  "kui_color_text_danger_weakest": "#ffe5e5",
+  "kui_color_text_decorative_aqua": "#00abd2",
+  "kui_color_text_decorative_pink": "#d60067",
+  "kui_color_text_decorative_purple": "#6f28ff",
+  "kui_color_text_decorative_purple_strong": "#5e00f5",
+  "kui_color_text_disabled": "#afb7c5",
+  "kui_color_text_info": "#0044f4",
+  "kui_color_text_info_strong": "#0030cc",
+  "kui_color_text_info_stronger": "#002099",
+  "kui_color_text_info_strongest": "#001466",
+  "kui_color_text_info_weak": "#5f9aff",
+  "kui_color_text_info_weaker": "#bee2ff",
+  "kui_color_text_info_weakest": "#eefaff",
+  "kui_color_text_inverse": "#ffffff",
+  "kui_color_text_neutral": "#6c7489",
+  "kui_color_text_neutral_strong": "#52596e",
+  "kui_color_text_neutral_stronger": "#3a3f51",
+  "kui_color_text_neutral_strongest": "#232633",
+  "kui_color_text_neutral_weak": "#afb7c5",
+  "kui_color_text_neutral_weaker": "#e0e4ea",
+  "kui_color_text_neutral_weakest": "#f9fafb",
+  "kui_color_text_primary": "#0044f4",
+  "kui_color_text_primary_strong": "#0030cc",
+  "kui_color_text_primary_stronger": "#002099",
+  "kui_color_text_primary_strongest": "#001466",
+  "kui_color_text_primary_weak": "#5f9aff",
+  "kui_color_text_primary_weaker": "#bee2ff",
+  "kui_color_text_primary_weakest": "#eefaff",
+  "kui_color_text_success": "#007d60",
+  "kui_color_text_success_strong": "#005944",
+  "kui_color_text_success_stronger": "#004737",
+  "kui_color_text_success_strongest": "#003629",
+  "kui_color_text_success_weak": "#00d6a4",
+  "kui_color_text_success_weaker": "#b5ffee",
+  "kui_color_text_success_weakest": "#ecfffb",
+  "kui_color_text_warning": "#995c00",
+  "kui_color_text_warning_strong": "#804400",
+  "kui_color_text_warning_stronger": "#662d00",
+  "kui_color_text_warning_strongest": "#4d1b00",
+  "kui_color_text_warning_weak": "#ffc400",
+  "kui_color_text_warning_weaker": "#fff296",
+  "kui_color_text_warning_weakest": "#fffce0",
+  "kui_animation_duration_20": "0.2s",
+  "kui_border_radius_0": "0px",
+  "kui_border_radius_10": "2px",
+  "kui_border_radius_20": "4px",
+  "kui_border_radius_30": "6px",
+  "kui_border_radius_40": "8px",
+  "kui_border_radius_50": "10px",
+  "kui_border_radius_circle": "50%",
+  "kui_border_radius_round": "100px",
+  "kui_border_width_0": "0px",
+  "kui_border_width_10": "1px",
+  "kui_border_width_20": "2px",
+  "kui_border_width_30": "4px",
+  "kui_breakpoint_mobile": "640px",
+  "kui_breakpoint_phablet": "768px",
+  "kui_breakpoint_tablet": "1024px",
+  "kui_breakpoint_laptop": "1280px",
+  "kui_breakpoint_desktop": "1536px",
+  "kui_icon_color_danger": "#f50045",
+  "kui_icon_color_neutral": "#828a9e",
+  "kui_icon_color_primary": "#306fff",
+  "kui_icon_color_success": "#00a17b",
+  "kui_icon_color_warning": "#ffc400",
+  "kui_icon_size_10": "10px",
+  "kui_icon_size_20": "12px",
+  "kui_icon_size_30": "16px",
+  "kui_icon_size_40": "20px",
+  "kui_icon_size_50": "24px",
+  "kui_icon_size_60": "32px",
+  "kui_icon_size_70": "40px",
+  "kui_icon_size_80": "48px",
+  "kui_method_color_background_connect": "#f1f0ff",
+  "kui_method_color_background_delete": "#ffe5e5",
+  "kui_method_color_background_get": "#eefaff",
+  "kui_method_color_background_head": "#52596e",
+  "kui_method_color_background_options": "#e0e4ea",
+  "kui_method_color_background_patch": "#ecfcff",
+  "kui_method_color_background_post": "#ecfffb",
+  "kui_method_color_background_put": "#fffce0",
+  "kui_method_color_background_trace": "#fff0f7",
+  "kui_method_color_text_connect": "#6f28ff",
+  "kui_method_color_text_connect_strong": "#5e00f5",
+  "kui_method_color_text_delete": "#d60027",
+  "kui_method_color_text_delete_strong": "#ad000e",
+  "kui_method_color_text_get": "#0044f4",
+  "kui_method_color_text_get_strong": "#0030cc",
+  "kui_method_color_text_head": "#e0e4ea",
+  "kui_method_color_text_head_strong": "#afb7c5",
+  "kui_method_color_text_options": "#52596e",
+  "kui_method_color_text_options_strong": "#3a3f51",
+  "kui_method_color_text_patch": "#00819d",
+  "kui_method_color_text_patch_strong": "#00647a",
+  "kui_method_color_text_post": "#007d60",
+  "kui_method_color_text_post_strong": "#005944",
+  "kui_method_color_text_put": "#995c00",
+  "kui_method_color_text_put_strong": "#804400",
+  "kui_method_color_text_trace": "#d60067",
+  "kui_method_color_text_trace_strong": "#ad0053",
+  "kui_navigation_color_background": "#000933",
+  "kui_navigation_color_background_selected": "rgba(255, 255, 255, 0.12)",
+  "kui_navigation_color_border": "rgba(255, 255, 255, 0.12)",
+  "kui_navigation_color_border_child": "#00fabe",
+  "kui_navigation_color_border_divider": "rgba(255, 255, 255, 0.24)",
+  "kui_navigation_color_text": "#bee2ff",
+  "kui_navigation_color_text_focus": "#ffffff",
+  "kui_navigation_color_text_hover": "#eefaff",
+  "kui_navigation_color_text_selected": "#00fabe",
+  "kui_navigation_shadow_border": "0 0 0 1px rgba(255, 255, 255, 0.12) inset",
+  "kui_navigation_shadow_border_child": "4px 0 0 0 #00fabe inset",
+  "kui_navigation_shadow_focus": "0 0 0 1px rgba(255, 255, 255, 0.60) inset",
+  "kui_status_color_100": "#bee2ff",
+  "kui_status_color_101": "#8fc1ff",
+  "kui_status_color_102": "#5f9aff",
+  "kui_status_color_103": "#306fff",
+  "kui_status_color_200": "#b5ffee",
+  "kui_status_color_201": "#00fabe",
+  "kui_status_color_202": "#00d6a4",
+  "kui_status_color_203": "#00a17b",
+  "kui_status_color_204": "#007d60",
+  "kui_status_color_205": "#005944",
+  "kui_status_color_206": "#b5ffee",
+  "kui_status_color_207": "#00fabe",
+  "kui_status_color_208": "#b5ffee",
+  "kui_status_color_226": "#00a17b",
+  "kui_status_color_300": "#fff296",
+  "kui_status_color_301": "#ffe04b",
+  "kui_status_color_302": "#ffc400",
+  "kui_status_color_303": "#b37600",
+  "kui_status_color_304": "#995c00",
+  "kui_status_color_305": "#804400",
+  "kui_status_color_307": "#fff296",
+  "kui_status_color_308": "#ffe04b",
+  "kui_status_color_400": "#FFC2B3",
+  "kui_status_color_401": "#FF9877",
+  "kui_status_color_402": "#FF723C",
+  "kui_status_color_403": "#F75008",
+  "kui_status_color_404": "#D13500",
+  "kui_status_color_405": "#A31F00",
+  "kui_status_color_406": "#FFC2B3",
+  "kui_status_color_407": "#FF9877",
+  "kui_status_color_408": "#FF723C",
+  "kui_status_color_409": "#F75008",
+  "kui_status_color_410": "#D13500",
+  "kui_status_color_411": "#A31F00",
+  "kui_status_color_412": "#FFC2B3",
+  "kui_status_color_413": "#FF9877",
+  "kui_status_color_414": "#FF723C",
+  "kui_status_color_415": "#F75008",
+  "kui_status_color_416": "#D13500",
+  "kui_status_color_417": "#A31F00",
+  "kui_status_color_418": "#FFC2B3",
+  "kui_status_color_421": "#FF9877",
+  "kui_status_color_422": "#FF723C",
+  "kui_status_color_423": "#F75008",
+  "kui_status_color_424": "#D13500",
+  "kui_status_color_425": "#A31F00",
+  "kui_status_color_426": "#FFC2B3",
+  "kui_status_color_428": "#FF9877",
+  "kui_status_color_429": "#FF723C",
+  "kui_status_color_431": "#F75008",
+  "kui_status_color_451": "#D13500",
+  "kui_status_color_500": "#ffabab",
+  "kui_status_color_501": "#ff7272",
+  "kui_status_color_502": "#ff3954",
+  "kui_status_color_503": "#f50045",
+  "kui_status_color_504": "#d60027",
+  "kui_status_color_505": "#ad000e",
+  "kui_status_color_506": "#ffabab",
+  "kui_status_color_507": "#ff7272",
+  "kui_status_color_508": "#ff3954",
+  "kui_status_color_510": "#f50045",
+  "kui_status_color_511": "#d60027",
+  "kui_status_color_1na": "#eefaff",
+  "kui_status_color_2na": "#ecfffb",
+  "kui_status_color_3na": "#fffce0",
+  "kui_status_color_4na": "#FFF1EF",
+  "kui_status_color_5na": "#ffe5e5",
+  "kui_status_color_100s": "#5f9aff",
+  "kui_status_color_200s": "#00d6a4",
+  "kui_status_color_300s": "#ffc400",
+  "kui_status_color_400s": "#FF723C",
+  "kui_status_color_500s": "#ff3954",
+  "kui_status_color_background_100": "#eefaff",
+  "kui_status_color_background_200": "#ecfffb",
+  "kui_status_color_background_300": "#fffce0",
+  "kui_status_color_background_400": "#FFF1EF",
+  "kui_status_color_background_500": "#ffe5e5",
+  "kui_status_color_text_100": "#0044f4",
+  "kui_status_color_text_200": "#007d60",
+  "kui_status_color_text_300": "#995c00",
+  "kui_status_color_text_400": "#D13500",
+  "kui_status_color_text_500": "#d60027",
+  "kui_font_family_code": "'JetBrains Mono', Consolas, monospace",
+  "kui_font_family_heading": "'Inter', Roboto, Helvetica, sans-serif",
+  "kui_font_family_text": "'Inter', Roboto, Helvetica, sans-serif",
+  "kui_font_size_10": "10px",
+  "kui_font_size_20": "12px",
+  "kui_font_size_30": "14px",
+  "kui_font_size_40": "16px",
+  "kui_font_size_50": "18px",
+  "kui_font_size_60": "20px",
+  "kui_font_size_70": "24px",
+  "kui_font_size_80": "32px",
+  "kui_font_size_90": "40px",
+  "kui_font_size_100": "48px",
+  "kui_font_weight_bold": "700",
+  "kui_font_weight_medium": "500",
+  "kui_font_weight_regular": "400",
+  "kui_font_weight_semibold": "600",
+  "kui_letter_spacing_0": "normal",
+  "kui_letter_spacing_minus_10": "-0.12px",
+  "kui_letter_spacing_minus_20": "-0.24px",
+  "kui_letter_spacing_minus_30": "-0.32px",
+  "kui_letter_spacing_minus_40": "-0.4px",
+  "kui_letter_spacing_minus_50": "-0.48px",
+  "kui_letter_spacing_normal": "normal",
+  "kui_line_height_10": "12px",
+  "kui_line_height_20": "16px",
+  "kui_line_height_30": "20px",
+  "kui_line_height_40": "24px",
+  "kui_line_height_50": "28px",
+  "kui_line_height_60": "32px",
+  "kui_line_height_70": "36px",
+  "kui_line_height_80": "40px",
+  "kui_line_height_90": "48px",
+  "kui_line_height_100": "56px",
+  "kui_shadow": "0px 4px 20px 0px rgba(0, 0, 0, 0.08)",
+  "kui_shadow_border": "0px 0px 0px 1px #e0e4ea inset",
+  "kui_shadow_border_danger": "0px 0px 0px 1px #d60027 inset",
+  "kui_shadow_border_danger_strong": "0px 0px 0px 1px #ad000e inset",
+  "kui_shadow_border_disabled": "0px 0px 0px 1px #e0e4ea inset",
+  "kui_shadow_border_primary": "0px 0px 0px 1px #0044f4 inset",
+  "kui_shadow_border_primary_strongest": "0px 0px 0px 1px #001466 inset",
+  "kui_shadow_border_primary_weak": "0px 0px 0px 1px #5f9aff inset",
+  "kui_shadow_focus": "0px 0px 0px 4px rgba(0, 68, 244, 0.2)",
+  "kui_space_0": "0px",
+  "kui_space_10": "2px",
+  "kui_space_20": "4px",
+  "kui_space_30": "6px",
+  "kui_space_40": "8px",
+  "kui_space_50": "12px",
+  "kui_space_60": "16px",
+  "kui_space_70": "20px",
+  "kui_space_80": "24px",
+  "kui_space_90": "32px",
+  "kui_space_100": "40px",
+  "kui_space_110": "48px",
+  "kui_space_120": "56px",
+  "kui_space_130": "64px",
+  "kui_space_140": "80px",
+  "kui_space_150": "96px",
+  "kui_space_auto": "auto"
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "sass": "^1.97.3",
     "semantic-release": "^25.0.3",
     "shx": "^0.4.0",
-    "style-dictionary": "^4.4.0",
+    "style-dictionary": "^5.4.0",
     "typescript": "^6.0.2",
     "vite": "^8.0.0",
     "vite-plugin-restart": "^2.0.0",

--- a/platforms/css.mjs
+++ b/platforms/css.mjs
@@ -4,7 +4,7 @@ import { fileHeader } from 'style-dictionary/utils'
 
 StyleDictionary.registerFormat({
   name: 'css/variables/custom/initial-values',
-  format: async function({ dictionary, file, options }) {
+  format: async function({ dictionary, file }) {
     return (await fileHeader({ file })) +
     '/**\n' +
     ' * IMPORTANT: You should **not** import this file in your host project.\n' +

--- a/platforms/css.mjs
+++ b/platforms/css.mjs
@@ -22,8 +22,8 @@ StyleDictionary.registerFormat({
     '*/\n' +
     ':root {\n' +
       dictionary.allTokens.map(token => {
-        const value = unquoteString(JSON.stringify(token.value))
-        const comment = unquoteString(JSON.stringify(token.comment))
+        const value = unquoteString(JSON.stringify(token.$value))
+        const comment = unquoteString(JSON.stringify(token.$description))
 
         // Set the value of the variable to `initial` to initialize as essentially an empty value
         let tokenOutput = `  /* ${comment ? comment.replace(/([^.])$/, '$1.') : ''} Default value: \`${value}\` */\n`

--- a/platforms/markdown.mjs
+++ b/platforms/markdown.mjs
@@ -7,8 +7,8 @@ StyleDictionary.registerFormat({
   format: async function({ dictionary, file, options }) {
     // Generate the SCSS variable tokens
     const scssTokens = dictionary.allTokens.map(token => {
-      const value = unquoteString(JSON.stringify(token.value))
-      const comment = unquoteString(JSON.stringify(token.comment))
+      const value = unquoteString(JSON.stringify(token.$value))
+      const comment = unquoteString(JSON.stringify(token.$description))
 
       let tokenOutput = ''
       if (comment) {
@@ -20,8 +20,8 @@ StyleDictionary.registerFormat({
 
     // Generate the SCSS variable tokens
     const scssMap = dictionary.allTokens.map(token => {
-      const value = unquoteString(JSON.stringify(token.value))
-      const comment = unquoteString(JSON.stringify(token.comment))
+      const value = unquoteString(JSON.stringify(token.$value))
+      const comment = unquoteString(JSON.stringify(token.$description))
 
       let tokenOutput = ''
       if (comment) {
@@ -33,8 +33,8 @@ StyleDictionary.registerFormat({
 
     // Generate the LESS variable tokens
     const lessTokens = dictionary.allTokens.map(token => {
-      const value = unquoteString(JSON.stringify(token.value))
-      const comment = unquoteString(JSON.stringify(token.comment))
+      const value = unquoteString(JSON.stringify(token.$value))
+      const comment = unquoteString(JSON.stringify(token.$description))
 
       let tokenOutput = ''
       if (comment) {
@@ -46,8 +46,8 @@ StyleDictionary.registerFormat({
 
     // Generate the CSS custom properties
     const cssTokens = dictionary.allTokens.map(token => {
-      const value = unquoteString(JSON.stringify(token.value))
-      const comment = unquoteString(JSON.stringify(token.comment))
+      const value = unquoteString(JSON.stringify(token.$value))
+      const comment = unquoteString(JSON.stringify(token.$description))
 
       let tokenOutput = ''
       if (comment) {
@@ -59,8 +59,8 @@ StyleDictionary.registerFormat({
 
     // Generate the JavaScript variable tokens
     const javascriptTokens = dictionary.allTokens.map(token => {
-      const value = JSON.stringify(token.value)
-      const comment = unquoteString(JSON.stringify(token.comment))
+      const value = JSON.stringify(token.$value)
+      const comment = unquoteString(JSON.stringify(token.$description))
 
       let tokenOutput = ''
       if (comment) {
@@ -72,7 +72,7 @@ StyleDictionary.registerFormat({
 
     // Generate the JavaScript variable tokens
     const jsonTokens = dictionary.allTokens.map((token, idx) => {
-      const value = JSON.stringify(token.value)
+      const value = JSON.stringify(token.$value)
 
       let tokenOutput = `  "${token.name.replace(/-/g, '_').toLowerCase()}": ${value},`
       if ((idx + 1) === dictionary.allTokens.length) {

--- a/platforms/markdown.mjs
+++ b/platforms/markdown.mjs
@@ -4,7 +4,7 @@ import { fileHeader } from 'style-dictionary/utils'
 
 StyleDictionary.registerFormat({
   name: 'css/variables/custom/markdown',
-  format: async function({ dictionary, file, options }) {
+  format: async function({ dictionary, file }) {
     // Generate the SCSS variable tokens
     const scssTokens = dictionary.allTokens.map(token => {
       const value = unquoteString(JSON.stringify(token.$value))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ importers:
         specifier: ^0.4.0
         version: 0.4.0
       style-dictionary:
-        specifier: ^4.4.0
-        version: 4.4.0
+        specifier: ^5.4.0
+        version: 5.4.0(tslib@2.6.3)
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
@@ -246,11 +246,11 @@ packages:
   '@bundled-es-modules/deepmerge@4.3.1':
     resolution: {integrity: sha512-Rk453EklPUPC3NRWc3VUNI/SSUjdBaFoaQvFRmNBNtMHVtOFD5AntiWg5kEE1hqcPqedYFDzxE3ZcMYPcA195w==}
 
-  '@bundled-es-modules/glob@10.4.2':
-    resolution: {integrity: sha512-740y5ofkzydsFao5EXJrGilcIL6EFEw/cmPf2uhTw9J6G1YOhiIFjNFCHdpgEiiH5VlU3G0SARSjlFlimRRSMA==}
+  '@bundled-es-modules/glob@13.0.6':
+    resolution: {integrity: sha512-x9nR2e1pt8LF0yLPC6yz/aUoiN7qJJwZ1znLxIXCxGyH+8BI+yO/sklBdn1+QbUyWXQBM+CjfZz3IhqtgIoDVg==}
 
-  '@bundled-es-modules/memfs@4.9.4':
-    resolution: {integrity: sha512-1XyYPUaIHwEOdF19wYVLBtHJRr42Do+3ctht17cZOHwHf67vkmRNPlYDGY2kJps4RgE5+c7nEZmEzxxvb1NZWA==}
+  '@bundled-es-modules/memfs@4.17.0':
+    resolution: {integrity: sha512-ykdrkEmQr9BV804yd37ikXfNnvxrwYfY9Z2/EtMHFEFadEjsQXJ1zL9bVZrKNLDtm91UdUOEHso6Aweg93K6xQ==}
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -590,10 +590,6 @@ packages:
     resolution: {integrity: sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==}
     engines: {node: '>=18.18'}
 
-  '@isaacs/cliui@8.0.2':
-    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
-    engines: {node: '>=12'}
-
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -616,14 +612,116 @@ packages:
     peerDependencies:
       tslib: '2'
 
-  '@jsonjoy.com/json-pack@1.0.4':
-    resolution: {integrity: sha512-aOcSN4MeAtFROysrbqG137b7gaDDSmVrl5mpo6sT/w+kcXpWnzhMjmY/Fh/sDx26NBxyIE7MB1seqLeCAzy9Sg==}
+  '@jsonjoy.com/base64@17.67.0':
+    resolution: {integrity: sha512-5SEsJGsm15aP8TQGkDfJvz9axgPwAEm98S5DxOuYe8e1EbfajcDmgeXXzccEjh+mLnjqEKrkBdjHWS5vFNwDdw==}
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
 
-  '@jsonjoy.com/util@1.3.0':
-    resolution: {integrity: sha512-Cebt4Vk7k1xHy87kHY7KSPLT77A7Ev7IfOblyLZhtYEhrdQ6fX4EoLq3xOQ3O/DRMEh2ok5nyC180E+ABS8Wmw==}
+  '@jsonjoy.com/buffers@1.2.1':
+    resolution: {integrity: sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/buffers@17.67.0':
+    resolution: {integrity: sha512-tfExRpYxBvi32vPs9ZHaTjSP4fHAfzSmcahOfNxtvGHcyJel+aibkPlGeBB+7AoC6hL7lXIE++8okecBxx7lcw==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/codegen@1.0.0':
+    resolution: {integrity: sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/codegen@17.67.0':
+    resolution: {integrity: sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-core@4.57.2':
+    resolution: {integrity: sha512-SVjwklkpIV5wrynpYtuYnfYH1QF4/nDuLBX7VXdb+3miglcAgBVZb/5y0cOsehRV/9Vb+3UqhkMq3/NR3ztdkQ==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-fsa@4.57.2':
+    resolution: {integrity: sha512-fhO8+iR2I+OCw668ISDJdn1aArc9zx033sWejIyzQ8RBeXa9bDSaUeA3ix0poYOfrj1KdOzytmYNv2/uLDfV6g==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-node-builtins@4.57.2':
+    resolution: {integrity: sha512-xhiegylRmhw43Ki2HO1ZBL7DQ5ja/qpRsL29VtQ2xuUHiuDGbgf2uD4p9Qd8hJI5P6RCtGYD50IXHXVq/Ocjcg==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-node-to-fsa@4.57.2':
+    resolution: {integrity: sha512-18LmWTSONhoAPW+IWRuf8w/+zRolPFGPeGwMxlAhhfY11EKzX+5XHDBPAw67dBF5dxDErHJbl40U+3IXSDRXSQ==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-node-utils@4.57.2':
+    resolution: {integrity: sha512-rsPSJgekz43IlNbLyAM/Ab+ouYLWGp5DDBfYBNNEqDaSpsbXfthBn29Q4muFA9L0F+Z3mKo+CWlgSCXrf+mOyQ==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-node@4.57.2':
+    resolution: {integrity: sha512-nX2AdL6cOFwLdju9G4/nbRnYevmCJbh7N7hvR3gGm97Cs60uEjyd0rpR+YBS7cTg175zzl22pGKXR5USaQMvKg==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-print@4.57.2':
+    resolution: {integrity: sha512-wK9NSow48i4DbDl9F1CQE5TqnyZOJ04elU3WFG5aJ76p+YxO/ulyBBQvKsessPxdo381Bc2pcEoyPujMOhcRqQ==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-snapshot@4.57.2':
+    resolution: {integrity: sha512-GdduDZuoP5V/QCgJkx9+BZ6SC0EZ/smXAdTS7PfMqgMTGXLlt/bH/FqMYaqB9JmLf05sJPtO0XRbAwwkEEPbVw==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/json-pack@1.21.0':
+    resolution: {integrity: sha512-+AKG+R2cfZMShzrF2uQw34v3zbeDYUqnQ+jg7ORic3BGtfw9p/+N6RJbq/kkV8JmYZaINknaEQ2m0/f693ZPpg==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/json-pack@17.67.0':
+    resolution: {integrity: sha512-t0ejURcGaZsn1ClbJ/3kFqSOjlryd92eQY465IYrezsXmPcfHPE/av4twRSxf6WE+TkZgLY+71vCZbiIiFKA/w==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/json-pointer@1.0.2':
+    resolution: {integrity: sha512-Fsn6wM2zlDzY1U+v4Nc8bo3bVqgfNTGcn6dMgs6FjrEnt4ZCe60o6ByKRjOGlI2gow0aE/Q41QOigdTqkyK5fg==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/json-pointer@17.67.0':
+    resolution: {integrity: sha512-+iqOFInH+QZGmSuaybBUNdh7yvNrXvqR+h3wjXm0N/3JK1EyyFAeGJvqnmQL61d1ARLlk/wJdFKSL+LHJ1eaUA==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/util@1.9.0':
+    resolution: {integrity: sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/util@17.67.0':
+    resolution: {integrity: sha512-6+8xBaz1rLSohlGh68D1pdw3AwDi9xydm8QNlAFkvnavCJYSze+pxoW2VKP8p308jtlMRLs5NTHfPlZLd4w7ew==}
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
@@ -784,10 +882,6 @@ packages:
   '@parcel/watcher@2.4.1':
     resolution: {integrity: sha512-HNjmfLQEVRZmHRET336f20H/8kOozUGwk7yajvsonjNxbj2wBTK1WsQuHkD5yYh9RxFGL2EyDHryOihOwUoKDA==}
     engines: {node: '>= 10.0.0'}
-
-  '@pkgjs/parseargs@0.11.0':
-    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
-    engines: {node: '>=14'}
 
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
@@ -1146,12 +1240,9 @@ packages:
   '@vue/shared@3.5.29':
     resolution: {integrity: sha512-w7SR0A5zyRByL9XUkCfdLs7t9XOHUyJ67qPGQjOou3p6GvBeBW+AVjUUmlxtZ4PIYaRvE+1LmK44O4uajlZwcg==}
 
-  '@yarnpkg/lockfile@1.1.0':
-    resolution: {integrity: sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==}
-
-  '@zip.js/zip.js@2.7.48':
-    resolution: {integrity: sha512-J7cliimZ2snAbr0IhLx2U8BwfA1pKucahKzTpFtYq4hEgKxwvFJcIjCIVNPwQpfVab7iVP+AKmoH1gidBlyhiQ==}
-    engines: {bun: '>=0.7.0', deno: '>=1.0.0', node: '>=16.5.0'}
+  '@zip.js/zip.js@2.8.26':
+    resolution: {integrity: sha512-RQ4h9F6DOiHxpdocUDrOl6xBM+yOtz+LkUol47AVWcfebGBDpZ7w7Xvz9PS24JgXvLGiXXzSAfdCdVy1tPlaFA==}
+    engines: {bun: '>=0.7.0', deno: '>=1.0.0', node: '>=18.0.0'}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -1262,6 +1353,10 @@ packages:
     resolution: {integrity: sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==}
     engines: {node: 20 || >=22}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -1298,6 +1393,10 @@ packages:
     resolution: {integrity: sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==}
     engines: {node: 20 || >=22}
 
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+    engines: {node: 18 || 20 || >=22}
+
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
@@ -1321,8 +1420,16 @@ packages:
     resolution: {integrity: sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==}
     engines: {node: '>=6'}
 
-  call-bind@1.0.7:
-    resolution: {integrity: sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==}
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bind@1.0.9:
+    resolution: {integrity: sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
   callsites@3.1.0:
@@ -1348,12 +1455,12 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
-  chalk@5.3.0:
-    resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
-    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
-
   chalk@5.4.1:
     resolution: {integrity: sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   change-case@5.4.4:
@@ -1382,10 +1489,6 @@ packages:
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
-
-  ci-info@3.9.0:
-    resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
-    engines: {node: '>=8'}
 
   clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
@@ -1450,6 +1553,9 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  colorjs.io@0.5.2:
+    resolution: {integrity: sha512-twmVoizEW7ylZSN32OgKdXRmo1qg+wT5/6C3xu5b9QsWzSFAhHLn2xd8ro0diCsKfCj1RdaTP/nrcW+vAoQPIw==}
 
   commander@12.1.0:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
@@ -1677,11 +1783,12 @@ packages:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
     engines: {node: '>=8'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   duplexer2@0.1.4:
     resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
-
-  eastasianwidth@0.2.0:
-    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
   electron-to-chromium@1.5.4:
     resolution: {integrity: sha512-orzA81VqLyIGUEA77YkVA1D+N+nNfl2isJVjjmOyrlxuooZ19ynb+dOlaDTqd/idKRS9lDCSBmtzM+kyCsMnkA==}
@@ -1694,9 +1801,6 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-
-  emoji-regex@9.2.2:
-    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   emojilib@2.4.0:
     resolution: {integrity: sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==}
@@ -1730,12 +1834,16 @@ packages:
   error-stack-parser-es@1.0.5:
     resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
 
-  es-define-property@1.0.0:
-    resolution: {integrity: sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==}
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
 
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
 
   esbuild@0.27.2:
@@ -1986,9 +2094,6 @@ packages:
     resolution: {integrity: sha512-2kCCtc+JvcZ86IGAz3Z2Y0A1baIz9fL31pH/0S1IqZr9Iwnjq8izfPtrCyQKO6TLMPELLsQMre7VDqeIKCsHkA==}
     engines: {node: '>=18'}
 
-  find-yarn-workspace-root@2.0.0:
-    resolution: {integrity: sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==}
-
   findup-sync@4.0.0:
     resolution: {integrity: sha512-6jvvn/12IC4quLBL1KNokxC7wWTvYncaVUYSoxWw7YykPLuRrnv4qdHcSOywOI5RpkOVGeQRtWM8/q+G6W6qfQ==}
     engines: {node: '>= 8'}
@@ -2000,12 +2105,9 @@ packages:
   flatted@3.3.1:
     resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==}
 
-  for-each@0.3.3:
-    resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
-
-  foreground-child@3.2.1:
-    resolution: {integrity: sha512-PXUUyLqrR2XCWICfv6ukppP96sdFwWbNEnfEMt7jNsISjMsvaLNinAHNDYyvkyU+SZG2BTSbT5NjG+vZslfGTA==}
-    engines: {node: '>=14'}
+  for-each@0.3.5:
+    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
+    engines: {node: '>= 0.4'}
 
   from2@2.3.0:
     resolution: {integrity: sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==}
@@ -2033,6 +2135,10 @@ packages:
     resolution: {integrity: sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA==}
     engines: {node: '>=18'}
 
+  generator-function@2.0.1:
+    resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
+    engines: {node: '>= 0.4'}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -2045,8 +2151,12 @@ packages:
     resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
     engines: {node: '>=18'}
 
-  get-intrinsic@1.2.4:
-    resolution: {integrity: sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==}
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
   get-stream@4.1.0:
@@ -2089,14 +2199,19 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
-  glob@10.4.5:
-    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-    hasBin: true
+  glob-to-regex.js@1.2.0:
+    resolution: {integrity: sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
 
   glob@13.0.5:
     resolution: {integrity: sha512-BzXxZg24Ibra1pbQ/zE7Kys4Ua1ks7Bn6pKLkVPZ9FZe4JQS6/Q7ef3LG1H+k7lUf5l4T3PLSyYyYJVYUvfgTw==}
     engines: {node: 20 || >=22}
+
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
@@ -2133,8 +2248,9 @@ packages:
   globrex@0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
 
-  gopd@1.0.1:
-    resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
 
   graceful-fs@4.2.10:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
@@ -2161,12 +2277,8 @@ packages:
   has-property-descriptors@1.0.2:
     resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
 
-  has-proto@1.0.3:
-    resolution: {integrity: sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==}
-    engines: {node: '>= 0.4'}
-
-  has-symbols@1.0.3:
-    resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
 
   has-tostringtag@1.0.2:
@@ -2175,6 +2287,10 @@ packages:
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
   highlight.js@10.7.3:
@@ -2305,8 +2421,8 @@ packages:
     resolution: {integrity: sha512-2dYz766i9HprMBasCMvHMuazJ7u4WzhJwo5kb3iPSiW/iRYV6uPari3zHoqZlnuaR7V1bEiNMxikhp37rdBXbw==}
     engines: {node: '>=12'}
 
-  is-arguments@1.1.1:
-    resolution: {integrity: sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==}
+  is-arguments@1.2.0:
+    resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
     engines: {node: '>= 0.4'}
 
   is-arrayish@0.2.1:
@@ -2323,11 +2439,6 @@ packages:
   is-core-module@2.15.0:
     resolution: {integrity: sha512-Dd+Lb2/zvk9SKy1TGCt1wFJFo/MWBPMX5x7KcvLajWTGuomczdQX61PvY5yK6SVACwpoexWo81IfFyoKY2QnTA==}
     engines: {node: '>= 0.4'}
-
-  is-docker@2.2.1:
-    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
-    engines: {node: '>=8'}
-    hasBin: true
 
   is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
@@ -2346,8 +2457,8 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
-  is-generator-function@1.0.10:
-    resolution: {integrity: sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==}
+  is-generator-function@1.1.2:
+    resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
     engines: {node: '>= 0.4'}
 
   is-glob@4.0.3:
@@ -2379,6 +2490,10 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-regex@1.2.1:
+    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
+    engines: {node: '>= 0.4'}
+
   is-stream@1.1.0:
     resolution: {integrity: sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==}
     engines: {node: '>=0.10.0'}
@@ -2395,8 +2510,8 @@ packages:
     resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
     engines: {node: '>=18'}
 
-  is-typed-array@1.1.13:
-    resolution: {integrity: sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==}
+  is-typed-array@1.1.15:
+    resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
     engines: {node: '>= 0.4'}
 
   is-unicode-supported@0.1.0:
@@ -2418,19 +2533,12 @@ packages:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
     engines: {node: '>=0.10.0'}
 
-  is-wsl@2.2.0:
-    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
-    engines: {node: '>=8'}
-
   is-wsl@3.1.0:
     resolution: {integrity: sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==}
     engines: {node: '>=16'}
 
   isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
-
-  isarray@2.0.5:
-    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -2442,9 +2550,6 @@ packages:
   issue-parser@7.0.1:
     resolution: {integrity: sha512-3YZcUUR2Wt1WsapF+S/WiA2WmlW0cWAoPccMqne7AxEBhCdFeTPjfv/Axb8V2gyCgY3nRw+ksZ3xSUX+R47iAg==}
     engines: {node: ^18.17 || >=20.6.1}
-
-  jackspeak@3.4.3:
-    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   java-properties@1.0.2:
     resolution: {integrity: sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==}
@@ -2492,10 +2597,6 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
-  json-stable-stringify@1.1.1:
-    resolution: {integrity: sha512-SU/971Kt5qVQfJpyDveVhQ/vya+5hvrjClFOcr8c0Fq5aODJjMwutrOfCU+eCnVD5gpx1Q3fEqkyom77zH1iIg==}
-    engines: {node: '>= 0.4'}
-
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
@@ -2508,14 +2609,8 @@ packages:
   jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
 
-  jsonify@0.0.1:
-    resolution: {integrity: sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==}
-
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
-
-  klaw-sync@6.0.0:
-    resolution: {integrity: sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==}
 
   kolorist@1.8.0:
     resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
@@ -2690,6 +2785,10 @@ packages:
     resolution: {integrity: sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==}
     engines: {node: 20 || >=22}
 
+  lru-cache@11.3.5:
+    resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -2711,9 +2810,14 @@ packages:
     engines: {node: '>= 18'}
     hasBin: true
 
-  memfs@4.11.1:
-    resolution: {integrity: sha512-LZcMTBAgqUUKNXZagcZxvXXfgF1bHX7Y7nQ0QyEiNbRJgE29GhgPd8Yna1VQcLlPiHt/5RFJMWYN9Uv/VPNvjQ==}
-    engines: {node: '>= 4.0.0'}
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  memfs@4.57.2:
+    resolution: {integrity: sha512-2nWzSsJzrukurSDna4Z0WywuScK4Id3tSKejgu74u8KCdW4uNrseKRSIDg75C6Yw5ZRqBe0F0EtMNlTbUq8bAQ==}
+    peerDependencies:
+      tslib: '2'
 
   memorystream@0.3.1:
     resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
@@ -2762,6 +2866,10 @@ packages:
     resolution: {integrity: sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A==}
     engines: {node: 20 || >=22}
 
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -2777,6 +2885,10 @@ packages:
 
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   mitt@3.0.1:
@@ -2950,8 +3062,8 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
-  object-inspect@1.13.2:
-    resolution: {integrity: sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==}
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
   object-is@1.1.6:
@@ -2962,8 +3074,8 @@ packages:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
 
-  object.assign@4.1.5:
-    resolution: {integrity: sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==}
+  object.assign@4.1.7:
+    resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
     engines: {node: '>= 0.4'}
 
   ohash@2.0.11:
@@ -2983,10 +3095,6 @@ packages:
   open@10.2.0:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
-
-  open@7.4.2:
-    resolution: {integrity: sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==}
-    engines: {node: '>=8'}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -3096,11 +3204,6 @@ packages:
   parse5@6.0.1:
     resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
 
-  patch-package@8.0.0:
-    resolution: {integrity: sha512-da8BVIhzjtgScwDJ2TtKsfT5JFWz1hYoBl9rUQ1f38MC2HwnEIkK8VN3dKMKcP7P7bvvgzNDbfNHtx3MsQb5vA==}
-    engines: {node: '>=14', npm: '>5'}
-    hasBin: true
-
   path-exists@3.0.0:
     resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
     engines: {node: '>=4'}
@@ -3128,13 +3231,13 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
-  path-scurry@1.11.1:
-    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
-    engines: {node: '>=16 || 14 >=14.18'}
-
   path-scurry@2.0.0:
     resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
     engines: {node: 20 || >=22}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -3186,8 +3289,8 @@ packages:
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
 
-  possible-typed-array-names@1.0.0:
-    resolution: {integrity: sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==}
+  possible-typed-array-names@1.1.0:
+    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
   postcss-selector-parser@6.1.1:
@@ -3206,8 +3309,8 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier@3.4.2:
-    resolution: {integrity: sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==}
+  prettier@3.8.3:
+    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -3235,8 +3338,8 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  qs@6.13.0:
-    resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
     engines: {node: '>=0.6'}
 
   quansync@0.2.11:
@@ -3342,11 +3445,6 @@ packages:
     engines: {node: '>= 0.10'}
     deprecated: Use String.prototype.padEnd() instead
 
-  rimraf@2.7.1:
-    resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
-    hasBin: true
-
   rimraf@6.1.3:
     resolution: {integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==}
     engines: {node: 20 || >=22}
@@ -3376,6 +3474,10 @@ packages:
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safe-regex-test@1.1.0:
+    resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
+    engines: {node: '>= 0.4'}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -3446,8 +3548,20 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  side-channel@1.0.6:
-    resolution: {integrity: sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==}
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
   signal-exit@3.0.7:
@@ -3468,10 +3582,6 @@ packages:
   skin-tone@2.0.0:
     resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
     engines: {node: '>=8'}
-
-  slash@2.0.0:
-    resolution: {integrity: sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==}
-    engines: {node: '>=6'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -3520,10 +3630,6 @@ packages:
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
-
-  string-width@5.1.2:
-    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
-    engines: {node: '>=12'}
 
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
@@ -3579,9 +3685,9 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  style-dictionary@4.4.0:
-    resolution: {integrity: sha512-+xU0IA1StzqAqFs/QtXkK+XJa7wpS4X5H+JQccRKsRCElgeLGocFU1U/UMvMUylKFw6vwGV+Y/a2wb2pm5rFFQ==}
-    engines: {node: '>=18.0.0'}
+  style-dictionary@5.4.0:
+    resolution: {integrity: sha512-6BzO0DV19t6KUEXYfvHJ73d3y8bBDcd0wNLfoZRX817obJ8YX5Vev8Xh3+k9601tHE8qRJ/586iLt0byuY2THw==}
+    engines: {node: '>=22.0.0'}
     hasBin: true
 
   super-regex@1.0.0:
@@ -3638,8 +3744,8 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
-  thingies@1.21.0:
-    resolution: {integrity: sha512-hsqsJsFMsV+aD4s3CWKk85ep/3I9XzYV/IXaSouJMYIoDlgyi11cBhsqYe9/geRfB0YIikBQg6raRaM+nIMP9g==}
+  thingies@2.6.0:
+    resolution: {integrity: sha512-rMHRjmlFLM1R96UYPvpmnc3LYtdFrT33JIB7L9hetGue1qAPfn1N2LJeEjxUSidu1Iku+haLZXDuEXUHNGO/lg==}
     engines: {node: '>=10.18'}
     peerDependencies:
       tslib: ^2
@@ -3680,8 +3786,8 @@ packages:
     resolution: {integrity: sha512-aXJDbk6SnumuaZSANd21XAo15ucCDE38H4fkqiGsc3MhCK+wOlZvLP9cB/TvpHT0mOyWgC4Z8EwRlzqYSUzdsA==}
     engines: {node: '>= 0.4'}
 
-  tree-dump@1.0.2:
-    resolution: {integrity: sha512-dpev9ABuLWdEubk+cIaI9cHwRNNDjkBBLXTwI4UCUFdQ5xXKqNXoK4FEciw/vxf+NQ7Cb7sGUyeUtORvHIdRXQ==}
+  tree-dump@1.1.0:
+    resolution: {integrity: sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA==}
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
@@ -3936,8 +4042,8 @@ packages:
   which-module@2.0.1:
     resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
 
-  which-typed-array@1.1.15:
-    resolution: {integrity: sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==}
+  which-typed-array@1.1.20:
+    resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
     engines: {node: '>= 0.4'}
 
   which@1.3.1:
@@ -3976,10 +4082,6 @@ packages:
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
-
-  wrap-ansi@8.1.0:
-    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
-    engines: {node: '>=12'}
 
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
@@ -4281,26 +4383,27 @@ snapshots:
     dependencies:
       deepmerge: 4.3.1
 
-  '@bundled-es-modules/glob@10.4.2':
+  '@bundled-es-modules/glob@13.0.6':
     dependencies:
       buffer: 6.0.3
       events: 3.3.0
-      glob: 10.4.5
-      patch-package: 8.0.0
+      glob: 13.0.6
       path: 0.12.7
       stream: 0.0.3
       string_decoder: 1.3.0
       url: 0.11.4
 
-  '@bundled-es-modules/memfs@4.9.4':
+  '@bundled-es-modules/memfs@4.17.0(tslib@2.6.3)':
     dependencies:
       assert: 2.1.0
       buffer: 6.0.3
       events: 3.3.0
-      memfs: 4.11.1
+      memfs: 4.57.2(tslib@2.6.3)
       path: 0.12.7
       stream: 0.0.3
       util: 0.12.5
+    transitivePeerDependencies:
+      - tslib
 
   '@colors/colors@1.5.0':
     optional: true
@@ -4638,15 +4741,6 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.2': {}
 
-  '@isaacs/cliui@8.0.2':
-    dependencies:
-      string-width: 5.1.2
-      string-width-cjs: string-width@4.2.3
-      strip-ansi: 7.1.0
-      strip-ansi-cjs: strip-ansi@6.0.1
-      wrap-ansi: 8.1.0
-      wrap-ansi-cjs: wrap-ansi@7.0.0
-
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -4670,16 +4764,127 @@ snapshots:
     dependencies:
       tslib: 2.6.3
 
-  '@jsonjoy.com/json-pack@1.0.4(tslib@2.6.3)':
+  '@jsonjoy.com/base64@17.67.0(tslib@2.6.3)':
     dependencies:
-      '@jsonjoy.com/base64': 1.1.2(tslib@2.6.3)
-      '@jsonjoy.com/util': 1.3.0(tslib@2.6.3)
-      hyperdyperid: 1.2.0
-      thingies: 1.21.0(tslib@2.6.3)
       tslib: 2.6.3
 
-  '@jsonjoy.com/util@1.3.0(tslib@2.6.3)':
+  '@jsonjoy.com/buffers@1.2.1(tslib@2.6.3)':
     dependencies:
+      tslib: 2.6.3
+
+  '@jsonjoy.com/buffers@17.67.0(tslib@2.6.3)':
+    dependencies:
+      tslib: 2.6.3
+
+  '@jsonjoy.com/codegen@1.0.0(tslib@2.6.3)':
+    dependencies:
+      tslib: 2.6.3
+
+  '@jsonjoy.com/codegen@17.67.0(tslib@2.6.3)':
+    dependencies:
+      tslib: 2.6.3
+
+  '@jsonjoy.com/fs-core@4.57.2(tslib@2.6.3)':
+    dependencies:
+      '@jsonjoy.com/fs-node-builtins': 4.57.2(tslib@2.6.3)
+      '@jsonjoy.com/fs-node-utils': 4.57.2(tslib@2.6.3)
+      thingies: 2.6.0(tslib@2.6.3)
+      tslib: 2.6.3
+
+  '@jsonjoy.com/fs-fsa@4.57.2(tslib@2.6.3)':
+    dependencies:
+      '@jsonjoy.com/fs-core': 4.57.2(tslib@2.6.3)
+      '@jsonjoy.com/fs-node-builtins': 4.57.2(tslib@2.6.3)
+      '@jsonjoy.com/fs-node-utils': 4.57.2(tslib@2.6.3)
+      thingies: 2.6.0(tslib@2.6.3)
+      tslib: 2.6.3
+
+  '@jsonjoy.com/fs-node-builtins@4.57.2(tslib@2.6.3)':
+    dependencies:
+      tslib: 2.6.3
+
+  '@jsonjoy.com/fs-node-to-fsa@4.57.2(tslib@2.6.3)':
+    dependencies:
+      '@jsonjoy.com/fs-fsa': 4.57.2(tslib@2.6.3)
+      '@jsonjoy.com/fs-node-builtins': 4.57.2(tslib@2.6.3)
+      '@jsonjoy.com/fs-node-utils': 4.57.2(tslib@2.6.3)
+      tslib: 2.6.3
+
+  '@jsonjoy.com/fs-node-utils@4.57.2(tslib@2.6.3)':
+    dependencies:
+      '@jsonjoy.com/fs-node-builtins': 4.57.2(tslib@2.6.3)
+      tslib: 2.6.3
+
+  '@jsonjoy.com/fs-node@4.57.2(tslib@2.6.3)':
+    dependencies:
+      '@jsonjoy.com/fs-core': 4.57.2(tslib@2.6.3)
+      '@jsonjoy.com/fs-node-builtins': 4.57.2(tslib@2.6.3)
+      '@jsonjoy.com/fs-node-utils': 4.57.2(tslib@2.6.3)
+      '@jsonjoy.com/fs-print': 4.57.2(tslib@2.6.3)
+      '@jsonjoy.com/fs-snapshot': 4.57.2(tslib@2.6.3)
+      glob-to-regex.js: 1.2.0(tslib@2.6.3)
+      thingies: 2.6.0(tslib@2.6.3)
+      tslib: 2.6.3
+
+  '@jsonjoy.com/fs-print@4.57.2(tslib@2.6.3)':
+    dependencies:
+      '@jsonjoy.com/fs-node-utils': 4.57.2(tslib@2.6.3)
+      tree-dump: 1.1.0(tslib@2.6.3)
+      tslib: 2.6.3
+
+  '@jsonjoy.com/fs-snapshot@4.57.2(tslib@2.6.3)':
+    dependencies:
+      '@jsonjoy.com/buffers': 17.67.0(tslib@2.6.3)
+      '@jsonjoy.com/fs-node-utils': 4.57.2(tslib@2.6.3)
+      '@jsonjoy.com/json-pack': 17.67.0(tslib@2.6.3)
+      '@jsonjoy.com/util': 17.67.0(tslib@2.6.3)
+      tslib: 2.6.3
+
+  '@jsonjoy.com/json-pack@1.21.0(tslib@2.6.3)':
+    dependencies:
+      '@jsonjoy.com/base64': 1.1.2(tslib@2.6.3)
+      '@jsonjoy.com/buffers': 1.2.1(tslib@2.6.3)
+      '@jsonjoy.com/codegen': 1.0.0(tslib@2.6.3)
+      '@jsonjoy.com/json-pointer': 1.0.2(tslib@2.6.3)
+      '@jsonjoy.com/util': 1.9.0(tslib@2.6.3)
+      hyperdyperid: 1.2.0
+      thingies: 2.6.0(tslib@2.6.3)
+      tree-dump: 1.1.0(tslib@2.6.3)
+      tslib: 2.6.3
+
+  '@jsonjoy.com/json-pack@17.67.0(tslib@2.6.3)':
+    dependencies:
+      '@jsonjoy.com/base64': 17.67.0(tslib@2.6.3)
+      '@jsonjoy.com/buffers': 17.67.0(tslib@2.6.3)
+      '@jsonjoy.com/codegen': 17.67.0(tslib@2.6.3)
+      '@jsonjoy.com/json-pointer': 17.67.0(tslib@2.6.3)
+      '@jsonjoy.com/util': 17.67.0(tslib@2.6.3)
+      hyperdyperid: 1.2.0
+      thingies: 2.6.0(tslib@2.6.3)
+      tree-dump: 1.1.0(tslib@2.6.3)
+      tslib: 2.6.3
+
+  '@jsonjoy.com/json-pointer@1.0.2(tslib@2.6.3)':
+    dependencies:
+      '@jsonjoy.com/codegen': 1.0.0(tslib@2.6.3)
+      '@jsonjoy.com/util': 1.9.0(tslib@2.6.3)
+      tslib: 2.6.3
+
+  '@jsonjoy.com/json-pointer@17.67.0(tslib@2.6.3)':
+    dependencies:
+      '@jsonjoy.com/util': 17.67.0(tslib@2.6.3)
+      tslib: 2.6.3
+
+  '@jsonjoy.com/util@1.9.0(tslib@2.6.3)':
+    dependencies:
+      '@jsonjoy.com/buffers': 1.2.1(tslib@2.6.3)
+      '@jsonjoy.com/codegen': 1.0.0(tslib@2.6.3)
+      tslib: 2.6.3
+
+  '@jsonjoy.com/util@17.67.0(tslib@2.6.3)':
+    dependencies:
+      '@jsonjoy.com/buffers': 17.67.0(tslib@2.6.3)
+      '@jsonjoy.com/codegen': 17.67.0(tslib@2.6.3)
       tslib: 2.6.3
 
   '@kong/eslint-config-kong-ui@1.6.1(@typescript-eslint/parser@8.46.1(eslint@9.39.3(jiti@2.4.2))(typescript@6.0.2))(eslint@9.39.3(jiti@2.4.2))(typescript@6.0.2)':
@@ -4839,9 +5044,6 @@ snapshots:
       '@parcel/watcher-win32-arm64': 2.4.1
       '@parcel/watcher-win32-ia32': 2.4.1
       '@parcel/watcher-win32-x64': 2.4.1
-    optional: true
-
-  '@pkgjs/parseargs@0.11.0':
     optional: true
 
   '@pnpm/config.env-replace@1.1.0': {}
@@ -5303,9 +5505,7 @@ snapshots:
 
   '@vue/shared@3.5.29': {}
 
-  '@yarnpkg/lockfile@1.1.0': {}
-
-  '@zip.js/zip.js@2.7.48': {}
+  '@zip.js/zip.js@2.8.26': {}
 
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
@@ -5388,10 +5588,10 @@ snapshots:
 
   assert@2.1.0:
     dependencies:
-      call-bind: 1.0.7
+      call-bind: 1.0.9
       is-nan: 1.3.2
       object-is: 1.1.6
-      object.assign: 4.1.5
+      object.assign: 4.1.7
       util: 0.12.5
 
   ast-kit@2.2.0:
@@ -5408,11 +5608,13 @@ snapshots:
 
   available-typed-arrays@1.0.7:
     dependencies:
-      possible-typed-array-names: 1.0.0
+      possible-typed-array-names: 1.1.0
 
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.3: {}
+
+  balanced-match@4.0.4: {}
 
   base64-js@1.5.1: {}
 
@@ -5456,6 +5658,10 @@ snapshots:
     dependencies:
       balanced-match: 4.0.3
 
+  brace-expansion@5.0.5:
+    dependencies:
+      balanced-match: 4.0.4
+
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
@@ -5483,13 +5689,22 @@ snapshots:
 
   cachedir@2.3.0: {}
 
-  call-bind@1.0.7:
+  call-bind-apply-helpers@1.0.2:
     dependencies:
-      es-define-property: 1.0.0
       es-errors: 1.3.0
       function-bind: 1.1.2
-      get-intrinsic: 1.2.4
+
+  call-bind@1.0.9:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
       set-function-length: 1.2.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   callsites@3.1.0: {}
 
@@ -5510,9 +5725,9 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
-  chalk@5.3.0: {}
-
   chalk@5.4.1: {}
+
+  chalk@5.6.2: {}
 
   change-case@5.4.4: {}
 
@@ -5546,8 +5761,6 @@ snapshots:
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
-
-  ci-info@3.9.0: {}
 
   clean-stack@2.2.0: {}
 
@@ -5617,6 +5830,8 @@ snapshots:
   color-name@1.1.3: {}
 
   color-name@1.1.4: {}
+
+  colorjs.io@0.5.2: {}
 
   commander@12.1.0: {}
 
@@ -5803,9 +6018,9 @@ snapshots:
 
   define-data-property@1.1.4:
     dependencies:
-      es-define-property: 1.0.0
+      es-define-property: 1.0.1
       es-errors: 1.3.0
-      gopd: 1.0.1
+      gopd: 1.2.0
 
   define-lazy-prop@3.0.0: {}
 
@@ -5834,11 +6049,15 @@ snapshots:
     dependencies:
       is-obj: 2.0.0
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   duplexer2@0.1.4:
     dependencies:
       readable-stream: 2.3.8
-
-  eastasianwidth@0.2.0: {}
 
   electron-to-chromium@1.5.4: {}
 
@@ -5847,8 +6066,6 @@ snapshots:
   emoji-regex@7.0.3: {}
 
   emoji-regex@8.0.0: {}
-
-  emoji-regex@9.2.2: {}
 
   emojilib@2.4.0: {}
 
@@ -5878,11 +6095,13 @@ snapshots:
 
   error-stack-parser-es@1.0.5: {}
 
-  es-define-property@1.0.0:
-    dependencies:
-      get-intrinsic: 1.2.4
+  es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
 
   esbuild@0.27.2:
     optionalDependencies:
@@ -6213,10 +6432,6 @@ snapshots:
       semver-regex: 4.0.5
       super-regex: 1.0.0
 
-  find-yarn-workspace-root@2.0.0:
-    dependencies:
-      micromatch: 4.0.8
-
   findup-sync@4.0.0:
     dependencies:
       detect-file: 1.0.0
@@ -6231,14 +6446,9 @@ snapshots:
 
   flatted@3.3.1: {}
 
-  for-each@0.3.3:
+  for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
-
-  foreground-child@3.2.1:
-    dependencies:
-      cross-spawn: 7.0.6
-      signal-exit: 4.1.0
 
   from2@2.3.0:
     dependencies:
@@ -6267,19 +6477,31 @@ snapshots:
 
   function-timeout@1.0.2: {}
 
+  generator-function@2.0.1: {}
+
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.4.0: {}
 
-  get-intrinsic@1.2.4:
+  get-intrinsic@1.3.0:
     dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
       es-errors: 1.3.0
+      es-object-atoms: 1.1.1
       function-bind: 1.1.2
-      has-proto: 1.0.3
-      has-symbols: 1.0.3
-      hasown: 2.0.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
 
   get-stream@4.1.0:
     dependencies:
@@ -6323,20 +6545,21 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
-  glob@10.4.5:
+  glob-to-regex.js@1.2.0(tslib@2.6.3):
     dependencies:
-      foreground-child: 3.2.1
-      jackspeak: 3.4.3
-      minimatch: 9.0.5
-      minipass: 7.1.2
-      package-json-from-dist: 1.0.1
-      path-scurry: 1.11.1
+      tslib: 2.6.3
 
   glob@13.0.5:
     dependencies:
       minimatch: 10.2.1
       minipass: 7.1.2
       path-scurry: 2.0.0
+
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
 
   glob@7.2.3:
     dependencies:
@@ -6375,9 +6598,7 @@ snapshots:
 
   globrex@0.1.2: {}
 
-  gopd@1.0.1:
-    dependencies:
-      get-intrinsic: 1.2.4
+  gopd@1.2.0: {}
 
   graceful-fs@4.2.10: {}
 
@@ -6400,17 +6621,19 @@ snapshots:
 
   has-property-descriptors@1.0.2:
     dependencies:
-      es-define-property: 1.0.0
+      es-define-property: 1.0.1
 
-  has-proto@1.0.3: {}
-
-  has-symbols@1.0.3: {}
+  has-symbols@1.1.0: {}
 
   has-tostringtag@1.0.2:
     dependencies:
-      has-symbols: 1.0.3
+      has-symbols: 1.1.0
 
   hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
 
@@ -6546,9 +6769,9 @@ snapshots:
       from2: 2.3.0
       p-is-promise: 3.0.0
 
-  is-arguments@1.1.1:
+  is-arguments@1.2.0:
     dependencies:
-      call-bind: 1.0.7
+      call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
   is-arrayish@0.2.1: {}
@@ -6563,8 +6786,6 @@ snapshots:
     dependencies:
       hasown: 2.0.2
 
-  is-docker@2.2.1: {}
-
   is-docker@3.0.0: {}
 
   is-extglob@2.1.1: {}
@@ -6573,9 +6794,13 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
-  is-generator-function@1.0.10:
+  is-generator-function@1.1.2:
     dependencies:
+      call-bound: 1.0.4
+      generator-function: 2.0.1
+      get-proto: 1.0.1
       has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
 
   is-glob@4.0.3:
     dependencies:
@@ -6589,7 +6814,7 @@ snapshots:
 
   is-nan@1.3.2:
     dependencies:
-      call-bind: 1.0.7
+      call-bind: 1.0.9
       define-properties: 1.2.1
 
   is-number@7.0.0: {}
@@ -6597,6 +6822,13 @@ snapshots:
   is-obj@2.0.0: {}
 
   is-plain-obj@4.1.0: {}
+
+  is-regex@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.3
 
   is-stream@1.1.0: {}
 
@@ -6606,9 +6838,9 @@ snapshots:
 
   is-stream@4.0.1: {}
 
-  is-typed-array@1.1.13:
+  is-typed-array@1.1.15:
     dependencies:
-      which-typed-array: 1.1.15
+      which-typed-array: 1.1.20
 
   is-unicode-supported@0.1.0: {}
 
@@ -6620,17 +6852,11 @@ snapshots:
 
   is-windows@1.0.2: {}
 
-  is-wsl@2.2.0:
-    dependencies:
-      is-docker: 2.2.1
-
   is-wsl@3.1.0:
     dependencies:
       is-inside-container: 1.0.0
 
   isarray@1.0.0: {}
-
-  isarray@2.0.5: {}
 
   isexe@2.0.0: {}
 
@@ -6643,12 +6869,6 @@ snapshots:
       lodash.isplainobject: 4.0.6
       lodash.isstring: 4.0.1
       lodash.uniqby: 4.7.0
-
-  jackspeak@3.4.3:
-    dependencies:
-      '@isaacs/cliui': 8.0.2
-    optionalDependencies:
-      '@pkgjs/parseargs': 0.11.0
 
   java-properties@1.0.2: {}
 
@@ -6679,13 +6899,6 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
-  json-stable-stringify@1.1.1:
-    dependencies:
-      call-bind: 1.0.7
-      isarray: 2.0.5
-      jsonify: 0.0.1
-      object-keys: 1.1.1
-
   json5@2.2.3: {}
 
   jsonc-eslint-parser@2.4.0:
@@ -6701,15 +6914,9 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
-  jsonify@0.0.1: {}
-
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
-
-  klaw-sync@6.0.0:
-    dependencies:
-      graceful-fs: 4.2.11
 
   kolorist@1.8.0: {}
 
@@ -6844,6 +7051,8 @@ snapshots:
 
   lru-cache@11.2.2: {}
 
+  lru-cache@11.3.5: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -6869,11 +7078,23 @@ snapshots:
 
   marked@15.0.12: {}
 
-  memfs@4.11.1:
+  math-intrinsics@1.1.0: {}
+
+  memfs@4.57.2(tslib@2.6.3):
     dependencies:
-      '@jsonjoy.com/json-pack': 1.0.4(tslib@2.6.3)
-      '@jsonjoy.com/util': 1.3.0(tslib@2.6.3)
-      tree-dump: 1.0.2(tslib@2.6.3)
+      '@jsonjoy.com/fs-core': 4.57.2(tslib@2.6.3)
+      '@jsonjoy.com/fs-fsa': 4.57.2(tslib@2.6.3)
+      '@jsonjoy.com/fs-node': 4.57.2(tslib@2.6.3)
+      '@jsonjoy.com/fs-node-builtins': 4.57.2(tslib@2.6.3)
+      '@jsonjoy.com/fs-node-to-fsa': 4.57.2(tslib@2.6.3)
+      '@jsonjoy.com/fs-node-utils': 4.57.2(tslib@2.6.3)
+      '@jsonjoy.com/fs-print': 4.57.2(tslib@2.6.3)
+      '@jsonjoy.com/fs-snapshot': 4.57.2(tslib@2.6.3)
+      '@jsonjoy.com/json-pack': 1.21.0(tslib@2.6.3)
+      '@jsonjoy.com/util': 1.9.0(tslib@2.6.3)
+      glob-to-regex.js: 1.2.0(tslib@2.6.3)
+      thingies: 2.6.0(tslib@2.6.3)
+      tree-dump: 1.1.0(tslib@2.6.3)
       tslib: 2.6.3
 
   memorystream@0.3.1: {}
@@ -6908,6 +7129,10 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.2
 
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.5
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.11
@@ -6921,6 +7146,8 @@ snapshots:
   minimist@1.2.8: {}
 
   minipass@7.1.2: {}
+
+  minipass@7.1.3: {}
 
   mitt@3.0.1: {}
 
@@ -7023,20 +7250,22 @@ snapshots:
 
   object-assign@4.1.1: {}
 
-  object-inspect@1.13.2: {}
+  object-inspect@1.13.4: {}
 
   object-is@1.1.6:
     dependencies:
-      call-bind: 1.0.7
+      call-bind: 1.0.9
       define-properties: 1.2.1
 
   object-keys@1.1.1: {}
 
-  object.assign@4.1.5:
+  object.assign@4.1.7:
     dependencies:
-      call-bind: 1.0.7
+      call-bind: 1.0.9
+      call-bound: 1.0.4
       define-properties: 1.2.1
-      has-symbols: 1.0.3
+      es-object-atoms: 1.1.1
+      has-symbols: 1.1.0
       object-keys: 1.1.1
 
   ohash@2.0.11: {}
@@ -7059,11 +7288,6 @@ snapshots:
       define-lazy-prop: 3.0.0
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
-
-  open@7.4.2:
-    dependencies:
-      is-docker: 2.2.1
-      is-wsl: 2.2.0
 
   optionator@0.9.4:
     dependencies:
@@ -7168,24 +7392,6 @@ snapshots:
 
   parse5@6.0.1: {}
 
-  patch-package@8.0.0:
-    dependencies:
-      '@yarnpkg/lockfile': 1.1.0
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      cross-spawn: 7.0.6
-      find-yarn-workspace-root: 2.0.0
-      fs-extra: 9.1.0
-      json-stable-stringify: 1.1.1
-      klaw-sync: 6.0.0
-      minimist: 1.2.8
-      open: 7.4.2
-      rimraf: 2.7.1
-      semver: 7.6.3
-      slash: 2.0.0
-      tmp: 0.0.33
-      yaml: 2.8.2
-
   path-exists@3.0.0: {}
 
   path-exists@4.0.0: {}
@@ -7200,15 +7406,15 @@ snapshots:
 
   path-parse@1.0.7: {}
 
-  path-scurry@1.11.1:
-    dependencies:
-      lru-cache: 10.4.3
-      minipass: 7.1.2
-
   path-scurry@2.0.0:
     dependencies:
       lru-cache: 11.2.2
       minipass: 7.1.2
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.3.5
+      minipass: 7.1.3
 
   path-type@4.0.0: {}
 
@@ -7252,7 +7458,7 @@ snapshots:
       exsolve: 1.0.8
       pathe: 2.0.3
 
-  possible-typed-array-names@1.0.0: {}
+  possible-typed-array-names@1.1.0: {}
 
   postcss-selector-parser@6.1.1:
     dependencies:
@@ -7273,7 +7479,7 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier@3.4.2: {}
+  prettier@3.8.3: {}
 
   pretty-ms@9.2.0:
     dependencies:
@@ -7294,9 +7500,9 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  qs@6.13.0:
+  qs@6.15.1:
     dependencies:
-      side-channel: 1.0.6
+      side-channel: 1.1.0
 
   quansync@0.2.11: {}
 
@@ -7408,10 +7614,6 @@ snapshots:
 
   right-pad@1.0.1: {}
 
-  rimraf@2.7.1:
-    dependencies:
-      glob: 7.2.3
-
   rimraf@6.1.3:
     dependencies:
       glob: 13.0.5
@@ -7453,6 +7655,12 @@ snapshots:
   safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
+
+  safe-regex-test@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-regex: 1.2.1
 
   safer-buffer@2.1.2: {}
 
@@ -7515,8 +7723,8 @@ snapshots:
       define-data-property: 1.1.4
       es-errors: 1.3.0
       function-bind: 1.1.2
-      get-intrinsic: 1.2.4
-      gopd: 1.0.1
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
       has-property-descriptors: 1.0.2
 
   shebang-command@1.2.0:
@@ -7545,12 +7753,33 @@ snapshots:
       minimist: 1.2.8
       shelljs: 0.9.2
 
-  side-channel@1.0.6:
+  side-channel-list@1.0.1:
     dependencies:
-      call-bind: 1.0.7
       es-errors: 1.3.0
-      get-intrinsic: 1.2.4
-      object-inspect: 1.13.2
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   signal-exit@3.0.7: {}
 
@@ -7571,8 +7800,6 @@ snapshots:
   skin-tone@2.0.0:
     dependencies:
       unicode-emoji-modifier-base: 1.0.0
-
-  slash@2.0.0: {}
 
   source-map-js@1.2.1: {}
 
@@ -7623,12 +7850,6 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
-  string-width@5.1.2:
-    dependencies:
-      eastasianwidth: 0.2.0
-      emoji-regex: 9.2.2
-      strip-ansi: 7.1.0
-
   string-width@7.2.0:
     dependencies:
       emoji-regex: 10.6.0
@@ -7671,21 +7892,23 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  style-dictionary@4.4.0:
+  style-dictionary@5.4.0(tslib@2.6.3):
     dependencies:
       '@bundled-es-modules/deepmerge': 4.3.1
-      '@bundled-es-modules/glob': 10.4.2
-      '@bundled-es-modules/memfs': 4.9.4
-      '@zip.js/zip.js': 2.7.48
-      chalk: 5.3.0
+      '@bundled-es-modules/glob': 13.0.6
+      '@bundled-es-modules/memfs': 4.17.0(tslib@2.6.3)
+      '@zip.js/zip.js': 2.8.26
+      chalk: 5.6.2
       change-case: 5.4.4
+      colorjs.io: 0.5.2
       commander: 12.1.0
       is-plain-obj: 4.1.0
       json5: 2.2.3
-      patch-package: 8.0.0
       path-unified: 0.2.0
-      prettier: 3.4.2
+      prettier: 3.8.3
       tinycolor2: 1.6.0
+    transitivePeerDependencies:
+      - tslib
 
   super-regex@1.0.0:
     dependencies:
@@ -7738,7 +7961,7 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
-  thingies@1.21.0(tslib@2.6.3):
+  thingies@2.6.0(tslib@2.6.3):
     dependencies:
       tslib: 2.6.3
 
@@ -7774,7 +7997,7 @@ snapshots:
 
   traverse@0.6.8: {}
 
-  tree-dump@1.0.2(tslib@2.6.3):
+  tree-dump@1.1.0(tslib@2.6.3):
     dependencies:
       tslib: 2.6.3
 
@@ -7873,7 +8096,7 @@ snapshots:
   url@0.11.4:
     dependencies:
       punycode: 1.4.1
-      qs: 6.13.0
+      qs: 6.15.1
 
   util-deprecate@1.0.2: {}
 
@@ -7884,10 +8107,10 @@ snapshots:
   util@0.12.5:
     dependencies:
       inherits: 2.0.4
-      is-arguments: 1.1.1
-      is-generator-function: 1.0.10
-      is-typed-array: 1.1.13
-      which-typed-array: 1.1.15
+      is-arguments: 1.2.0
+      is-generator-function: 1.1.2
+      is-typed-array: 1.1.15
+      which-typed-array: 1.1.20
 
   validate-npm-package-license@3.0.4:
     dependencies:
@@ -8022,12 +8245,14 @@ snapshots:
 
   which-module@2.0.1: {}
 
-  which-typed-array@1.1.15:
+  which-typed-array@1.1.20:
     dependencies:
       available-typed-arrays: 1.0.7
-      call-bind: 1.0.7
-      for-each: 0.3.3
-      gopd: 1.0.1
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      for-each: 0.3.5
+      get-proto: 1.0.1
+      gopd: 1.2.0
       has-tostringtag: 1.0.2
 
   which@1.3.1:
@@ -8067,12 +8292,6 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-
-  wrap-ansi@8.1.0:
-    dependencies:
-      ansi-styles: 6.2.1
-      string-width: 5.1.2
-      strip-ansi: 7.1.0
 
   wrap-ansi@9.0.2:
     dependencies:

--- a/tokens/alias/color/index.json
+++ b/tokens/alias/color/index.json
@@ -3,476 +3,474 @@
     "alias": {
       "aqua": {
         "10": {
-          "comment": "Alias for #ECFCFF.",
-          "type": "color",
-          "value": "#ECFCFF"
+          "$description": "Alias for #ECFCFF.",
+          "$type": "color",
+          "$value": "#ECFCFF"
         },
         "20": {
-          "comment": "Alias for #B3F1FF.",
-          "type": "color",
-          "value": "#B3F1FF"
+          "$description": "Alias for #B3F1FF.",
+          "$type": "color",
+          "$value": "#B3F1FF"
         },
         "30": {
-          "comment": "Alias for #67E3FF.",
-          "type": "color",
-          "value": "#67E3FF"
+          "$description": "Alias for #67E3FF.",
+          "$type": "color",
+          "$value": "#67E3FF"
         },
         "40": {
-          "comment": "Alias for #00C8F4.",
-          "type": "color",
-          "value": "#00C8F4"
+          "$description": "Alias for #00C8F4.",
+          "$type": "color",
+          "$value": "#00C8F4"
         },
         "50": {
-          "comment": "Alias for #00ABD2.",
-          "type": "color",
-          "value": "#00ABD2"
+          "$description": "Alias for #00ABD2.",
+          "$type": "color",
+          "$value": "#00ABD2"
         },
         "60": {
-          "comment": "Alias for #00819D.",
-          "type": "color",
-          "value": "#00819D"
+          "$description": "Alias for #00819D.",
+          "$type": "color",
+          "$value": "#00819D"
         },
         "70": {
-          "comment": "Alias for #00647A.",
-          "type": "color",
-          "value": "#00647A"
+          "$description": "Alias for #00647A.",
+          "$type": "color",
+          "$value": "#00647A"
         },
         "80": {
-          "comment": "Alias for #004757.",
-          "type": "color",
-          "value": "#004757"
+          "$description": "Alias for #004757.",
+          "$type": "color",
+          "$value": "#004757"
         },
         "90": {
-          "comment": "Alias for #003946.",
-          "type": "color",
-          "value": "#003946"
+          "$description": "Alias for #003946.",
+          "$type": "color",
+          "$value": "#003946"
         },
         "100": {
-          "comment": "Alias for #002B34.",
-          "type": "color",
-          "value": "#002B34"
+          "$description": "Alias for #002B34.",
+          "$type": "color",
+          "$value": "#002B34"
         }
       },
       "black": {
-        "comment": "Alias for #000.",
-        "type": "color",
-        "value": "#000"
+        "$description": "Alias for #000.",
+        "$type": "color",
+        "$value": "#000"
       },
       "blue": {
         "10": {
-          "comment": "Alias for #EEFAFF.",
-          "type": "color",
-          "value": "#EEFAFF"
+          "$description": "Alias for #EEFAFF.",
+          "$type": "color",
+          "$value": "#EEFAFF"
         },
         "20": {
-          "comment": "Alias for #BEE2FF.",
-          "type": "color",
-          "value": "#BEE2FF"
+          "$description": "Alias for #BEE2FF.",
+          "$type": "color",
+          "$value": "#BEE2FF"
         },
         "30": {
-          "comment": "Alias for #8FC1FF.",
-          "type": "color",
-          "value": "#8FC1FF"
+          "$description": "Alias for #8FC1FF.",
+          "$type": "color",
+          "$value": "#8FC1FF"
         },
         "40": {
-          "comment": "Alias for #5F9AFF.",
-          "type": "color",
-          "value": "#5F9AFF"
+          "$description": "Alias for #5F9AFF.",
+          "$type": "color",
+          "$value": "#5F9AFF"
         },
         "50": {
-          "comment": "Alias for #306FFF.",
-          "type": "color",
-          "value": "#306FFF"
+          "$description": "Alias for #306FFF.",
+          "$type": "color",
+          "$value": "#306FFF"
         },
         "60": {
-          "comment": "Alias for #0044F4.",
-          "type": "color",
-          "value": "#0044F4"
+          "$description": "Alias for #0044F4.",
+          "$type": "color",
+          "$value": "#0044F4"
         },
         "70": {
-          "comment": "Alias for #0030CC.",
-          "type": "color",
-          "value": "#0030CC"
+          "$description": "Alias for #0030CC.",
+          "$type": "color",
+          "$value": "#0030CC"
         },
         "80": {
-          "comment": "Alias for #002099.",
-          "type": "color",
-          "value": "#002099"
+          "$description": "Alias for #002099.",
+          "$type": "color",
+          "$value": "#002099"
         },
         "90": {
-          "comment": "Alias for #001466.",
-          "type": "color",
-          "value": "#001466"
+          "$description": "Alias for #001466.",
+          "$type": "color",
+          "$value": "#001466"
         },
         "100": {
-          "comment": "Alias for #000933.",
-          "rgb": "0, 9, 51",
-          "type": "color",
-          "value": "#000933"
+          "$description": "Alias for #000933.",
+          "$type": "color",
+          "$value": "#000933"
         }
       },
       "gray": {
         "10": {
-          "comment": "Alias for #F9FAFB.",
-          "type": "color",
-          "value": "#F9FAFB"
+          "$description": "Alias for #F9FAFB.",
+          "$type": "color",
+          "$value": "#F9FAFB"
         },
         "20": {
-          "comment": "Alias for #E0E4EA.",
-          "type": "color",
-          "value": "#E0E4EA"
+          "$description": "Alias for #E0E4EA.",
+          "$type": "color",
+          "$value": "#E0E4EA"
         },
         "30": {
-          "comment": "Alias for #C7CED8.",
-          "type": "color",
-          "value": "#C7CED8"
+          "$description": "Alias for #C7CED8.",
+          "$type": "color",
+          "$value": "#C7CED8"
         },
         "40": {
-          "comment": "Alias for #AFB7C5.",
-          "type": "color",
-          "value": "#AFB7C5"
+          "$description": "Alias for #AFB7C5.",
+          "$type": "color",
+          "$value": "#AFB7C5"
         },
         "50": {
-          "comment": "Alias for #828A9E.",
-          "type": "color",
-          "value": "#828A9E"
+          "$description": "Alias for #828A9E.",
+          "$type": "color",
+          "$value": "#828A9E"
         },
         "60": {
-          "comment": "Alias for #6C7489",
-          "type": "color",
-          "value": "#6C7489"
+          "$description": "Alias for #6C7489",
+          "$type": "color",
+          "$value": "#6C7489"
         },
         "70": {
-          "comment": "Alias for #52596E.",
-          "type": "color",
-          "value": "#52596E"
+          "$description": "Alias for #52596E.",
+          "$type": "color",
+          "$value": "#52596E"
         },
         "80": {
-          "comment": "Alias for #3A3F51.",
-          "type": "color",
-          "value": "#3A3F51"
+          "$description": "Alias for #3A3F51.",
+          "$type": "color",
+          "$value": "#3A3F51"
         },
         "90": {
-          "comment": "Alias for #232633.",
-          "type": "color",
-          "value": "#232633"
+          "$description": "Alias for #232633.",
+          "$type": "color",
+          "$value": "#232633"
         },
         "100": {
-          "comment": "Alias for #0D0E14.",
-          "type": "color",
-          "value": "#0D0E14"
+          "$description": "Alias for #0D0E14.",
+          "$type": "color",
+          "$value": "#0D0E14"
         }
       },
       "green": {
         "10": {
-          "comment": "Alias for #ECFFFB.",
-          "type": "color",
-          "value": "#ECFFFB"
+          "$description": "Alias for #ECFFFB.",
+          "$type": "color",
+          "$value": "#ECFFFB"
         },
         "20": {
-          "comment": "Alias for #B5FFEE.",
-          "type": "color",
-          "value": "#B5FFEE"
+          "$description": "Alias for #B5FFEE.",
+          "$type": "color",
+          "$value": "#B5FFEE"
         },
         "30": {
-          "comment": "Alias for #00FABE.",
-          "type": "color",
-          "value": "#00FABE"
+          "$description": "Alias for #00FABE.",
+          "$type": "color",
+          "$value": "#00FABE"
         },
         "40": {
-          "comment": "Alias for #00D6A4.",
-          "type": "color",
-          "value": "#00D6A4"
+          "$description": "Alias for #00D6A4.",
+          "$type": "color",
+          "$value": "#00D6A4"
         },
         "50": {
-          "comment": "Alias for #00A17B.",
-          "type": "color",
-          "value": "#00A17B"
+          "$description": "Alias for #00A17B.",
+          "$type": "color",
+          "$value": "#00A17B"
         },
         "60": {
-          "comment": "Alias for #007D60.",
-          "type": "color",
-          "value": "#007D60"
+          "$description": "Alias for #007D60.",
+          "$type": "color",
+          "$value": "#007D60"
         },
         "70": {
-          "comment": "Alias for #005944.",
-          "type": "color",
-          "value": "#005944"
+          "$description": "Alias for #005944.",
+          "$type": "color",
+          "$value": "#005944"
         },
         "80": {
-          "comment": "Alias for #004737.",
-          "type": "color",
-          "value": "#004737"
+          "$description": "Alias for #004737.",
+          "$type": "color",
+          "$value": "#004737"
         },
         "90": {
-          "comment": "Alias for #003629.",
-          "type": "color",
-          "value": "#003629"
+          "$description": "Alias for #003629.",
+          "$type": "color",
+          "$value": "#003629"
         },
         "100": {
-          "comment": "Alias for #00241B.",
-          "type": "color",
-          "value": "#00241B"
+          "$description": "Alias for #00241B.",
+          "$type": "color",
+          "$value": "#00241B"
         }
       },
       "orange": {
         "10": {
-          "comment": "Alias for #FFF1EF.",
-          "value": "#FFF1EF"
+          "$description": "Alias for #FFF1EF.",
+          "$value": "#FFF1EF"
         },
         "20": {
-          "comment": "Alias for #FFC2B3.",
-          "value": "#FFC2B3"
+          "$description": "Alias for #FFC2B3.",
+          "$value": "#FFC2B3"
         },
         "30": {
-          "comment": "Alias for #FF9877.",
-          "value": "#FF9877"
+          "$description": "Alias for #FF9877.",
+          "$value": "#FF9877"
         },
         "40": {
-          "comment": "Alias for #FF723C.",
-          "value": "#FF723C"
+          "$description": "Alias for #FF723C.",
+          "$value": "#FF723C"
         },
         "50": {
-          "comment": "Alias for #F75008.",
-          "value": "#F75008"
+          "$description": "Alias for #F75008.",
+          "$value": "#F75008"
         },
         "60": {
-          "comment": "Alias for #D13500.",
-          "value": "#D13500"
+          "$description": "Alias for #D13500.",
+          "$value": "#D13500"
         },
         "70": {
-          "comment": "Alias for #A31F00.",
-          "value": "#A31F00"
+          "$description": "Alias for #A31F00.",
+          "$value": "#A31F00"
         },
         "80": {
-          "comment": "Alias for #750D00.",
-          "value": "#750D00"
+          "$description": "Alias for #750D00.",
+          "$value": "#750D00"
         },
         "90": {
-          "comment": "Alias for #470200.",
-          "value": "#470200"
+          "$description": "Alias for #470200.",
+          "$value": "#470200"
         },
         "100": {
-          "comment": "Alias for #330100.",
-          "value": "#330100"
+          "$description": "Alias for #330100.",
+          "$value": "#330100"
         }
       },
       "pink": {
         "10": {
-          "comment": "Alias for #FFF0F7.",
-          "type": "color",
-          "value": "#FFF0F7"
+          "$description": "Alias for #FFF0F7.",
+          "$type": "color",
+          "$value": "#FFF0F7"
         },
         "20": {
-          "comment": "Alias for #FFB4D8.",
-          "type": "color",
-          "value": "#FFB4D8"
+          "$description": "Alias for #FFB4D8.",
+          "$type": "color",
+          "$value": "#FFB4D8"
         },
         "30": {
-          "comment": "Alias for #FF78B9.",
-          "type": "color",
-          "value": "#FF78B9"
+          "$description": "Alias for #FF78B9.",
+          "$type": "color",
+          "$value": "#FF78B9"
         },
         "40": {
-          "comment": "Alias for #FF3C99.",
-          "type": "color",
-          "value": "#FF3C99"
+          "$description": "Alias for #FF3C99.",
+          "$type": "color",
+          "$value": "#FF3C99"
         },
         "50": {
-          "comment": "Alias for #F4007A.",
-          "type": "color",
-          "value": "#F4007A"
+          "$description": "Alias for #F4007A.",
+          "$type": "color",
+          "$value": "#F4007A"
         },
         "60": {
-          "comment": "Alias for #D60067.",
-          "type": "color",
-          "value": "#D60067"
+          "$description": "Alias for #D60067.",
+          "$type": "color",
+          "$value": "#D60067"
         },
         "70": {
-          "comment": "Alias for #AD0053.",
-          "type": "color",
-          "value": "#AD0053"
+          "$description": "Alias for #AD0053.",
+          "$type": "color",
+          "$value": "#AD0053"
         },
         "80": {
-          "comment": "Alias for #85003F.",
-          "type": "color",
-          "value": "#85003F"
+          "$description": "Alias for #85003F.",
+          "$type": "color",
+          "$value": "#85003F"
         },
         "90": {
-          "comment": "Alias for #5C002C.",
-          "type": "color",
-          "value": "#5C002C"
+          "$description": "Alias for #5C002C.",
+          "$type": "color",
+          "$value": "#5C002C"
         },
         "100": {
-          "comment": "Alias for #330018.",
-          "type": "color",
-          "value": "#330018"
+          "$description": "Alias for #330018.",
+          "$type": "color",
+          "$value": "#330018"
         }
       },
       "purple": {
         "10": {
-          "comment": "Alias for #F1F0FF.",
-          "type": "color",
-          "value": "#F1F0FF"
+          "$description": "Alias for #F1F0FF.",
+          "$type": "color",
+          "$value": "#F1F0FF"
         },
         "20": {
-          "comment": "Alias for #CFC8FF.",
-          "type": "color",
-          "value": "#CFC8FF"
+          "$description": "Alias for #CFC8FF.",
+          "$type": "color",
+          "$value": "#CFC8FF"
         },
         "30": {
-          "comment": "Alias for #B2A0FF.",
-          "type": "color",
-          "value": "#B2A0FF"
+          "$description": "Alias for #B2A0FF.",
+          "$type": "color",
+          "$value": "#B2A0FF"
         },
         "40": {
-          "comment": "Alias for #9878FF.",
-          "type": "color",
-          "value": "#9878FF"
+          "$description": "Alias for #9878FF.",
+          "$type": "color",
+          "$value": "#9878FF"
         },
         "50": {
-          "comment": "Alias for #8250FF.",
-          "type": "color",
-          "value": "#8250FF"
+          "$description": "Alias for #8250FF.",
+          "$type": "color",
+          "$value": "#8250FF"
         },
         "60": {
-          "comment": "Alias for #6F28FF.",
-          "type": "color",
-          "value": "#6F28FF"
+          "$description": "Alias for #6F28FF.",
+          "$type": "color",
+          "$value": "#6F28FF"
         },
         "70": {
-          "comment": "Alias for #5E00F5.",
-          "type": "color",
-          "value": "#5E00F5"
+          "$description": "Alias for #5E00F5.",
+          "$type": "color",
+          "$value": "#5E00F5"
         },
         "80": {
-          "comment": "Alias for #4900C2.",
-          "type": "color",
-          "value": "#4900C2"
+          "$description": "Alias for #4900C2.",
+          "$type": "color",
+          "$value": "#4900C2"
         },
         "90": {
-          "comment": "Alias for #350085.",
-          "type": "color",
-          "value": "#350085"
+          "$description": "Alias for #350085.",
+          "$type": "color",
+          "$value": "#350085"
         },
         "100": {
-          "comment": "Alias for #200047.",
-          "type": "color",
-          "value": "#200047"
+          "$description": "Alias for #200047.",
+          "$type": "color",
+          "$value": "#200047"
         }
       },
       "red": {
         "10": {
-          "comment": "Alias for #FFE5E5.",
-          "type": "color",
-          "value": "#FFE5E5"
+          "$description": "Alias for #FFE5E5.",
+          "$type": "color",
+          "$value": "#FFE5E5"
         },
         "20": {
-          "comment": "Alias for #FFABAB.",
-          "type": "color",
-          "value": "#FFABAB"
+          "$description": "Alias for #FFABAB.",
+          "$type": "color",
+          "$value": "#FFABAB"
         },
         "30": {
-          "comment": "Alias for #FF7272.",
-          "type": "color",
-          "value": "#FF7272"
+          "$description": "Alias for #FF7272.",
+          "$type": "color",
+          "$value": "#FF7272"
         },
         "40": {
-          "comment": "Alias for #FF3954.",
-          "type": "color",
-          "value": "#FF3954"
+          "$description": "Alias for #FF3954.",
+          "$type": "color",
+          "$value": "#FF3954"
         },
         "50": {
-          "comment": "Alias for #F50045.",
-          "type": "color",
-          "value": "#F50045"
+          "$description": "Alias for #F50045.",
+          "$type": "color",
+          "$value": "#F50045"
         },
         "60": {
-          "comment": "Alias for #D60027.",
-          "type": "color",
-          "value": "#D60027"
+          "$description": "Alias for #D60027.",
+          "$type": "color",
+          "$value": "#D60027"
         },
         "70": {
-          "comment": "Alias for #AD000E.",
-          "type": "color",
-          "value": "#AD000E"
+          "$description": "Alias for #AD000E.",
+          "$type": "color",
+          "$value": "#AD000E"
         },
         "80": {
-          "comment": "Alias for #850000.",
-          "type": "color",
-          "value": "#850000"
+          "$description": "Alias for #850000.",
+          "$type": "color",
+          "$value": "#850000"
         },
         "90": {
-          "comment": "Alias for #5C0000.",
-          "type": "color",
-          "value": "#5C0000"
+          "$description": "Alias for #5C0000.",
+          "$type": "color",
+          "$value": "#5C0000"
         },
         "100": {
-          "comment": "Alias for #330000.",
-          "type": "color",
-          "value": "#330000"
+          "$description": "Alias for #330000.",
+          "$type": "color",
+          "$value": "#330000"
         }
       },
       "transparent": {
-        "comment": "Alias for transparent.",
-        "value": "transparent"
+        "$description": "Alias for transparent.",
+        "$value": "transparent"
       },
       "white": {
-        "comment": "Alias for #FFF.",
-        "rgb": "255, 255, 255",
-        "type": "color",
-        "value": "#FFF"
+        "$description": "Alias for #FFF.",
+        "$type": "color",
+        "$value": "#FFF"
       },
       "yellow": {
         "10": {
-          "comment": "Alias for #FFFCE0.",
-          "type": "color",
-          "value": "#FFFCE0"
+          "$description": "Alias for #FFFCE0.",
+          "$type": "color",
+          "$value": "#FFFCE0"
         },
         "20": {
-          "comment": "Alias for #FFF296.",
-          "type": "color",
-          "value": "#FFF296"
+          "$description": "Alias for #FFF296.",
+          "$type": "color",
+          "$value": "#FFF296"
         },
         "30": {
-          "comment": "Alias for #FFE04B.",
-          "type": "color",
-          "value": "#FFE04B"
+          "$description": "Alias for #FFE04B.",
+          "$type": "color",
+          "$value": "#FFE04B"
         },
         "40": {
-          "comment": "Alias for #FFC400.",
-          "type": "color",
-          "value": "#FFC400"
+          "$description": "Alias for #FFC400.",
+          "$type": "color",
+          "$value": "#FFC400"
         },
         "50": {
-          "comment": "Alias for #B37600.",
-          "type": "color",
-          "value": "#B37600"
+          "$description": "Alias for #B37600.",
+          "$type": "color",
+          "$value": "#B37600"
         },
         "60": {
-          "comment": "Alias for #995C00.",
-          "type": "color",
-          "value": "#995C00"
+          "$description": "Alias for #995C00.",
+          "$type": "color",
+          "$value": "#995C00"
         },
         "70": {
-          "comment": "Alias for #804400.",
-          "type": "color",
-          "value": "#804400"
+          "$description": "Alias for #804400.",
+          "$type": "color",
+          "$value": "#804400"
         },
         "80": {
-          "comment": "Alias for #662D00.",
-          "type": "color",
-          "value": "#662D00"
+          "$description": "Alias for #662D00.",
+          "$type": "color",
+          "$value": "#662D00"
         },
         "90": {
-          "comment": "Alias for #4D1B00.",
-          "type": "color",
-          "value": "#4D1B00"
+          "$description": "Alias for #4D1B00.",
+          "$type": "color",
+          "$value": "#4D1B00"
         },
         "100": {
-          "comment": "Alias for #330C00.",
-          "type": "color",
-          "value": "#330C00"
+          "$description": "Alias for #330C00.",
+          "$type": "color",
+          "$value": "#330C00"
         }
       }
     }

--- a/tokens/source/animation/index.json
+++ b/tokens/source/animation/index.json
@@ -2,8 +2,8 @@
   "animation": {
     "duration": {
       "20": {
-        "comment": "Default transition timing",
-        "value": "0.2s"
+        "$description": "Default transition timing",
+        "$value": "0.2s"
       }
     }
   }

--- a/tokens/source/border/radius.json
+++ b/tokens/source/border/radius.json
@@ -2,36 +2,36 @@
   "border": {
     "radius": {
       "0": {
-        "comment": "0px border radius.",
-        "value": "0px"
+        "$description": "0px border radius.",
+        "$value": "0px"
       },
       "10": {
-        "comment": "2px border radius.",
-        "value": "2px"
+        "$description": "2px border radius.",
+        "$value": "2px"
       },
       "20": {
-        "comment": "4px border radius.",
-        "value": "4px"
+        "$description": "4px border radius.",
+        "$value": "4px"
       },
       "30": {
-        "comment": "6px border radius.",
-        "value": "6px"
+        "$description": "6px border radius.",
+        "$value": "6px"
       },
       "40": {
-        "comment": "8px border radius.",
-        "value": "8px"
+        "$description": "8px border radius.",
+        "$value": "8px"
       },
       "50": {
-        "comment": "10px border radius.",
-        "value": "10px"
+        "$description": "10px border radius.",
+        "$value": "10px"
       },
       "circle": {
-        "comment": "50% border radius used to create circles.",
-        "value": "50%"
+        "$description": "50% border radius used to create circles.",
+        "$value": "50%"
       },
       "round": {
-        "comment": "100px border radius used to create pill shapes.",
-        "value": "100px"
+        "$description": "100px border radius used to create pill shapes.",
+        "$value": "100px"
       }
     }
   }

--- a/tokens/source/border/width.json
+++ b/tokens/source/border/width.json
@@ -2,20 +2,20 @@
   "border": {
     "width": {
       "0": {
-        "comment": "0px border width.",
-        "value": "0px"
+        "$description": "0px border width.",
+        "$value": "0px"
       },
       "10": {
-        "comment": "1px border width.",
-        "value": "1px"
+        "$description": "1px border width.",
+        "$value": "1px"
       },
       "20": {
-        "comment": "2px border width.",
-        "value": "2px"
+        "$description": "2px border width.",
+        "$value": "2px"
       },
       "30": {
-        "comment": "4px border width.",
-        "value": "4px"
+        "$description": "4px border width.",
+        "$value": "4px"
       }
     }
   }

--- a/tokens/source/breakpoint/index.json
+++ b/tokens/source/breakpoint/index.json
@@ -1,29 +1,29 @@
 {
   "breakpoint": {
     "mobile": {
-      "comment": "Used for larger mobile screens. Any viewport width under this value is considered mobile.",
-      "type": "breakpoint",
-      "value": "640px"
+      "$description": "Used for larger mobile screens. Any viewport width under this value is considered mobile.",
+      "$type": "breakpoint",
+      "$value": "640px"
     },
     "phablet": {
-      "comment": "Used for tablet screens.",
-      "type": "breakpoint",
-      "value": "768px"
+      "$description": "Used for tablet screens.",
+      "$type": "breakpoint",
+      "$value": "768px"
     },
     "tablet": {
-      "comment": "Used for larger tablet screens. Any viewport width less than this value will likely show a mobile layout. Any viewport width this value and greater will likely show a desktop layout.",
-      "type": "breakpoint",
-      "value": "1024px"
+      "$description": "Used for larger tablet screens. Any viewport width less than this value will likely show a mobile layout. Any viewport width this value and greater will likely show a desktop layout.",
+      "$type": "breakpoint",
+      "$value": "1024px"
     },
     "laptop": {
-      "comment": "Used for standard desktop screens.",
-      "type": "breakpoint",
-      "value": "1280px"
+      "$description": "Used for standard desktop screens.",
+      "$type": "breakpoint",
+      "$value": "1280px"
     },
     "desktop": {
-      "comment": "Used for larger desktop screens.",
-      "type": "breakpoint",
-      "value": "1536px"
+      "$description": "Used for larger desktop screens.",
+      "$type": "breakpoint",
+      "$value": "1536px"
     }
   }
 }

--- a/tokens/source/color/background.json
+++ b/tokens/source/color/background.json
@@ -2,271 +2,271 @@
   "color": {
     "background": {
       "_": {
-        "comment": "Default background color for containers (white).",
-        "type": "color",
-        "value": "{color.alias.white.value}"
+        "$description": "Default background color for containers (white).",
+        "$type": "color",
+        "$value": "{color.alias.white}"
       },
       "danger": {
         "_": {
-          "comment": "Background color for danger actions or messages (red.60).",
-          "type": "color",
-          "value": "{color.alias.red.60.value}"
+          "$description": "Background color for danger actions or messages (red.60).",
+          "$type": "color",
+          "$value": "{color.alias.red.60}"
         },
         "strong": {
-          "comment": "Strong background color for danger actions or messages (red.70).",
-          "type": "color",
-          "value": "{color.alias.red.70.value}"
+          "$description": "Strong background color for danger actions or messages (red.70).",
+          "$type": "color",
+          "$value": "{color.alias.red.70}"
         },
         "stronger": {
-          "comment": "Stronger background color for danger actions or messages (red.80).",
-          "type": "color",
-          "value": "{color.alias.red.80.value}"
+          "$description": "Stronger background color for danger actions or messages (red.80).",
+          "$type": "color",
+          "$value": "{color.alias.red.80}"
         },
         "strongest": {
-          "comment": "Strongest background color for danger actions or messages (red.90).",
-          "type": "color",
-          "value": "{color.alias.red.90.value}"
+          "$description": "Strongest background color for danger actions or messages (red.90).",
+          "$type": "color",
+          "$value": "{color.alias.red.90}"
         },
         "weak": {
-          "comment": "Weak background color for danger actions or messages (red.40).",
-          "type": "color",
-          "value": "{color.alias.red.40.value}"
+          "$description": "Weak background color for danger actions or messages (red.40).",
+          "$type": "color",
+          "$value": "{color.alias.red.40}"
         },
         "weaker": {
-          "comment": "Weaker background color for danger actions or messages (red.20).",
-          "type": "color",
-          "value": "{color.alias.red.20.value}"
+          "$description": "Weaker background color for danger actions or messages (red.20).",
+          "$type": "color",
+          "$value": "{color.alias.red.20}"
         },
         "weakest": {
-          "comment": "Weakest background color for danger actions or messages (red.10).",
-          "type": "color",
-          "value": "{color.alias.red.10.value}"
+          "$description": "Weakest background color for danger actions or messages (red.10).",
+          "$type": "color",
+          "$value": "{color.alias.red.10}"
         }
       },
       "decorative": {
         "aqua": {
           "weakest": {
-            "comment": "Weakest background color for decorative purposes (aqua.10).",
-            "type": "color",
-            "value": "{color.alias.aqua.10.value}"
+            "$description": "Weakest background color for decorative purposes (aqua.10).",
+            "$type": "color",
+            "$value": "{color.alias.aqua.10}"
           }
         },
         "purple": {
           "_": {
-            "comment": "Background color for decorative purposes (purple.60).",
-            "type": "color",
-            "value": "{color.alias.purple.60.value}"
+            "$description": "Background color for decorative purposes (purple.60).",
+            "$type": "color",
+            "$value": "{color.alias.purple.60}"
           },
           "weakest": {
-            "comment": "Weakest background color for decorative purposes (purple.10).",
-            "type": "color",
-            "value": "{color.alias.purple.10.value}"
+            "$description": "Weakest background color for decorative purposes (purple.10).",
+            "$type": "color",
+            "$value": "{color.alias.purple.10}"
           }
         }
       },
       "disabled": {
-        "comment": "Background color for disabled elements (gray.20).",
-        "type": "color",
-        "value": "{color.alias.gray.20.value}"
+        "$description": "Background color for disabled elements (gray.20).",
+        "$type": "color",
+        "$value": "{color.alias.gray.20}"
       },
       "info": {
         "_": {
-          "comment": "Background color for info elements (blue.60).",
-          "type": "color",
-          "value": "{color.alias.blue.60.value}"
+          "$description": "Background color for info elements (blue.60).",
+          "$type": "color",
+          "$value": "{color.alias.blue.60}"
         },
         "strong": {
-          "comment": "Strong background color for info elements (blue.70).",
-          "type": "color",
-          "value": "{color.alias.blue.70.value}"
+          "$description": "Strong background color for info elements (blue.70).",
+          "$type": "color",
+          "$value": "{color.alias.blue.70}"
         },
         "stronger": {
-          "comment": "Stronger background color for info elements (blue.80).",
-          "type": "color",
-          "value": "{color.alias.blue.80.value}"
+          "$description": "Stronger background color for info elements (blue.80).",
+          "$type": "color",
+          "$value": "{color.alias.blue.80}"
         },
         "strongest": {
-          "comment": "Strongest background color for info elements (blue.90).",
-          "type": "color",
-          "value": "{color.alias.blue.90.value}"
+          "$description": "Strongest background color for info elements (blue.90).",
+          "$type": "color",
+          "$value": "{color.alias.blue.90}"
         },
         "weak": {
-          "comment": "Weak background color for info elements (blue.40).",
-          "type": "color",
-          "value": "{color.alias.blue.40.value}"
+          "$description": "Weak background color for info elements (blue.40).",
+          "$type": "color",
+          "$value": "{color.alias.blue.40}"
         },
         "weaker": {
-          "comment": "Weaker background color for info elements (blue.20).",
-          "type": "color",
-          "value": "{color.alias.blue.20.value}"
+          "$description": "Weaker background color for info elements (blue.20).",
+          "$type": "color",
+          "$value": "{color.alias.blue.20}"
         },
         "weakest": {
-          "comment": "Weakest background color for info elements (blue.10).",
-          "type": "color",
-          "value": "{color.alias.blue.10.value}"
+          "$description": "Weakest background color for info elements (blue.10).",
+          "$type": "color",
+          "$value": "{color.alias.blue.10}"
         }
       },
       "inverse": {
-        "comment": "Inverse background color for containers (blue.100)",
-        "type": "color",
-        "value": "{color.alias.blue.100.value}"
+        "$description": "Inverse background color for containers (blue.100)",
+        "$type": "color",
+        "$value": "{color.alias.blue.100}"
       },
       "neutral": {
         "_": {
-          "comment": "Background color for neutral elements (gray.60).",
-          "type": "color",
-          "value": "{color.alias.gray.60.value}"
+          "$description": "Background color for neutral elements (gray.60).",
+          "$type": "color",
+          "$value": "{color.alias.gray.60}"
         },
         "strong": {
-          "comment": "Strong background color for neutral elements (gray.70).",
-          "type": "color",
-          "value": "{color.alias.gray.70.value}"
+          "$description": "Strong background color for neutral elements (gray.70).",
+          "$type": "color",
+          "$value": "{color.alias.gray.70}"
         },
         "stronger": {
-          "comment": "Stronger background color for neutral elements (gray.80).",
-          "type": "color",
-          "value": "{color.alias.gray.80.value}"
+          "$description": "Stronger background color for neutral elements (gray.80).",
+          "$type": "color",
+          "$value": "{color.alias.gray.80}"
         },
         "strongest": {
-          "comment": "Strongest background color for neutral elements (gray.90).",
-          "type": "color",
-          "value": "{color.alias.gray.90.value}"
+          "$description": "Strongest background color for neutral elements (gray.90).",
+          "$type": "color",
+          "$value": "{color.alias.gray.90}"
         },
         "weak": {
-          "comment": "Weak background color for neutral elements (gray.40).",
-          "type": "color",
-          "value": "{color.alias.gray.40.value}"
+          "$description": "Weak background color for neutral elements (gray.40).",
+          "$type": "color",
+          "$value": "{color.alias.gray.40}"
         },
         "weaker": {
-          "comment": "Weaker background color for neutral elements (gray.20).",
-          "type": "color",
-          "value": "{color.alias.gray.20.value}"
+          "$description": "Weaker background color for neutral elements (gray.20).",
+          "$type": "color",
+          "$value": "{color.alias.gray.20}"
         },
         "weakest": {
-          "comment": "Weakest background color for neutral elements (gray.10).",
-          "type": "color",
-          "value": "{color.alias.gray.10.value}"
+          "$description": "Weakest background color for neutral elements (gray.10).",
+          "$type": "color",
+          "$value": "{color.alias.gray.10}"
         }
       },
       "overlay": {
-        "comment": "Overlay background color (rgba(blue.100, 0.6))",
-        "type": "color",
-        "value": "rgba({color.alias.blue.100.rgb}, 0.6)"
+        "$description": "Overlay background color (rgba(0, 9, 51, 0.6))",
+        "$type": "color",
+        "$value": "rgba(0, 9, 51, 0.6)"
       },
       "primary": {
         "_": {
-          "comment": "Background color for primary actions or messages (blue.60).",
-          "type": "color",
-          "value": "{color.alias.blue.60.value}"
+          "$description": "Background color for primary actions or messages (blue.60).",
+          "$type": "color",
+          "$value": "{color.alias.blue.60}"
         },
         "strong": {
-          "comment": "Strong background color for primary actions or messages (blue.70).",
-          "type": "color",
-          "value": "{color.alias.blue.70.value}"
+          "$description": "Strong background color for primary actions or messages (blue.70).",
+          "$type": "color",
+          "$value": "{color.alias.blue.70}"
         },
         "stronger": {
-          "comment": "Stronger background color for primary actions or messages (blue.80).",
-          "type": "color",
-          "value": "{color.alias.blue.80.value}"
+          "$description": "Stronger background color for primary actions or messages (blue.80).",
+          "$type": "color",
+          "$value": "{color.alias.blue.80}"
         },
         "strongest": {
-          "comment": "Strongest background color for primary actions or messages (blue.90).",
-          "type": "color",
-          "value": "{color.alias.blue.90.value}"
+          "$description": "Strongest background color for primary actions or messages (blue.90).",
+          "$type": "color",
+          "$value": "{color.alias.blue.90}"
         },
         "weak": {
-          "comment": "Weak background color for primary actions or messages (blue.40).",
-          "type": "color",
-          "value": "{color.alias.blue.40.value}"
+          "$description": "Weak background color for primary actions or messages (blue.40).",
+          "$type": "color",
+          "$value": "{color.alias.blue.40}"
         },
         "weaker": {
-          "comment": "Weaker background color for primary actions or messages (blue.20).",
-          "type": "color",
-          "value": "{color.alias.blue.20.value}"
+          "$description": "Weaker background color for primary actions or messages (blue.20).",
+          "$type": "color",
+          "$value": "{color.alias.blue.20}"
         },
         "weakest": {
-          "comment": "Weakest background color for primary actions or messages (blue.10)",
-          "type": "color",
-          "value": "{color.alias.blue.10.value}"
+          "$description": "Weakest background color for primary actions or messages (blue.10)",
+          "$type": "color",
+          "$value": "{color.alias.blue.10}"
         }
       },
       "success": {
         "_": {
-          "comment": "Background color for success elements (green.60).",
-          "type": "color",
-          "value": "{color.alias.green.60.value}"
+          "$description": "Background color for success elements (green.60).",
+          "$type": "color",
+          "$value": "{color.alias.green.60}"
         },
         "strong": {
-          "comment": "Strong background color for success elements (green.70).",
-          "type": "color",
-          "value": "{color.alias.green.70.value}"
+          "$description": "Strong background color for success elements (green.70).",
+          "$type": "color",
+          "$value": "{color.alias.green.70}"
         },
         "stronger": {
-          "comment": "Stronger background color for success elements (green.80).",
-          "type": "color",
-          "value": "{color.alias.green.80.value}"
+          "$description": "Stronger background color for success elements (green.80).",
+          "$type": "color",
+          "$value": "{color.alias.green.80}"
         },
         "strongest": {
-          "comment": "Strongest background color for success elements (green.90).",
-          "type": "color",
-          "value": "{color.alias.green.90.value}"
+          "$description": "Strongest background color for success elements (green.90).",
+          "$type": "color",
+          "$value": "{color.alias.green.90}"
         },
         "weak": {
-          "comment": "Weak background color for success elements (green.40).",
-          "type": "color",
-          "value": "{color.alias.green.40.value}"
+          "$description": "Weak background color for success elements (green.40).",
+          "$type": "color",
+          "$value": "{color.alias.green.40}"
         },
         "weaker": {
-          "comment": "Weaker background color for success elements (green.20).",
-          "type": "color",
-          "value": "{color.alias.green.20.value}"
+          "$description": "Weaker background color for success elements (green.20).",
+          "$type": "color",
+          "$value": "{color.alias.green.20}"
         },
         "weakest": {
-          "comment": "Weakest background color for success elements (green.10).",
-          "type": "color",
-          "value": "{color.alias.green.10.value}"
+          "$description": "Weakest background color for success elements (green.10).",
+          "$type": "color",
+          "$value": "{color.alias.green.10}"
         }
       },
       "transparent": {
-        "comment": "Transparent background color (transparent).",
-        "type": "color",
-        "value": "{color.alias.transparent.value}"
+        "$description": "Transparent background color (transparent).",
+        "$type": "color",
+        "$value": "{color.alias.transparent}"
       },
       "warning": {
         "_": {
-          "comment": "Background color for warning elements (yellow.60).",
-          "type": "color",
-          "value": "{color.alias.yellow.60.value}"
+          "$description": "Background color for warning elements (yellow.60).",
+          "$type": "color",
+          "$value": "{color.alias.yellow.60}"
         },
         "strong": {
-          "comment": "Strong background color for warning elements (yellow.70).",
-          "type": "color",
-          "value": "{color.alias.yellow.70.value}"
+          "$description": "Strong background color for warning elements (yellow.70).",
+          "$type": "color",
+          "$value": "{color.alias.yellow.70}"
         },
         "stronger": {
-          "comment": "Stronger background color for warning elements (yellow.80).",
-          "type": "color",
-          "value": "{color.alias.yellow.80.value}"
+          "$description": "Stronger background color for warning elements (yellow.80).",
+          "$type": "color",
+          "$value": "{color.alias.yellow.80}"
         },
         "strongest": {
-          "comment": "Strongest background color for warning elements (yellow.90).",
-          "type": "color",
-          "value": "{color.alias.yellow.90.value}"
+          "$description": "Strongest background color for warning elements (yellow.90).",
+          "$type": "color",
+          "$value": "{color.alias.yellow.90}"
         },
         "weak": {
-          "comment": "Weak background color for warning elements (yellow.40).",
-          "type": "color",
-          "value": "{color.alias.yellow.40.value}"
+          "$description": "Weak background color for warning elements (yellow.40).",
+          "$type": "color",
+          "$value": "{color.alias.yellow.40}"
         },
         "weaker": {
-          "comment": "Weaker background color for warning elements (yellow.20).",
-          "type": "color",
-          "value": "{color.alias.yellow.20.value}"
+          "$description": "Weaker background color for warning elements (yellow.20).",
+          "$type": "color",
+          "$value": "{color.alias.yellow.20}"
         },
         "weakest": {
-          "comment": "Weakest background color for warning elements (yellow.10).",
-          "type": "color",
-          "value": "{color.alias.yellow.10.value}"
+          "$description": "Weakest background color for warning elements (yellow.10).",
+          "$type": "color",
+          "$value": "{color.alias.yellow.10}"
         }
       }
     }

--- a/tokens/source/color/border.json
+++ b/tokens/source/color/border.json
@@ -2,142 +2,142 @@
   "color": {
     "border": {
       "_": {
-        "comment": "Default border color for containers (gray.20).",
-        "type": "color",
-        "value": "{color.alias.gray.20.value}"
+        "$description": "Default border color for containers (gray.20).",
+        "$type": "color",
+        "$value": "{color.alias.gray.20}"
       },
       "danger": {
         "_": {
-          "comment": "Border color for danger actions or messages (red.60).",
-          "type": "color",
-          "value": "{color.alias.red.60.value}"
+          "$description": "Border color for danger actions or messages (red.60).",
+          "$type": "color",
+          "$value": "{color.alias.red.60}"
         },
         "strong": {
-          "comment": "Strong border color for danger actions or messages (red.70).",
-          "type": "color",
-          "value": "{color.alias.red.70.value}"
+          "$description": "Strong border color for danger actions or messages (red.70).",
+          "$type": "color",
+          "$value": "{color.alias.red.70}"
         },
         "stronger": {
-          "comment": "Stronger border color for danger actions or messages (red.80).",
-          "type": "color",
-          "value": "{color.alias.red.80.value}"
+          "$description": "Stronger border color for danger actions or messages (red.80).",
+          "$type": "color",
+          "$value": "{color.alias.red.80}"
         },
         "strongest": {
-          "comment": "Strongest border color for danger actions or messages (red.90).",
-          "type": "color",
-          "value": "{color.alias.red.90.value}"
+          "$description": "Strongest border color for danger actions or messages (red.90).",
+          "$type": "color",
+          "$value": "{color.alias.red.90}"
         },
         "weak": {
-          "comment": "Weak border color for danger actions or messages (red.40).",
-          "type": "color",
-          "value": "{color.alias.red.40.value}"
+          "$description": "Weak border color for danger actions or messages (red.40).",
+          "$type": "color",
+          "$value": "{color.alias.red.40}"
         },
         "weaker": {
-          "comment": "Weaker border color for danger actions or messages (red.20).",
-          "type": "color",
-          "value": "{color.alias.red.20.value}"
+          "$description": "Weaker border color for danger actions or messages (red.20).",
+          "$type": "color",
+          "$value": "{color.alias.red.20}"
         },
         "weakest": {
-          "comment": "Weakest border color for danger actions or messages (red.10).",
-          "type": "color",
-          "value": "{color.alias.red.10.value}"
+          "$description": "Weakest border color for danger actions or messages (red.10).",
+          "$type": "color",
+          "$value": "{color.alias.red.10}"
         }
       },
       "decorative": {
         "purple": {
-          "comment": "Border color for decorative purposes (purple.60).",
-          "type": "color",
-          "value": "{color.alias.purple.60.value}"
+          "$description": "Border color for decorative purposes (purple.60).",
+          "$type": "color",
+          "$value": "{color.alias.purple.60}"
         }
       },
       "disabled": {
-        "comment": "Border color for disabled elements (gray.20).",
-        "type": "color",
-        "value": "{color.alias.gray.20.value}"
+        "$description": "Border color for disabled elements (gray.20).",
+        "$type": "color",
+        "$value": "{color.alias.gray.20}"
       },
       "inverse": {
-        "comment": "Inverse border color (rgba(white, 0.2)).",
-        "type": "color",
-        "value": "rgba({color.alias.white.rgb}, 0.2)"
+        "$description": "Inverse border color (rgba(255, 255, 255, 0.2)).",
+        "$type": "color",
+        "$value": "rgba(255, 255, 255, 0.2)"
       },
       "neutral": {
         "_": {
-          "comment": "Border color for neutral elements (gray.60)",
-          "type": "color",
-          "value": "{color.alias.gray.60.value}"
+          "$description": "Border color for neutral elements (gray.60)",
+          "$type": "color",
+          "$value": "{color.alias.gray.60}"
         },
         "strong": {
-          "comment": "Strong border color for neutral elements (gray.70)",
-          "type": "color",
-          "value": "{color.alias.gray.70.value}"
+          "$description": "Strong border color for neutral elements (gray.70)",
+          "$type": "color",
+          "$value": "{color.alias.gray.70}"
         },
         "stronger": {
-          "comment": "Stronger border color for neutral elements (gray.80)",
-          "type": "color",
-          "value": "{color.alias.gray.80.value}"
+          "$description": "Stronger border color for neutral elements (gray.80)",
+          "$type": "color",
+          "$value": "{color.alias.gray.80}"
         },
         "strongest": {
-          "comment": "Strongest border color for neutral elements (gray.90)",
-          "type": "color",
-          "value": "{color.alias.gray.90.value}"
+          "$description": "Strongest border color for neutral elements (gray.90)",
+          "$type": "color",
+          "$value": "{color.alias.gray.90}"
         },
         "weak": {
-          "comment": "Weak border color for neutral elements (gray.40)",
-          "type": "color",
-          "value": "{color.alias.gray.40.value}"
+          "$description": "Weak border color for neutral elements (gray.40)",
+          "$type": "color",
+          "$value": "{color.alias.gray.40}"
         },
         "weaker": {
-          "comment": "Weaker border color for neutral elements (gray.20)",
-          "type": "color",
-          "value": "{color.alias.gray.20.value}"
+          "$description": "Weaker border color for neutral elements (gray.20)",
+          "$type": "color",
+          "$value": "{color.alias.gray.20}"
         },
         "weakest": {
-          "comment": "Weakest border color for neutral elements (gray.10)",
-          "type": "color",
-          "value": "{color.alias.gray.10.value}"
+          "$description": "Weakest border color for neutral elements (gray.10)",
+          "$type": "color",
+          "$value": "{color.alias.gray.10}"
         }
       },
       "primary": {
         "_": {
-          "comment": "Border color for primary actions or messages (blue.60).",
-          "type": "color",
-          "value": "{color.alias.blue.60.value}"
+          "$description": "Border color for primary actions or messages (blue.60).",
+          "$type": "color",
+          "$value": "{color.alias.blue.60}"
         },
         "strong": {
-          "comment": "Strong border color for primary actions or messages (blue.70).",
-          "type": "color",
-          "value": "{color.alias.blue.70.value}"
+          "$description": "Strong border color for primary actions or messages (blue.70).",
+          "$type": "color",
+          "$value": "{color.alias.blue.70}"
         },
         "stronger": {
-          "comment": "Stronger border color for primary actions or messages (blue.80).",
-          "type": "color",
-          "value": "{color.alias.blue.80.value}"
+          "$description": "Stronger border color for primary actions or messages (blue.80).",
+          "$type": "color",
+          "$value": "{color.alias.blue.80}"
         },
         "strongest": {
-          "comment": "Strongest border color for primary actions or messages (blue.90).",
-          "type": "color",
-          "value": "{color.alias.blue.90.value}"
+          "$description": "Strongest border color for primary actions or messages (blue.90).",
+          "$type": "color",
+          "$value": "{color.alias.blue.90}"
         },
         "weak": {
-          "comment": "Weak border color for primary actions or messages (blue.40).",
-          "type": "color",
-          "value": "{color.alias.blue.40.value}"
+          "$description": "Weak border color for primary actions or messages (blue.40).",
+          "$type": "color",
+          "$value": "{color.alias.blue.40}"
         },
         "weaker": {
-          "comment": "Weaker border color for primary actions or messages (blue.20).",
-          "type": "color",
-          "value": "{color.alias.blue.20.value}"
+          "$description": "Weaker border color for primary actions or messages (blue.20).",
+          "$type": "color",
+          "$value": "{color.alias.blue.20}"
         },
         "weakest": {
-          "comment": "Weakest border color for primary actions or messages (blue.10).",
-          "type": "color",
-          "value": "{color.alias.blue.10.value}"
+          "$description": "Weakest border color for primary actions or messages (blue.10).",
+          "$type": "color",
+          "$value": "{color.alias.blue.10}"
         }
       },
       "transparent": {
-        "comment": "Transparent border color (transparent).",
-        "type": "color",
-        "value": "{color.alias.transparent.value}"
+        "$description": "Transparent border color (transparent).",
+        "$type": "color",
+        "$value": "{color.alias.transparent}"
       }
     }
   }

--- a/tokens/source/color/text.json
+++ b/tokens/source/color/text.json
@@ -2,264 +2,264 @@
   "color": {
     "text": {
       "_": {
-        "comment": "Default text color (blue.100).",
-        "type": "color",
-        "value": "{color.alias.blue.100.value}"
+        "$description": "Default text color (blue.100).",
+        "$type": "color",
+        "$value": "{color.alias.blue.100}"
       },
       "danger": {
         "_": {
-          "comment": "Text color for danger actions or messages (red.60).",
-          "type": "color",
-          "value": "{color.alias.red.60.value}"
+          "$description": "Text color for danger actions or messages (red.60).",
+          "$type": "color",
+          "$value": "{color.alias.red.60}"
         },
         "strong": {
-          "comment": "Strong text color for danger actions or messages (red.70).",
-          "type": "color",
-          "value": "{color.alias.red.70.value}"
+          "$description": "Strong text color for danger actions or messages (red.70).",
+          "$type": "color",
+          "$value": "{color.alias.red.70}"
         },
         "stronger": {
-          "comment": "Stronger text color for danger actions or messages (red.80).",
-          "type": "color",
-          "value": "{color.alias.red.80.value}"
+          "$description": "Stronger text color for danger actions or messages (red.80).",
+          "$type": "color",
+          "$value": "{color.alias.red.80}"
         },
         "strongest": {
-          "comment": "Strongest text color for danger actions or messages (red.90).",
-          "type": "color",
-          "value": "{color.alias.red.90.value}"
+          "$description": "Strongest text color for danger actions or messages (red.90).",
+          "$type": "color",
+          "$value": "{color.alias.red.90}"
         },
         "weak": {
-          "comment": "Weak text color for danger actions or messages (red.40).",
-          "type": "color",
-          "value": "{color.alias.red.40.value}"
+          "$description": "Weak text color for danger actions or messages (red.40).",
+          "$type": "color",
+          "$value": "{color.alias.red.40}"
         },
         "weaker": {
-          "comment": "Weaker text color for danger actions or messages (red.20).",
-          "type": "color",
-          "value": "{color.alias.red.20.value}"
+          "$description": "Weaker text color for danger actions or messages (red.20).",
+          "$type": "color",
+          "$value": "{color.alias.red.20}"
         },
         "weakest": {
-          "comment": "Weakest text color for danger actions or messages (red.10).",
-          "type": "color",
-          "value": "{color.alias.red.10.value}"
+          "$description": "Weakest text color for danger actions or messages (red.10).",
+          "$type": "color",
+          "$value": "{color.alias.red.10}"
         }
       },
       "decorative": {
         "aqua": {
-          "comment": "Text color for decorative purposes (aqua.50).",
-          "type": "color",
-          "value": "{color.alias.aqua.50.value}"
+          "$description": "Text color for decorative purposes (aqua.50).",
+          "$type": "color",
+          "$value": "{color.alias.aqua.50}"
         },
         "pink": {
-          "comment": "Text color for decorative purposes (pink.60).",
-          "type": "color",
-          "value": "{color.alias.pink.60.value}"
+          "$description": "Text color for decorative purposes (pink.60).",
+          "$type": "color",
+          "$value": "{color.alias.pink.60}"
         },
         "purple": {
           "_": {
-            "comment": "Text color for decorative purposes (purple.60).",
-            "type": "color",
-            "value": "{color.alias.purple.60.value}"
+            "$description": "Text color for decorative purposes (purple.60).",
+            "$type": "color",
+            "$value": "{color.alias.purple.60}"
           },
           "strong": {
-            "comment": "Strong text color for decorative purposes (purple.70).",
-            "type": "color",
-            "value": "{color.alias.purple.70.value}"
+            "$description": "Strong text color for decorative purposes (purple.70).",
+            "$type": "color",
+            "$value": "{color.alias.purple.70}"
           }
         }
       },
       "disabled": {
-        "comment": "Text color for disabled elements (gray.40).",
-        "type": "color",
-        "value": "{color.alias.gray.40.value}"
+        "$description": "Text color for disabled elements (gray.40).",
+        "$type": "color",
+        "$value": "{color.alias.gray.40}"
       },
       "info": {
         "_": {
-          "comment": "Text color for info elements (blue.60).",
-          "type": "color",
-          "value": "{color.alias.blue.60.value}"
+          "$description": "Text color for info elements (blue.60).",
+          "$type": "color",
+          "$value": "{color.alias.blue.60}"
         },
         "strong": {
-          "comment": "Strong text color for info elements (blue.70).",
-          "type": "color",
-          "value": "{color.alias.blue.70.value}"
+          "$description": "Strong text color for info elements (blue.70).",
+          "$type": "color",
+          "$value": "{color.alias.blue.70}"
         },
         "stronger": {
-          "comment": "Stronger text color for info elements (blue.80).",
-          "type": "color",
-          "value": "{color.alias.blue.80.value}"
+          "$description": "Stronger text color for info elements (blue.80).",
+          "$type": "color",
+          "$value": "{color.alias.blue.80}"
         },
         "strongest": {
-          "comment": "Strongest text color for info elements (blue.90).",
-          "type": "color",
-          "value": "{color.alias.blue.90.value}"
+          "$description": "Strongest text color for info elements (blue.90).",
+          "$type": "color",
+          "$value": "{color.alias.blue.90}"
         },
         "weak": {
-          "comment": "Weak text color for info elements (blue.40).",
-          "type": "color",
-          "value": "{color.alias.blue.40.value}"
+          "$description": "Weak text color for info elements (blue.40).",
+          "$type": "color",
+          "$value": "{color.alias.blue.40}"
         },
         "weaker": {
-          "comment": "Weaker text color for info elements (blue.20).",
-          "type": "color",
-          "value": "{color.alias.blue.20.value}"
+          "$description": "Weaker text color for info elements (blue.20).",
+          "$type": "color",
+          "$value": "{color.alias.blue.20}"
         },
         "weakest": {
-          "comment": "Weakest text color for info elements (blue.10).",
-          "type": "color",
-          "value": "{color.alias.blue.10.value}"
+          "$description": "Weakest text color for info elements (blue.10).",
+          "$type": "color",
+          "$value": "{color.alias.blue.10}"
         }
       },
       "inverse": {
-        "comment": "Inverse text color (white).",
-        "type": "color",
-        "value": "{color.alias.white.value}"
+        "$description": "Inverse text color (white).",
+        "$type": "color",
+        "$value": "{color.alias.white}"
       },
       "neutral": {
         "_": {
-          "comment": "Text color for neutral elements (gray.60).",
-          "type": "color",
-          "value": "{color.alias.gray.60.value}"
+          "$description": "Text color for neutral elements (gray.60).",
+          "$type": "color",
+          "$value": "{color.alias.gray.60}"
         },
         "strong": {
-          "comment": "Strong text color for neutral elements (gray.70).",
-          "type": "color",
-          "value": "{color.alias.gray.70.value}"
+          "$description": "Strong text color for neutral elements (gray.70).",
+          "$type": "color",
+          "$value": "{color.alias.gray.70}"
         },
         "stronger": {
-          "comment": "Stronger text color for neutral elements (gray.80).",
-          "type": "color",
-          "value": "{color.alias.gray.80.value}"
+          "$description": "Stronger text color for neutral elements (gray.80).",
+          "$type": "color",
+          "$value": "{color.alias.gray.80}"
         },
         "strongest": {
-          "comment": "Strongest text color for neutral elements (gray.90).",
-          "type": "color",
-          "value": "{color.alias.gray.90.value}"
+          "$description": "Strongest text color for neutral elements (gray.90).",
+          "$type": "color",
+          "$value": "{color.alias.gray.90}"
         },
         "weak": {
-          "comment": "Weak text color for neutral elements (gray.40).",
-          "type": "color",
-          "value": "{color.alias.gray.40.value}"
+          "$description": "Weak text color for neutral elements (gray.40).",
+          "$type": "color",
+          "$value": "{color.alias.gray.40}"
         },
         "weaker": {
-          "comment": "Weaker text color for neutral elements (gray.20).",
-          "type": "color",
-          "value": "{color.alias.gray.20.value}"
+          "$description": "Weaker text color for neutral elements (gray.20).",
+          "$type": "color",
+          "$value": "{color.alias.gray.20}"
         },
         "weakest": {
-          "comment": "Weakest text color for neutral elements (gray.10).",
-          "type": "color",
-          "value": "{color.alias.gray.10.value}"
+          "$description": "Weakest text color for neutral elements (gray.10).",
+          "$type": "color",
+          "$value": "{color.alias.gray.10}"
         }
       },
       "primary": {
         "_": {
-          "comment": "Text color for primary actions or messages (blue.60).",
-          "type": "color",
-          "value": "{color.alias.blue.60.value}"
+          "$description": "Text color for primary actions or messages (blue.60).",
+          "$type": "color",
+          "$value": "{color.alias.blue.60}"
         },
         "strong": {
-          "comment": "Strong text color for primary actions or messages (blue.70).",
-          "type": "color",
-          "value": "{color.alias.blue.70.value}"
+          "$description": "Strong text color for primary actions or messages (blue.70).",
+          "$type": "color",
+          "$value": "{color.alias.blue.70}"
         },
         "stronger": {
-          "comment": "Stronger text color for primary actions or messages (blue.80).",
-          "type": "color",
-          "value": "{color.alias.blue.80.value}"
+          "$description": "Stronger text color for primary actions or messages (blue.80).",
+          "$type": "color",
+          "$value": "{color.alias.blue.80}"
         },
         "strongest": {
-          "comment": "Strongest text color for primary actions or messages (blue.90).",
-          "type": "color",
-          "value": "{color.alias.blue.90.value}"
+          "$description": "Strongest text color for primary actions or messages (blue.90).",
+          "$type": "color",
+          "$value": "{color.alias.blue.90}"
         },
         "weak": {
-          "comment": "Weak text color for primary actions or messages (blue.40).",
-          "type": "color",
-          "value": "{color.alias.blue.40.value}"
+          "$description": "Weak text color for primary actions or messages (blue.40).",
+          "$type": "color",
+          "$value": "{color.alias.blue.40}"
         },
         "weaker": {
-          "comment": "Weaker text color for primary actions or messages (blue.20).",
-          "type": "color",
-          "value": "{color.alias.blue.20.value}"
+          "$description": "Weaker text color for primary actions or messages (blue.20).",
+          "$type": "color",
+          "$value": "{color.alias.blue.20}"
         },
         "weakest": {
-          "comment": "Weakest text color for primary actions or messages (blue.10).",
-          "type": "color",
-          "value": "{color.alias.blue.10.value}"
+          "$description": "Weakest text color for primary actions or messages (blue.10).",
+          "$type": "color",
+          "$value": "{color.alias.blue.10}"
         }
       },
       "success": {
         "_": {
-          "comment": "Text color for success elements (green.60).",
-          "type": "color",
-          "value": "{color.alias.green.60.value}"
+          "$description": "Text color for success elements (green.60).",
+          "$type": "color",
+          "$value": "{color.alias.green.60}"
         },
         "strong": {
-          "comment": "Strong text color for success elements (green.70).",
-          "type": "color",
-          "value": "{color.alias.green.70.value}"
+          "$description": "Strong text color for success elements (green.70).",
+          "$type": "color",
+          "$value": "{color.alias.green.70}"
         },
         "stronger": {
-          "comment": "Stronger text color for success elements (green.80).",
-          "type": "color",
-          "value": "{color.alias.green.80.value}"
+          "$description": "Stronger text color for success elements (green.80).",
+          "$type": "color",
+          "$value": "{color.alias.green.80}"
         },
         "strongest": {
-          "comment": "Stronger text color for success elements (green.90).",
-          "type": "color",
-          "value": "{color.alias.green.90.value}"
+          "$description": "Stronger text color for success elements (green.90).",
+          "$type": "color",
+          "$value": "{color.alias.green.90}"
         },
         "weak": {
-          "comment": "Weak text color for success elements (green.40).",
-          "type": "color",
-          "value": "{color.alias.green.40.value}"
+          "$description": "Weak text color for success elements (green.40).",
+          "$type": "color",
+          "$value": "{color.alias.green.40}"
         },
         "weaker": {
-          "comment": "Weaker text color for success elements (green.20).",
-          "type": "color",
-          "value": "{color.alias.green.20.value}"
+          "$description": "Weaker text color for success elements (green.20).",
+          "$type": "color",
+          "$value": "{color.alias.green.20}"
         },
         "weakest": {
-          "comment": "Weakest text color for success elements (green.10).",
-          "type": "color",
-          "value": "{color.alias.green.10.value}"
+          "$description": "Weakest text color for success elements (green.10).",
+          "$type": "color",
+          "$value": "{color.alias.green.10}"
         }
       },
       "warning": {
         "_": {
-          "comment": "Text color for warning elements (yellow.60).",
-          "type": "color",
-          "value": "{color.alias.yellow.60.value}"
+          "$description": "Text color for warning elements (yellow.60).",
+          "$type": "color",
+          "$value": "{color.alias.yellow.60}"
         },
         "strong": {
-          "comment": "Strong text color for warning elements (yellow.70).",
-          "type": "color",
-          "value": "{color.alias.yellow.70.value}"
+          "$description": "Strong text color for warning elements (yellow.70).",
+          "$type": "color",
+          "$value": "{color.alias.yellow.70}"
         },
         "stronger": {
-          "comment": "Stronger text color for warning elements (yellow.80).",
-          "type": "color",
-          "value": "{color.alias.yellow.80.value}"
+          "$description": "Stronger text color for warning elements (yellow.80).",
+          "$type": "color",
+          "$value": "{color.alias.yellow.80}"
         },
         "strongest": {
-          "comment": "Strongest text color for warning elements (yellow.90).",
-          "type": "color",
-          "value": "{color.alias.yellow.90.value}"
+          "$description": "Strongest text color for warning elements (yellow.90).",
+          "$type": "color",
+          "$value": "{color.alias.yellow.90}"
         },
         "weak": {
-          "comment": "Weak text color for warning elements (yellow.40).",
-          "type": "color",
-          "value": "{color.alias.yellow.40.value}"
+          "$description": "Weak text color for warning elements (yellow.40).",
+          "$type": "color",
+          "$value": "{color.alias.yellow.40}"
         },
         "weaker": {
-          "comment": "Weaker text color for warning elements (yellow.20).",
-          "type": "color",
-          "value": "{color.alias.yellow.20.value}"
+          "$description": "Weaker text color for warning elements (yellow.20).",
+          "$type": "color",
+          "$value": "{color.alias.yellow.20}"
         },
         "weakest": {
-          "comment": "Weakest text color for warning elements (yellow.10).",
-          "type": "color",
-          "value": "{color.alias.yellow.10.value}"
+          "$description": "Weakest text color for warning elements (yellow.10).",
+          "$type": "color",
+          "$value": "{color.alias.yellow.10}"
         }
       }
     }

--- a/tokens/source/components/icon.json
+++ b/tokens/source/components/icon.json
@@ -2,58 +2,58 @@
   "icon": {
     "color": {
       "danger": {
-        "comment": "Danger color for icons.",
-        "value": "{color.alias.red.50.value}"
+        "$description": "Danger color for icons.",
+        "$value": "{color.alias.red.50}"
       },
       "neutral": {
-        "comment": "Neutral color for icons.",
-        "value": "{color.alias.gray.50.value}"
+        "$description": "Neutral color for icons.",
+        "$value": "{color.alias.gray.50}"
       },
       "primary": {
-        "comment": "Primary color for icons.",
-        "value": "{color.alias.blue.50.value}"
+        "$description": "Primary color for icons.",
+        "$value": "{color.alias.blue.50}"
       },
       "success": {
-        "comment": "Success color for icons.",
-        "value": "{color.alias.green.50.value}"
+        "$description": "Success color for icons.",
+        "$value": "{color.alias.green.50}"
       },
       "warning": {
-        "comment": "Warning color for icons.",
-        "value": "{color.alias.yellow.40.value}"
+        "$description": "Warning color for icons.",
+        "$value": "{color.alias.yellow.40}"
       }
     },
     "size": {
       "10": {
-        "comment": "10px icon size.",
-        "value": "10px"
+        "$description": "10px icon size.",
+        "$value": "10px"
       },
       "20": {
-        "comment": "12px icon size.",
-        "value": "12px"
+        "$description": "12px icon size.",
+        "$value": "12px"
       },
       "30": {
-        "comment": "16px icon size.",
-        "value": "16px"
+        "$description": "16px icon size.",
+        "$value": "16px"
       },
       "40": {
-        "comment": "20px icon size.",
-        "value": "20px"
+        "$description": "20px icon size.",
+        "$value": "20px"
       },
       "50": {
-        "comment": "24px icon size (default).",
-        "value": "24px"
+        "$description": "24px icon size (default).",
+        "$value": "24px"
       },
       "60": {
-        "comment": "32px icon size.",
-        "value": "32px"
+        "$description": "32px icon size.",
+        "$value": "32px"
       },
       "70": {
-        "comment": "40px icon size.",
-        "value": "40px"
+        "$description": "40px icon size.",
+        "$value": "40px"
       },
       "80": {
-        "comment": "48px icon size.",
-        "value": "48px"
+        "$description": "48px icon size.",
+        "$value": "48px"
       }
     }
   }

--- a/tokens/source/components/method.json
+++ b/tokens/source/components/method.json
@@ -3,131 +3,131 @@
     "color": {
       "background": {
         "connect": {
-          "comment": "Background color for the CONNECT method (purple.10).",
-          "value": "{color.alias.purple.10.value}"
+          "$description": "Background color for the CONNECT method (purple.10).",
+          "$value": "{color.alias.purple.10}"
         },
         "delete": {
-          "comment": "Background color for the DELETE method (red.10).",
-          "value": "{color.alias.red.10.value}"
+          "$description": "Background color for the DELETE method (red.10).",
+          "$value": "{color.alias.red.10}"
         },
         "get": {
-          "comment": "Background color for the GET method (blue.10).",
-          "value": "{color.alias.blue.10.value}"
+          "$description": "Background color for the GET method (blue.10).",
+          "$value": "{color.alias.blue.10}"
         },
         "head": {
-          "comment": "Background color for the HEAD method (gray.70).",
-          "value": "{color.alias.gray.70.value}"
+          "$description": "Background color for the HEAD method (gray.70).",
+          "$value": "{color.alias.gray.70}"
         },
         "options": {
-          "comment": "Background color for the OPTIONS method (gray.20).",
-          "value": "{color.alias.gray.20.value}"
+          "$description": "Background color for the OPTIONS method (gray.20).",
+          "$value": "{color.alias.gray.20}"
         },
         "patch": {
-          "comment": "Background color for the PATCH method (aqua.10).",
-          "value": "{color.alias.aqua.10.value}"
+          "$description": "Background color for the PATCH method (aqua.10).",
+          "$value": "{color.alias.aqua.10}"
         },
         "post": {
-          "comment": "Background color for the POST method (green.10).",
-          "value": "{color.alias.green.10.value}"
+          "$description": "Background color for the POST method (green.10).",
+          "$value": "{color.alias.green.10}"
         },
         "put": {
-          "comment": "Background color for the PUT method (yellow.10).",
-          "value": "{color.alias.yellow.10.value}"
+          "$description": "Background color for the PUT method (yellow.10).",
+          "$value": "{color.alias.yellow.10}"
         },
         "trace": {
-          "comment": "Background color for the TRACE method (pink.10).",
-          "value": "{color.alias.pink.10.value}"
+          "$description": "Background color for the TRACE method (pink.10).",
+          "$value": "{color.alias.pink.10}"
         }
       },
       "text": {
         "connect": {
           "_": {
-            "comment": "Text color for the CONNECT method (purple.60).",
-            "value": "{color.alias.purple.60.value}"
+            "$description": "Text color for the CONNECT method (purple.60).",
+            "$value": "{color.alias.purple.60}"
           },
           "strong": {
-            "comment": "Strong text color for the CONNECT method (purple.70).",
-            "value": "{color.alias.purple.70.value}"
+            "$description": "Strong text color for the CONNECT method (purple.70).",
+            "$value": "{color.alias.purple.70}"
           }
         },
         "delete": {
           "_": {
-            "comment": "Text color for the DELETE method (red.60).",
-            "value": "{color.alias.red.60.value}"
+            "$description": "Text color for the DELETE method (red.60).",
+            "$value": "{color.alias.red.60}"
           },
           "strong": {
-            "comment": "Strong text color for the DELETE method (red.70).",
-            "value": "{color.alias.red.70.value}"
+            "$description": "Strong text color for the DELETE method (red.70).",
+            "$value": "{color.alias.red.70}"
           }
         },
         "get": {
           "_": {
-            "comment": "Text color for the GET method (blue.60).",
-            "value": "{color.alias.blue.60.value}"
+            "$description": "Text color for the GET method (blue.60).",
+            "$value": "{color.alias.blue.60}"
           },
           "strong": {
-            "comment": "Strong text color for the GET method (blue.70).",
-            "value": "{color.alias.blue.70.value}"
+            "$description": "Strong text color for the GET method (blue.70).",
+            "$value": "{color.alias.blue.70}"
           }
         },
         "head": {
           "_": {
-            "comment": "Text color for the HEAD method (gray.20).",
-            "value": "{color.alias.gray.20.value}"
+            "$description": "Text color for the HEAD method (gray.20).",
+            "$value": "{color.alias.gray.20}"
           },
           "strong": {
-            "comment": "Strong text color for the HEAD method (gray.40).",
-            "value": "{color.alias.gray.40.value}"
+            "$description": "Strong text color for the HEAD method (gray.40).",
+            "$value": "{color.alias.gray.40}"
           }
         },
         "options": {
           "_": {
-            "comment": "Text color for the OPTIONS method (gray.70).",
-            "value": "{color.alias.gray.70.value}"
+            "$description": "Text color for the OPTIONS method (gray.70).",
+            "$value": "{color.alias.gray.70}"
           },
           "strong": {
-            "comment": "Strong text color for the OPTIONS method (gray.80).",
-            "value": "{color.alias.gray.80.value}"
+            "$description": "Strong text color for the OPTIONS method (gray.80).",
+            "$value": "{color.alias.gray.80}"
           }
         },
         "patch": {
           "_": {
-            "comment": "Text color for the PATCH method (aqua.60).",
-            "value": "{color.alias.aqua.60.value}"
+            "$description": "Text color for the PATCH method (aqua.60).",
+            "$value": "{color.alias.aqua.60}"
           },
           "strong": {
-            "comment": "Strong text color for the PATCH method (aqua.70).",
-            "value": "{color.alias.aqua.70.value}"
+            "$description": "Strong text color for the PATCH method (aqua.70).",
+            "$value": "{color.alias.aqua.70}"
           }
         },
         "post": {
           "_": {
-            "comment": "Text color for the POST method (green.60).",
-            "value": "{color.alias.green.60.value}"
+            "$description": "Text color for the POST method (green.60).",
+            "$value": "{color.alias.green.60}"
           },
           "strong": {
-            "comment": "Strong text color for the POST method (green.70).",
-            "value": "{color.alias.green.70.value}"
+            "$description": "Strong text color for the POST method (green.70).",
+            "$value": "{color.alias.green.70}"
           }
         },
         "put": {
           "_": {
-            "comment": "Text color for the PUT method (yellow.60).",
-            "value": "{color.alias.yellow.60.value}"
+            "$description": "Text color for the PUT method (yellow.60).",
+            "$value": "{color.alias.yellow.60}"
           },
           "strong": {
-            "comment": "Strong text color for the PUT method (yellow.70).",
-            "value": "{color.alias.yellow.70.value}"
+            "$description": "Strong text color for the PUT method (yellow.70).",
+            "$value": "{color.alias.yellow.70}"
           }
         },
         "trace": {
           "_": {
-            "comment": "Text color for the TRACE method (pink.60).",
-            "value": "{color.alias.pink.60.value}"
+            "$description": "Text color for the TRACE method (pink.60).",
+            "$value": "{color.alias.pink.60}"
           },
           "strong": {
-            "comment": "Strong text color for the TRACE method (pink.70).",
-            "value": "{color.alias.pink.70.value}"
+            "$description": "Strong text color for the TRACE method (pink.70).",
+            "$value": "{color.alias.pink.70}"
           }
         }
       }

--- a/tokens/source/components/navigation.json
+++ b/tokens/source/components/navigation.json
@@ -3,61 +3,61 @@
     "color": {
       "background": {
         "_": {
-          "comment": "blue.100",
-          "value": "{color.alias.blue.100.value}"
+          "$description": "blue.100",
+          "$value": "{color.alias.blue.100}"
         },
         "selected": {
-          "comment": "The background color of a selected navigation item.",
-          "value": "rgba({color.alias.white.rgb}, 0.12)"
+          "$description": "The background color of a selected navigation item.",
+          "$value": "rgba(255, 255, 255, 0.12)"
         }
       },
       "border": {
         "_": {
-          "comment": "rgba(white, 0.12)",
-          "value": "rgba({color.alias.white.rgb}, 0.12)"
+          "$description": "rgba(255, 255, 255, 0.12)",
+          "$value": "rgba(255, 255, 255, 0.12)"
         },
         "child": {
-          "comment": "The border color for a selected child navigation item.",
-          "value": "{color.alias.green.30.value}"
+          "$description": "The border color for a selected child navigation item.",
+          "$value": "{color.alias.green.30}"
         },
         "divider": {
-          "comment": "The color of the navigation section divider.",
-          "value": "rgba({color.alias.white.rgb}, 0.24)"
+          "$description": "The color of the navigation section divider.",
+          "$value": "rgba(255, 255, 255, 0.24)"
         }
       },
       "text": {
         "_": {
-          "comment": "Navigation link and icon color.",
-          "value": "{color.alias.blue.20.value}"
+          "$description": "Navigation link and icon color.",
+          "$value": "{color.alias.blue.20}"
         },
         "focus": {
-          "comment": "Navigation link and icon focus-visible color.",
-          "value": "{color.alias.white.value}"
+          "$description": "Navigation link and icon focus-visible color.",
+          "$value": "{color.alias.white}"
         },
         "hover": {
-          "comment": "Navigation link and icon hover color.",
-          "value": "{color.alias.blue.10.value}"
+          "$description": "Navigation link and icon hover color.",
+          "$value": "{color.alias.blue.10}"
         },
         "selected": {
-          "comment": "Navigation link and icon selected color.",
-          "value": "{color.alias.green.30.value}"
+          "$description": "Navigation link and icon selected color.",
+          "$value": "{color.alias.green.30}"
         }
       }
     },
     "shadow": {
       "border": {
         "_": {
-          "comment": "The box-shadow for a focus-visible navigation link.",
-          "value": "0 0 0 1px rgba({color.alias.white.rgb}, 0.12) inset"
+          "$description": "The box-shadow for a focus-visible navigation link.",
+          "$value": "0 0 0 1px rgba(255, 255, 255, 0.12) inset"
         },
         "child": {
-          "comment": "The left box-shadow for an active child navigation link.",
-          "value": "4px 0 0 0 {color.alias.green.30.value} inset"
+          "$description": "The left box-shadow for an active child navigation link.",
+          "$value": "4px 0 0 0 {color.alias.green.30} inset"
         }
       },
       "focus": {
-        "comment": "Navigation link focus-visible box-shadow.",
-        "value": "0 0 0 1px rgba({color.alias.white.rgb}, 0.60) inset"
+        "$description": "Navigation link focus-visible box-shadow.",
+        "$value": "0 0 0 1px rgba(255, 255, 255, 0.60) inset"
       }
     }
   }

--- a/tokens/source/components/status.json
+++ b/tokens/source/components/status.json
@@ -2,339 +2,339 @@
   "status": {
     "color": {
       "1na": {
-        "comment": "Color for unknown response status codes in the 100-199 range (blue.10).",
-        "value": "{color.alias.blue.10.value}"
+        "$description": "Color for unknown response status codes in the 100-199 range (blue.10).",
+        "$value": "{color.alias.blue.10}"
       },
       "2na": {
-        "comment": "Color for unknown response status codes in the 200-299 range (green.10).",
-        "value": "{color.alias.green.10.value}"
+        "$description": "Color for unknown response status codes in the 200-299 range (green.10).",
+        "$value": "{color.alias.green.10}"
       },
       "3na": {
-        "comment": "Color for unknown response status codes in the 300-399 range (yellow.10).",
-        "value": "{color.alias.yellow.10.value}"
+        "$description": "Color for unknown response status codes in the 300-399 range (yellow.10).",
+        "$value": "{color.alias.yellow.10}"
       },
       "4na": {
-        "comment": "Color for unknown response status codes in the 400-499 range (orange.10).",
-        "value": "{color.alias.orange.10.value}"
+        "$description": "Color for unknown response status codes in the 400-499 range (orange.10).",
+        "$value": "{color.alias.orange.10}"
       },
       "5na": {
-        "comment": "Color for unknown response status codes in the 500-599 range (red.10).",
-        "value": "{color.alias.red.10.value}"
+        "$description": "Color for unknown response status codes in the 500-599 range (red.10).",
+        "$value": "{color.alias.red.10}"
       },
 
       "100": {
-        "comment": "Color representing response status code 100 (blue.20).",
-        "value": "{color.alias.blue.20.value}"
+        "$description": "Color representing response status code 100 (blue.20).",
+        "$value": "{color.alias.blue.20}"
       },
       "100s": {
-        "comment": "Color for a group of response status codes in the 100-199 range (blue.40).",
-        "value": "{color.alias.blue.40.value}"
+        "$description": "Color for a group of response status codes in the 100-199 range (blue.40).",
+        "$value": "{color.alias.blue.40}"
       },
       "101": {
-        "comment": "Color representing response status code 101 (blue.30).",
-        "value": "{color.alias.blue.30.value}"
+        "$description": "Color representing response status code 101 (blue.30).",
+        "$value": "{color.alias.blue.30}"
       },
       "102": {
-        "comment": "Color representing response status code 102 (blue.40).",
-        "value": "{color.alias.blue.40.value}"
+        "$description": "Color representing response status code 102 (blue.40).",
+        "$value": "{color.alias.blue.40}"
       },
       "103": {
-        "comment": "Color representing response status code 103 (blue.50).",
-        "value": "{color.alias.blue.50.value}"
+        "$description": "Color representing response status code 103 (blue.50).",
+        "$value": "{color.alias.blue.50}"
       },
       "200": {
-        "comment": "Color representing response status code 200 (green.20).",
-        "value": "{color.alias.green.20.value}"
+        "$description": "Color representing response status code 200 (green.20).",
+        "$value": "{color.alias.green.20}"
       },
       "200s": {
-        "comment": "Color for a group of response status codes in the 200-299 range (green.40).",
-        "value": "{color.alias.green.40.value}"
+        "$description": "Color for a group of response status codes in the 200-299 range (green.40).",
+        "$value": "{color.alias.green.40}"
       },
       "201": {
-        "comment": "Color representing response status code 201 (green.30).",
-        "value": "{color.alias.green.30.value}"
+        "$description": "Color representing response status code 201 (green.30).",
+        "$value": "{color.alias.green.30}"
       },
       "202": {
-        "comment": "Color representing response status code 202 (green.40).",
-        "value": "{color.alias.green.40.value}"
+        "$description": "Color representing response status code 202 (green.40).",
+        "$value": "{color.alias.green.40}"
       },
       "203": {
-        "comment": "Color representing response status code 203 (green.50).",
-        "value": "{color.alias.green.50.value}"
+        "$description": "Color representing response status code 203 (green.50).",
+        "$value": "{color.alias.green.50}"
       },
       "204": {
-        "comment": "Color representing response status code 204 (green.60).",
-        "value": "{color.alias.green.60.value}"
+        "$description": "Color representing response status code 204 (green.60).",
+        "$value": "{color.alias.green.60}"
       },
       "205": {
-        "comment": "Color representing response status code 205 (green.70).",
-        "value": "{color.alias.green.70.value}"
+        "$description": "Color representing response status code 205 (green.70).",
+        "$value": "{color.alias.green.70}"
       },
       "206": {
-        "comment": "Color representing response status code 206 (green.20).",
-        "value": "{color.alias.green.20.value}"
+        "$description": "Color representing response status code 206 (green.20).",
+        "$value": "{color.alias.green.20}"
       },
       "207": {
-        "comment": "Color representing response status code 207 (green.30).",
-        "value": "{color.alias.green.30.value}"
+        "$description": "Color representing response status code 207 (green.30).",
+        "$value": "{color.alias.green.30}"
       },
       "208": {
-        "comment": "Color representing response status code 208 (green.40).",
-        "value": "{color.alias.green.20.value}"
+        "$description": "Color representing response status code 208 (green.40).",
+        "$value": "{color.alias.green.20}"
       },
       "226": {
-        "comment": "Color representing response status code 226 (green.50).",
-        "value": "{color.alias.green.50.value}"
+        "$description": "Color representing response status code 226 (green.50).",
+        "$value": "{color.alias.green.50}"
       },
 
       "300": {
-        "comment": "Color representing response status code 100 (yellow.20).",
-        "value": "{color.alias.yellow.20.value}"
+        "$description": "Color representing response status code 100 (yellow.20).",
+        "$value": "{color.alias.yellow.20}"
       },
       "300s": {
-        "comment": "Color for a group of response status codes in the 300-399 range (yellow.40).",
-        "value": "{color.alias.yellow.40.value}"
+        "$description": "Color for a group of response status codes in the 300-399 range (yellow.40).",
+        "$value": "{color.alias.yellow.40}"
       },
       "301": {
-        "comment": "Color representing response status code 101 (yellow.30).",
-        "value": "{color.alias.yellow.30.value}"
+        "$description": "Color representing response status code 101 (yellow.30).",
+        "$value": "{color.alias.yellow.30}"
       },
       "302": {
-        "comment": "Color representing response status code 102 (yellow.40).",
-        "value": "{color.alias.yellow.40.value}"
+        "$description": "Color representing response status code 102 (yellow.40).",
+        "$value": "{color.alias.yellow.40}"
       },
       "303": {
-        "comment": "Color representing response status code 103 (yellow.50).",
-        "value": "{color.alias.yellow.50.value}"
+        "$description": "Color representing response status code 103 (yellow.50).",
+        "$value": "{color.alias.yellow.50}"
       },
       "304": {
-        "comment": "Color representing response status code 103 (yellow.60).",
-        "value": "{color.alias.yellow.60.value}"
+        "$description": "Color representing response status code 103 (yellow.60).",
+        "$value": "{color.alias.yellow.60}"
       },
       "305": {
-        "comment": "Color representing response status code 103 (yellow.70).",
-        "value": "{color.alias.yellow.70.value}"
+        "$description": "Color representing response status code 103 (yellow.70).",
+        "$value": "{color.alias.yellow.70}"
       },
       "307": {
-        "comment": "Color representing response status code 103 (yellow.20).",
-        "value": "{color.alias.yellow.20.value}"
+        "$description": "Color representing response status code 103 (yellow.20).",
+        "$value": "{color.alias.yellow.20}"
       },
       "308": {
-        "comment": "Color representing response status code 103 (yellow.30).",
-        "value": "{color.alias.yellow.30.value}"
+        "$description": "Color representing response status code 103 (yellow.30).",
+        "$value": "{color.alias.yellow.30}"
       },
 
       "400": {
-        "comment": "Color representing response status code 400 (orange.20).",
-        "value": "{color.alias.orange.20.value}"
+        "$description": "Color representing response status code 400 (orange.20).",
+        "$value": "{color.alias.orange.20}"
       },
       "400s": {
-        "comment": "Color for a group of response status codes in the 400-499 range (orange.40).",
-        "value": "{color.alias.orange.40.value}"
+        "$description": "Color for a group of response status codes in the 400-499 range (orange.40).",
+        "$value": "{color.alias.orange.40}"
       },
       "401": {
-        "comment": "Color representing response status code 401 (orange.30).",
-        "value": "{color.alias.orange.30.value}"
+        "$description": "Color representing response status code 401 (orange.30).",
+        "$value": "{color.alias.orange.30}"
       },
       "402": {
-        "comment": "Color representing response status code 402 (orange.40).",
-        "value": "{color.alias.orange.40.value}"
+        "$description": "Color representing response status code 402 (orange.40).",
+        "$value": "{color.alias.orange.40}"
       },
       "403": {
-        "comment": "Color representing response status code 403 (orange.50).",
-        "value": "{color.alias.orange.50.value}"
+        "$description": "Color representing response status code 403 (orange.50).",
+        "$value": "{color.alias.orange.50}"
       },
       "404": {
-        "comment": "Color representing response status code 404 (orange.60).",
-        "value": "{color.alias.orange.60.value}"
+        "$description": "Color representing response status code 404 (orange.60).",
+        "$value": "{color.alias.orange.60}"
       },
       "405": {
-        "comment": "Color representing response status code 405 (orange.70).",
-        "value": "{color.alias.orange.70.value}"
+        "$description": "Color representing response status code 405 (orange.70).",
+        "$value": "{color.alias.orange.70}"
       },
       "406": {
-        "comment": "Color representing response status code 406 (orange.20).",
-        "value": "{color.alias.orange.20.value}"
+        "$description": "Color representing response status code 406 (orange.20).",
+        "$value": "{color.alias.orange.20}"
       },
       "407": {
-        "comment": "Color representing response status code 407 (orange.30).",
-        "value": "{color.alias.orange.30.value}"
+        "$description": "Color representing response status code 407 (orange.30).",
+        "$value": "{color.alias.orange.30}"
       },
       "408": {
-        "comment": "Color representing response status code 408 (orange.40).",
-        "value": "{color.alias.orange.40.value}"
+        "$description": "Color representing response status code 408 (orange.40).",
+        "$value": "{color.alias.orange.40}"
       },
       "409": {
-        "comment": "Color representing response status code 409 (orange.50).",
-        "value": "{color.alias.orange.50.value}"
+        "$description": "Color representing response status code 409 (orange.50).",
+        "$value": "{color.alias.orange.50}"
       },
       "410": {
-        "comment": "Color representing response status code 410 (orange.60).",
-        "value": "{color.alias.orange.60.value}"
+        "$description": "Color representing response status code 410 (orange.60).",
+        "$value": "{color.alias.orange.60}"
       },
       "411": {
-        "comment": "Color representing response status code 411 (orange.70).",
-        "value": "{color.alias.orange.70.value}"
+        "$description": "Color representing response status code 411 (orange.70).",
+        "$value": "{color.alias.orange.70}"
       },
       "412": {
-        "comment": "Color representing response status code 412 (orange.20).",
-        "value": "{color.alias.orange.20.value}"
+        "$description": "Color representing response status code 412 (orange.20).",
+        "$value": "{color.alias.orange.20}"
       },
       "413": {
-        "comment": "Color representing response status code 413 (orange.30).",
-        "value": "{color.alias.orange.30.value}"
+        "$description": "Color representing response status code 413 (orange.30).",
+        "$value": "{color.alias.orange.30}"
       },
       "414": {
-        "comment": "Color representing response status code 414 (orange.40).",
-        "value": "{color.alias.orange.40.value}"
+        "$description": "Color representing response status code 414 (orange.40).",
+        "$value": "{color.alias.orange.40}"
       },
       "415": {
-        "comment": "Color representing response status code 415 (orange.50).",
-        "value": "{color.alias.orange.50.value}"
+        "$description": "Color representing response status code 415 (orange.50).",
+        "$value": "{color.alias.orange.50}"
       },
       "416": {
-        "comment": "Color representing response status code 416 (orange.60).",
-        "value": "{color.alias.orange.60.value}"
+        "$description": "Color representing response status code 416 (orange.60).",
+        "$value": "{color.alias.orange.60}"
       },
       "417": {
-        "comment": "Color representing response status code 417 (orange.70).",
-        "value": "{color.alias.orange.70.value}"
+        "$description": "Color representing response status code 417 (orange.70).",
+        "$value": "{color.alias.orange.70}"
       },
       "418": {
-        "comment": "Color representing response status code 418 (orange.20).",
-        "value": "{color.alias.orange.20.value}"
+        "$description": "Color representing response status code 418 (orange.20).",
+        "$value": "{color.alias.orange.20}"
       },
       "421": {
-        "comment": "Color representing response status code 421 (orange.30).",
-        "value": "{color.alias.orange.30.value}"
+        "$description": "Color representing response status code 421 (orange.30).",
+        "$value": "{color.alias.orange.30}"
       },
       "422": {
-        "comment": "Color representing response status code 422 (orange.40).",
-        "value": "{color.alias.orange.40.value}"
+        "$description": "Color representing response status code 422 (orange.40).",
+        "$value": "{color.alias.orange.40}"
       },
       "423": {
-        "comment": "Color representing response status code 423 (orange.50).",
-        "value": "{color.alias.orange.50.value}"
+        "$description": "Color representing response status code 423 (orange.50).",
+        "$value": "{color.alias.orange.50}"
       },
       "424": {
-        "comment": "Color representing response status code 424 (orange.60).",
-        "value": "{color.alias.orange.60.value}"
+        "$description": "Color representing response status code 424 (orange.60).",
+        "$value": "{color.alias.orange.60}"
       },
       "425": {
-        "comment": "Color representing response status code 425 (orange.70).",
-        "value": "{color.alias.orange.70.value}"
+        "$description": "Color representing response status code 425 (orange.70).",
+        "$value": "{color.alias.orange.70}"
       },
       "426": {
-        "comment": "Color representing response status code 426 (orange.20).",
-        "value": "{color.alias.orange.20.value}"
+        "$description": "Color representing response status code 426 (orange.20).",
+        "$value": "{color.alias.orange.20}"
       },
       "428": {
-        "comment": "Color representing response status code 428 (orange.30).",
-        "value": "{color.alias.orange.30.value}"
+        "$description": "Color representing response status code 428 (orange.30).",
+        "$value": "{color.alias.orange.30}"
       },
       "429": {
-        "comment": "Color representing response status code 429 (orange.40).",
-        "value": "{color.alias.orange.40.value}"
+        "$description": "Color representing response status code 429 (orange.40).",
+        "$value": "{color.alias.orange.40}"
       },
       "431": {
-        "comment": "Color representing response status code 431 (orange.50).",
-        "value": "{color.alias.orange.50.value}"
+        "$description": "Color representing response status code 431 (orange.50).",
+        "$value": "{color.alias.orange.50}"
       },
       "451": {
-        "comment": "Color representing response status code 451 (orange.60).",
-        "value": "{color.alias.orange.60.value}"
+        "$description": "Color representing response status code 451 (orange.60).",
+        "$value": "{color.alias.orange.60}"
       },
 
       "500": {
-        "comment": "Color representing response status code 500 (red.20).",
-        "value": "{color.alias.red.20.value}"
+        "$description": "Color representing response status code 500 (red.20).",
+        "$value": "{color.alias.red.20}"
       },
       "500s": {
-        "comment": "Color for a group of response status codes in the 500-599 range (red.40).",
-        "value": "{color.alias.red.40.value}"
+        "$description": "Color for a group of response status codes in the 500-599 range (red.40).",
+        "$value": "{color.alias.red.40}"
       },
       "501": {
-        "comment": "Color representing response status code 501 (red.30).",
-        "value": "{color.alias.red.30.value}"
+        "$description": "Color representing response status code 501 (red.30).",
+        "$value": "{color.alias.red.30}"
       },
       "502": {
-        "comment": "Color representing response status code 502 (red.40).",
-        "value": "{color.alias.red.40.value}"
+        "$description": "Color representing response status code 502 (red.40).",
+        "$value": "{color.alias.red.40}"
       },
       "503": {
-        "comment": "Color representing response status code 503 (red.50).",
-        "value": "{color.alias.red.50.value}"
+        "$description": "Color representing response status code 503 (red.50).",
+        "$value": "{color.alias.red.50}"
       },
       "504": {
-        "comment": "Color representing response status code 504 (red.60).",
-        "value": "{color.alias.red.60.value}"
+        "$description": "Color representing response status code 504 (red.60).",
+        "$value": "{color.alias.red.60}"
       },
       "505": {
-        "comment": "Color representing response status code 505 (red.70).",
-        "value": "{color.alias.red.70.value}"
+        "$description": "Color representing response status code 505 (red.70).",
+        "$value": "{color.alias.red.70}"
       },
       "506": {
-        "comment": "Color representing response status code 506 (red.20).",
-        "value": "{color.alias.red.20.value}"
+        "$description": "Color representing response status code 506 (red.20).",
+        "$value": "{color.alias.red.20}"
       },
       "507": {
-        "comment": "Color representing response status code 507 (red.30).",
-        "value": "{color.alias.red.30.value}"
+        "$description": "Color representing response status code 507 (red.30).",
+        "$value": "{color.alias.red.30}"
       },
       "508": {
-        "comment": "Color representing response status code 508 (red.40).",
-        "value": "{color.alias.red.40.value}"
+        "$description": "Color representing response status code 508 (red.40).",
+        "$value": "{color.alias.red.40}"
       },
       "510": {
-        "comment": "Color representing response status code 510 (red.50).",
-        "value": "{color.alias.red.50.value}"
+        "$description": "Color representing response status code 510 (red.50).",
+        "$value": "{color.alias.red.50}"
       },
       "511": {
-        "comment": "Color representing response status code 511 (red.60).",
-        "value": "{color.alias.red.60.value}"
+        "$description": "Color representing response status code 511 (red.60).",
+        "$value": "{color.alias.red.60}"
       },
       "background": {
         "100": {
-          "comment": "Background color for http status 100 elements (blue.10).",
-          "value": "{color.alias.blue.10.value}"
+          "$description": "Background color for http status 100 elements (blue.10).",
+          "$value": "{color.alias.blue.10}"
         },
         "200": {
-          "comment": "Background color for http status 200 elements (green.10).",
-          "value": "{color.alias.green.10.value}"
+          "$description": "Background color for http status 200 elements (green.10).",
+          "$value": "{color.alias.green.10}"
         },
         "300": {
-          "comment": "Background color for http status 300 elements (yellow.10).",
-          "value": "{color.alias.yellow.10.value}"
+          "$description": "Background color for http status 300 elements (yellow.10).",
+          "$value": "{color.alias.yellow.10}"
         },
         "400": {
-          "comment": "Background color for http status 400 elements (orange.10).",
-          "value": "{color.alias.orange.10.value}"
+          "$description": "Background color for http status 400 elements (orange.10).",
+          "$value": "{color.alias.orange.10}"
         },
         "500": {
-          "comment": "Background color for http status 500 elements (red.10).",
-          "value": "{color.alias.red.10.value}"
+          "$description": "Background color for http status 500 elements (red.10).",
+          "$value": "{color.alias.red.10}"
         }
       },
       "text": {
         "100": {
-          "comment": "Text color for http status 100 elements (blue.60).",
-          "value": "{color.alias.blue.60.value}"
+          "$description": "Text color for http status 100 elements (blue.60).",
+          "$value": "{color.alias.blue.60}"
         },
         "200": {
-          "comment": "Text color for http status 200 elements (green.60).",
-          "value": "{color.alias.green.60.value}"
+          "$description": "Text color for http status 200 elements (green.60).",
+          "$value": "{color.alias.green.60}"
         },
         "300": {
-          "comment": "Text color for http status 300 elements (yellow.60).",
-          "value": "{color.alias.yellow.60.value}"
+          "$description": "Text color for http status 300 elements (yellow.60).",
+          "$value": "{color.alias.yellow.60}"
         },
         "400": {
-          "comment": "Text color for http status 400 elements (orange.60).",
-          "value": "{color.alias.orange.60.value}"
+          "$description": "Text color for http status 400 elements (orange.60).",
+          "$value": "{color.alias.orange.60}"
         },
         "500": {
-          "comment": "Text color for http status 500 elements (red.60).",
-          "value": "{color.alias.red.60.value}"
+          "$description": "Text color for http status 500 elements (red.60).",
+          "$value": "{color.alias.red.60}"
         }
       }
     }

--- a/tokens/source/font/family.json
+++ b/tokens/source/font/family.json
@@ -2,19 +2,19 @@
   "font": {
     "family": {
       "code": {
-        "comment": "The standard monospace text font family. Typically used for code blocks, inline code, and copyable text.",
-        "type": "font",
-        "value": "'JetBrains Mono', Consolas, monospace"
+        "$description": "The standard monospace text font family. Typically used for code blocks, inline code, and copyable text.",
+        "$type": "font",
+        "$value": "'JetBrains Mono', Consolas, monospace"
       },
       "heading": {
-        "comment": "The standard heading text font family.",
-        "type": "font",
-        "value": "{font.family.text.value}"
+        "$description": "The standard heading text font family.",
+        "$type": "font",
+        "$value": "{font.family.text}"
       },
       "text": {
-        "comment": "The standard text font family.",
-        "type": "font",
-        "value": "'Inter', Roboto, Helvetica, sans-serif"
+        "$description": "The standard text font family.",
+        "$type": "font",
+        "$value": "'Inter', Roboto, Helvetica, sans-serif"
       }
     }
   }

--- a/tokens/source/font/size.json
+++ b/tokens/source/font/size.json
@@ -2,44 +2,44 @@
   "font": {
     "size": {
       "10": {
-        "type": "font",
-        "value": "10px"
+        "$type": "font",
+        "$value": "10px"
       },
       "20": {
-        "type": "font",
-        "value": "12px"
+        "$type": "font",
+        "$value": "12px"
       },
       "30": {
-        "type": "font",
-        "value": "14px"
+        "$type": "font",
+        "$value": "14px"
       },
       "40": {
-        "type": "font",
-        "value": "16px"
+        "$type": "font",
+        "$value": "16px"
       },
       "50": {
-        "type": "font",
-        "value": "18px"
+        "$type": "font",
+        "$value": "18px"
       },
       "60": {
-        "type": "font",
-        "value": "20px"
+        "$type": "font",
+        "$value": "20px"
       },
       "70": {
-        "type": "font",
-        "value": "24px"
+        "$type": "font",
+        "$value": "24px"
       },
       "80": {
-        "type": "font",
-        "value": "32px"
+        "$type": "font",
+        "$value": "32px"
       },
       "90": {
-        "type": "font",
-        "value": "40px"
+        "$type": "font",
+        "$value": "40px"
       },
       "100": {
-        "type": "font",
-        "value": "48px"
+        "$type": "font",
+        "$value": "48px"
       }
     }
   }

--- a/tokens/source/font/weight.json
+++ b/tokens/source/font/weight.json
@@ -2,24 +2,24 @@
   "font": {
     "weight": {
       "bold": {
-        "comment": "700: The bold font weight.",
-        "type": "font",
-        "value": "700"
+        "$description": "700: The bold font weight.",
+        "$type": "font",
+        "$value": "700"
       },
       "medium": {
-        "comment": "500: The medium font weight.",
-        "type": "font",
-        "value": "500"
+        "$description": "500: The medium font weight.",
+        "$type": "font",
+        "$value": "500"
       },
       "regular": {
-        "comment": "400: The normal font weight.",
-        "type": "font",
-        "value": "400"
+        "$description": "400: The normal font weight.",
+        "$type": "font",
+        "$value": "400"
       },
       "semibold": {
-        "comment": "600: The semibold font weight.",
-        "type": "font",
-        "value": "600"
+        "$description": "600: The semibold font weight.",
+        "$type": "font",
+        "$value": "600"
       }
     }
   }

--- a/tokens/source/letter-spacing/index.json
+++ b/tokens/source/letter-spacing/index.json
@@ -1,34 +1,34 @@
 {
   "letter_spacing": {
     "0": {
-      "comment": "Alias for letter-spacing-normal",
-      "value": "{letter_spacing.normal}"
+      "$description": "Alias for letter-spacing-normal",
+      "$value": "{letter_spacing.normal}"
     },
     "minus": {
       "10": {
-        "comment": "-0.12px",
-        "value": "-0.12px"
+        "$description": "-0.12px",
+        "$value": "-0.12px"
       },
       "20": {
-        "comment": "-0.24px",
-        "value": "-0.24px"
+        "$description": "-0.24px",
+        "$value": "-0.24px"
       },
       "30": {
-        "comment": "-0.32px",
-        "value": "-0.32px"
+        "$description": "-0.32px",
+        "$value": "-0.32px"
       },
       "40": {
-        "comment": "-0.4px",
-        "value": "-0.4px"
+        "$description": "-0.4px",
+        "$value": "-0.4px"
       },
       "50": {
-        "comment": "-0.48px",
-        "value": "-0.48px"
+        "$description": "-0.48px",
+        "$value": "-0.48px"
       }
     },
     "normal": {
-      "comment": "normal",
-      "value": "normal"
+      "$description": "normal",
+      "$value": "normal"
     }
   }
 }

--- a/tokens/source/line-height/index.json
+++ b/tokens/source/line-height/index.json
@@ -1,44 +1,44 @@
 {
   "line_height": {
     "10": {
-      "comment": "12px",
-      "value": "12px"
+      "$description": "12px",
+      "$value": "12px"
     },
     "20": {
-      "comment": "16px",
-      "value": "16px"
+      "$description": "16px",
+      "$value": "16px"
     },
     "30": {
-      "comment": "20px",
-      "value": "20px"
+      "$description": "20px",
+      "$value": "20px"
     },
     "40": {
-      "comment": "24px",
-      "value": "24px"
+      "$description": "24px",
+      "$value": "24px"
     },
     "50": {
-      "comment": "28px",
-      "value": "28px"
+      "$description": "28px",
+      "$value": "28px"
     },
     "60": {
-      "comment": "32px",
-      "value": "32px"
+      "$description": "32px",
+      "$value": "32px"
     },
     "70": {
-      "comment": "36px",
-      "value": "36px"
+      "$description": "36px",
+      "$value": "36px"
     },
     "80": {
-      "comment": "40px",
-      "value": "40px"
+      "$description": "40px",
+      "$value": "40px"
     },
     "90": {
-      "comment": "48px",
-      "value": "48px"
+      "$description": "48px",
+      "$value": "48px"
     },
     "100": {
-      "comment": "56px",
-      "value": "56px"
+      "$description": "56px",
+      "$value": "56px"
     }
   }
 }

--- a/tokens/source/shadow/index.json
+++ b/tokens/source/shadow/index.json
@@ -1,46 +1,46 @@
 {
   "shadow": {
     "_": {
-      "comment": "0px 4px 20px 0px rgba(0, 0, 0, 0.08)",
-      "value": "0px 4px 20px 0px rgba(0, 0, 0, 0.08)"
+      "$description": "0px 4px 20px 0px rgba(0, 0, 0, 0.08)",
+      "$value": "0px 4px 20px 0px rgba(0, 0, 0, 0.08)"
     },
     "border": {
       "_": {
-        "comment": "0px 0px 0px 1px gray.20 inset",
-        "value": "0px 0px 0px 1px {color.alias.gray.20.value} inset"
+        "$description": "0px 0px 0px 1px gray.20 inset",
+        "$value": "0px 0px 0px 1px {color.alias.gray.20} inset"
       },
       "danger": {
         "_": {
-          "comment": "0px 0px 0px 1px red.60 inset",
-          "value": "0px 0px 0px 1px {color.alias.red.60.value} inset"
+          "$description": "0px 0px 0px 1px red.60 inset",
+          "$value": "0px 0px 0px 1px {color.alias.red.60} inset"
         },
         "strong": {
-          "comment": "0px 0px 0px 1px red.70 inset",
-          "value": "0px 0px 0px 1px {color.alias.red.70.value} inset"
+          "$description": "0px 0px 0px 1px red.70 inset",
+          "$value": "0px 0px 0px 1px {color.alias.red.70} inset"
         }
       },
       "disabled": {
-        "comment": "0px 0px 0px 1px gray.20 inset",
-        "value": "0px 0px 0px 1px {color.alias.gray.20.value} inset"
+        "$description": "0px 0px 0px 1px gray.20 inset",
+        "$value": "0px 0px 0px 1px {color.alias.gray.20} inset"
       },
       "primary": {
         "_": {
-          "comment": "0px 0px 0px 1px blue.60 inset",
-          "value": "0px 0px 0px 1px {color.alias.blue.60.value} inset"
+          "$description": "0px 0px 0px 1px blue.60 inset",
+          "$value": "0px 0px 0px 1px {color.alias.blue.60} inset"
         },
         "strongest": {
-          "comment": "0px 0px 0px 1px blue.90 inset",
-          "value": "0px 0px 0px 1px {color.alias.blue.90.value} inset"
+          "$description": "0px 0px 0px 1px blue.90 inset",
+          "$value": "0px 0px 0px 1px {color.alias.blue.90} inset"
         },
         "weak": {
-          "comment": "0px 0px 0px 1px blue.40 inset",
-          "value": "0px 0px 0px 1px {color.alias.blue.40.value} inset"
+          "$description": "0px 0px 0px 1px blue.40 inset",
+          "$value": "0px 0px 0px 1px {color.alias.blue.40} inset"
         }
       }
     },
     "focus": {
-      "comment": "0px 0px 0px 4px rgba(0, 68, 244, 0.2)",
-      "value": "0px 0px 0px 4px rgba(0, 68, 244, 0.2)"
+      "$description": "0px 0px 0px 4px rgba(0, 68, 244, 0.2)",
+      "$value": "0px 0px 0px 4px rgba(0, 68, 244, 0.2)"
     }
   }
 }

--- a/tokens/source/space/index.json
+++ b/tokens/source/space/index.json
@@ -1,72 +1,72 @@
 {
   "space": {
     "0": {
-      "comment": "0px value for gaps, margin, or padding.",
-      "value": "0px"
+      "$description": "0px value for gaps, margin, or padding.",
+      "$value": "0px"
     },
     "10": {
-      "comment": "2px value for gaps, margin, or padding.",
-      "value": "2px"
+      "$description": "2px value for gaps, margin, or padding.",
+      "$value": "2px"
     },
     "20": {
-      "comment": "4px value for gaps, margin, or padding.",
-      "value": "4px"
+      "$description": "4px value for gaps, margin, or padding.",
+      "$value": "4px"
     },
     "30": {
-      "comment": "6px value for gaps, margin, or padding.",
-      "value": "6px"
+      "$description": "6px value for gaps, margin, or padding.",
+      "$value": "6px"
     },
     "40": {
-      "comment": "8px value for gaps, margin, or padding.",
-      "value": "8px"
+      "$description": "8px value for gaps, margin, or padding.",
+      "$value": "8px"
     },
     "50": {
-      "comment": "12px value for gaps, margin, or padding.",
-      "value": "12px"
+      "$description": "12px value for gaps, margin, or padding.",
+      "$value": "12px"
     },
     "60": {
-      "comment": "16px value for gaps, margin, or padding.",
-      "value": "16px"
+      "$description": "16px value for gaps, margin, or padding.",
+      "$value": "16px"
     },
     "70": {
-      "comment": "20px value for gaps, margin, or padding.",
-      "value": "20px"
+      "$description": "20px value for gaps, margin, or padding.",
+      "$value": "20px"
     },
     "80": {
-      "comment": "24px value for gaps, margin, or padding.",
-      "value": "24px"
+      "$description": "24px value for gaps, margin, or padding.",
+      "$value": "24px"
     },
     "90": {
-      "comment": "32px value for gaps, margin, or padding.",
-      "value": "32px"
+      "$description": "32px value for gaps, margin, or padding.",
+      "$value": "32px"
     },
     "100": {
-      "comment": "40px value for gaps, margin, or padding.",
-      "value": "40px"
+      "$description": "40px value for gaps, margin, or padding.",
+      "$value": "40px"
     },
     "110": {
-      "comment": "48px value for gaps, margin, or padding.",
-      "value": "48px"
+      "$description": "48px value for gaps, margin, or padding.",
+      "$value": "48px"
     },
     "120": {
-      "comment": "56px value for gaps, margin, or padding.",
-      "value": "56px"
+      "$description": "56px value for gaps, margin, or padding.",
+      "$value": "56px"
     },
     "130": {
-      "comment": "64px value for gaps, margin, or padding.",
-      "value": "64px"
+      "$description": "64px value for gaps, margin, or padding.",
+      "$value": "64px"
     },
     "140": {
-      "comment": "80px value for gaps, margin, or padding.",
-      "value": "80px"
+      "$description": "80px value for gaps, margin, or padding.",
+      "$value": "80px"
     },
     "150": {
-      "comment": "96px value for gaps, margin, or padding.",
-      "value": "96px"
+      "$description": "96px value for gaps, margin, or padding.",
+      "$value": "96px"
     },
     "auto": {
-      "comment": "auto",
-      "value": "auto"
+      "$description": "auto",
+      "$value": "auto"
     }
   }
 }


### PR DESCRIPTION
# Summary

Upgrade `style-dictionary` to v5

https://styledictionary.com/versions/v5/migration/

- [x] Validated outputs remain the same (other than rgb tokens)
- [x] Validated TOKENS.md is the same (other than rgb tokens)