### PR TITLE
feat: button component tokens

### DIFF
--- a/TOKENS.md
+++ b/TOKENS.md
@@ -2337,6 +2337,134 @@ You may scope your CSS custom property overrides inside the `:root` selector as 
 --kui-breakpoint-laptop: 1280px;
 /* Used for larger desktop screens. */
 --kui-breakpoint-desktop: 1536px;
+/* The border radius of the button. */
+--kui-button-border-radius: initial;
+/* The border width of the button. */
+--kui-button-border-width: initial;
+/* The background color of the danger button in its default state. */
+--kui-button-color-background-danger: initial;
+/* The background color of the danger button in its active state. */
+--kui-button-color-background-danger-active: initial;
+/* The background color of the danger button in its disabled state. */
+--kui-button-color-background-danger-disabled: initial;
+/* The background color of the danger button in its hover state. */
+--kui-button-color-background-danger-hover: initial;
+/* The background color of the primary button in its default state. */
+--kui-button-color-background-primary: initial;
+/* The background color of the primary button in its active state. */
+--kui-button-color-background-primary-active: initial;
+/* The background color of the primary button in its disabled state. */
+--kui-button-color-background-primary-disabled: initial;
+/* The background color of the primary button in its hover state. */
+--kui-button-color-background-primary-hover: initial;
+/* The background color of the secondary button in its default state. */
+--kui-button-color-background-secondary: initial;
+/* The background color of the secondary button in its active state. */
+--kui-button-color-background-secondary-active: initial;
+/* The background color of the secondary button in its disabled state. */
+--kui-button-color-background-secondary-disabled: initial;
+/* The background color of the secondary button in its hover state. */
+--kui-button-color-background-secondary-hover: initial;
+/* The background color of the tertiary button in its default state. */
+--kui-button-color-background-tertiary: initial;
+/* The background color of the tertiary button in its active state. */
+--kui-button-color-background-tertiary-active: initial;
+/* The background color of the tertiary button in its disabled state. */
+--kui-button-color-background-tertiary-disabled: initial;
+/* The background color of the tertiary button in its hover state. */
+--kui-button-color-background-tertiary-hover: initial;
+/* The border color of the danger button in its default state. */
+--kui-button-color-border-danger: initial;
+/* The border color of the danger button in its active state. */
+--kui-button-color-border-danger-active: initial;
+/* The border color of the danger button in its disabled state. */
+--kui-button-color-border-danger-disabled: initial;
+/* The border color of the danger button in its hover state. */
+--kui-button-color-border-danger-hover: initial;
+/* The border color of the primary button in its default state. */
+--kui-button-color-border-primary: initial;
+/* The border color of the primary button in its active state. */
+--kui-button-color-border-primary-active: initial;
+/* The border color of the primary button in its disabled state. */
+--kui-button-color-border-primary-disabled: initial;
+/* The border color of the primary button in its hover state. */
+--kui-button-color-border-primary-hover: initial;
+/* The border color of the secondary button in its default state. */
+--kui-button-color-border-secondary: initial;
+/* The border color of the secondary button in its active state. */
+--kui-button-color-border-secondary-active: initial;
+/* The border color of the secondary button in its disabled state. */
+--kui-button-color-border-secondary-disabled: initial;
+/* The border color of the secondary button in its hover state. */
+--kui-button-color-border-secondary-hover: initial;
+/* The border color of the tertiary button in its default state. */
+--kui-button-color-border-tertiary: initial;
+/* The border color of the tertiary button in its active state. */
+--kui-button-color-border-tertiary-active: initial;
+/* The border color of the tertiary button in its disabled state. */
+--kui-button-color-border-tertiary-disabled: initial;
+/* The border color of the tertiary button in its hover state. */
+--kui-button-color-border-tertiary-hover: initial;
+/* The text color of the danger button in its default state. */
+--kui-button-color-text-danger: initial;
+/* The text color of the danger button in its active state. */
+--kui-button-color-text-danger-active: initial;
+/* The text color of the danger button in its disabled state. */
+--kui-button-color-text-danger-disabled: initial;
+/* The text color of the danger button in its hover state. */
+--kui-button-color-text-danger-hover: initial;
+/* The text color of the primary button in its default state. */
+--kui-button-color-text-primary: initial;
+/* The text color of the primary button in its active state. */
+--kui-button-color-text-primary-active: initial;
+/* The text color of the primary button in its disabled state. */
+--kui-button-color-text-primary-disabled: initial;
+/* The text color of the primary button in its hover state. */
+--kui-button-color-text-primary-hover: initial;
+/* The text color of the secondary button in its default state. */
+--kui-button-color-text-secondary: initial;
+/* The text color of the secondary button in its active state. */
+--kui-button-color-text-secondary-active: initial;
+/* The text color of the secondary button in its disabled state. */
+--kui-button-color-text-secondary-disabled: initial;
+/* The text color of the secondary button in its hover state. */
+--kui-button-color-text-secondary-hover: initial;
+/* The text color of the tertiary button in its default state. */
+--kui-button-color-text-tertiary: initial;
+/* The text color of the tertiary button in its active state. */
+--kui-button-color-text-tertiary-active: initial;
+/* The text color of the tertiary button in its disabled state. */
+--kui-button-color-text-tertiary-disabled: initial;
+/* The text color of the tertiary button in its hover state. */
+--kui-button-color-text-tertiary-hover: initial;
+/* The font family for all buttons. */
+--kui-button-font-family: initial;
+/* The font size for large buttons. */
+--kui-button-font-size-large: initial;
+/* The font size for medium (default) buttons. */
+--kui-button-font-size-medium: initial;
+/* The font size for small buttons. */
+--kui-button-font-size-small: initial;
+/* The font weight for all buttons. */
+--kui-button-font-weight: initial;
+/* The line-height for large buttons. */
+--kui-button-line-height-large: initial;
+/* The line-height for medium (default) buttons. */
+--kui-button-line-height-medium: initial;
+/* The line-height for small buttons. */
+--kui-button-line-height-small: initial;
+/* The left and right padding for large buttons. */
+--kui-button-padding-large-x: initial;
+/* The top and bottom padding for large buttons. */
+--kui-button-padding-large-y: initial;
+/* The left and right padding for medium (default) buttons. */
+--kui-button-padding-medium-x: initial;
+/* The top and bottom padding for medium (default) buttons. */
+--kui-button-padding-medium-y: initial;
+/* The left and right padding for small buttons. */
+--kui-button-padding-small-x: initial;
+/* The top and bottom padding for small buttons. */
+--kui-button-padding-small-y: initial;
 /* Danger color for icons. */
 --kui-icon-color-danger: #f50045;
 /* Neutral color for icons. */

--- a/platforms/javascript.mjs
+++ b/platforms/javascript.mjs
@@ -17,8 +17,8 @@ export default {
     {
       format: 'javascript/es6',
       destination: 'index.mjs',
-      // Exclude alias tokens and asset tokens compiled in a separate file
-      filter: (token) => token.isSource === true && token.attributes.category !== 'asset',
+      // Exclude alias tokens, asset tokens, and component tokens with no value (runtime-only CSS customization surface)
+      filter: (token) => token.isSource === true && token.attributes.category !== 'asset' && token.original.$value !== '',
     },
     // Constants TypeScript types
     {
@@ -27,15 +27,15 @@ export default {
       options: {
         outputStringLiterals: true,
       },
-      // Exclude alias tokens and asset tokens compiled in a separate file
-      filter: (token) => token.isSource === true && token.attributes.category !== 'asset',
+      // Exclude alias tokens, asset tokens, and component tokens with no value (runtime-only CSS customization surface)
+      filter: (token) => token.isSource === true && token.attributes.category !== 'asset' && token.original.$value !== '',
     },
     // JavaScript CommonJS
     {
       format: 'javascript/module-flat',
       destination: 'cjs/index.js',
-      // Exclude alias tokens and asset tokens compiled in a separate file
-      filter: (token) => token.isSource === true && token.attributes.category !== 'asset',
+      // Exclude alias tokens, asset tokens, and component tokens with no value (runtime-only CSS customization surface)
+      filter: (token) => token.isSource === true && token.attributes.category !== 'asset' && token.original.$value !== '',
     },
     // CommonJS types
     {
@@ -44,8 +44,8 @@ export default {
       options: {
         outputStringLiterals: true,
       },
-      // Exclude alias tokens and asset tokens compiled in a separate file
-      filter: (token) => token.isSource === true && token.attributes.category !== 'asset',
+      // Exclude alias tokens, asset tokens, and component tokens with no value (runtime-only CSS customization surface)
+      filter: (token) => token.isSource === true && token.attributes.category !== 'asset' && token.original.$value !== '',
     },
   ],
 }

--- a/platforms/json.mjs
+++ b/platforms/json.mjs
@@ -15,8 +15,8 @@ export default {
     {
       format: 'json/flat',
       destination: 'tokens.json',
-      // Exclude alias tokens and asset tokens compiled in a separate file
-      filter: (token) => token.isSource === true && token.attributes.category !== 'asset',
+      // Exclude alias tokens, asset tokens, and component tokens with no value (runtime-only CSS customization surface)
+      filter: (token) => token.isSource === true && token.attributes.category !== 'asset' && token.original.$value !== '',
     },
   ],
 }

--- a/platforms/less.mjs
+++ b/platforms/less.mjs
@@ -17,8 +17,8 @@ export default {
     {
       format: 'less/variables',
       destination: 'variables.less',
-      // Exclude alias tokens and asset tokens compiled in a separate file
-      filter: (token) => token.isSource === true && token.attributes.category !== 'asset',
+      // Exclude alias tokens, asset tokens, and component tokens with no value (runtime-only CSS customization surface)
+      filter: (token) => token.isSource === true && token.attributes.category !== 'asset' && token.original.$value !== '',
     },
   ],
 }

--- a/platforms/markdown.mjs
+++ b/platforms/markdown.mjs
@@ -5,8 +5,11 @@ import { fileHeader } from 'style-dictionary/utils'
 StyleDictionary.registerFormat({
   name: 'css/variables/custom/markdown',
   format: async function({ dictionary, file }) {
-    // Generate the SCSS variable tokens
-    const scssTokens = dictionary.allTokens.map(token => {
+    const sourceTokens = dictionary.allTokens.filter(token => token.original.$value !== '')
+    const allTokens = dictionary.allTokens
+
+    // Generate the SCSS variable tokens (omit component tokens with no value — not emitted in the SCSS output)
+    const scssTokens = sourceTokens.map(token => {
       const value = unquoteString(JSON.stringify(token.$value))
       const comment = unquoteString(JSON.stringify(token.$description))
 
@@ -18,8 +21,8 @@ StyleDictionary.registerFormat({
       return tokenOutput
     }).join('\n')
 
-    // Generate the SCSS variable tokens
-    const scssMap = dictionary.allTokens.map(token => {
+    // Generate the SCSS map (omit component tokens with no value — not emitted in the SCSS output)
+    const scssMap = sourceTokens.map(token => {
       const value = unquoteString(JSON.stringify(token.$value))
       const comment = unquoteString(JSON.stringify(token.$description))
 
@@ -31,8 +34,8 @@ StyleDictionary.registerFormat({
       return tokenOutput
     }).join('\n')
 
-    // Generate the LESS variable tokens
-    const lessTokens = dictionary.allTokens.map(token => {
+    // Generate the LESS variable tokens (omit component tokens with no value — not emitted in the LESS output)
+    const lessTokens = sourceTokens.map(token => {
       const value = unquoteString(JSON.stringify(token.$value))
       const comment = unquoteString(JSON.stringify(token.$description))
 
@@ -44,9 +47,9 @@ StyleDictionary.registerFormat({
       return tokenOutput
     }).join('\n')
 
-    // Generate the CSS custom properties
-    const cssTokens = dictionary.allTokens.map(token => {
-      const value = unquoteString(JSON.stringify(token.$value))
+    // Generate the CSS custom properties (empty-value tokens render as `initial` — their correct runtime value)
+    const cssTokens = allTokens.map(token => {
+      const value = token.$value === '' ? 'initial' : unquoteString(JSON.stringify(token.$value))
       const comment = unquoteString(JSON.stringify(token.$description))
 
       let tokenOutput = ''
@@ -57,8 +60,8 @@ StyleDictionary.registerFormat({
       return tokenOutput
     }).join('\n')
 
-    // Generate the JavaScript variable tokens
-    const javascriptTokens = dictionary.allTokens.map(token => {
+    // Generate the JavaScript variable tokens (omit component tokens with no value — not emitted in the JS output)
+    const javascriptTokens = sourceTokens.map(token => {
       const value = JSON.stringify(token.$value)
       const comment = unquoteString(JSON.stringify(token.$description))
 
@@ -70,12 +73,12 @@ StyleDictionary.registerFormat({
       return tokenOutput
     }).join('\n')
 
-    // Generate the JavaScript variable tokens
-    const jsonTokens = dictionary.allTokens.map((token, idx) => {
+    // Generate the JSON tokens (omit component tokens with no value — not emitted in the JSON output)
+    const jsonTokens = sourceTokens.map((token, idx) => {
       const value = JSON.stringify(token.$value)
 
       let tokenOutput = `  "${token.name.replace(/-/g, '_').toLowerCase()}": ${value},`
-      if ((idx + 1) === dictionary.allTokens.length) {
+      if ((idx + 1) === sourceTokens.length) {
         tokenOutput = tokenOutput.replace(/,$/, '')
       }
       return tokenOutput

--- a/platforms/scss.mjs
+++ b/platforms/scss.mjs
@@ -57,20 +57,20 @@ export default {
       options: {
         themeable: true,
       },
-      // Exclude alias tokens and asset tokens compiled in a separate file
-      filter: (token) => token.isSource === true && token.attributes.category !== 'asset',
+      // Exclude alias tokens, asset tokens, and component tokens with no value (runtime-only CSS customization surface)
+      filter: (token) => token.isSource === true && token.attributes.category !== 'asset' && token.original.$value !== '',
     },
     // SCSS map
     {
       format: 'scss/map-flat',
       destination: '_map.scss',
-      // Exclude alias tokens and asset tokens compiled in a separate file
-      filter: (token) => token.isSource === true && token.attributes.category !== 'asset',
+      // Exclude alias tokens, asset tokens, and component tokens with no value (runtime-only CSS customization surface)
+      filter: (token) => token.isSource === true && token.attributes.category !== 'asset' && token.original.$value !== '',
       options: {
         mapName: 'kui-tokens-map',
       },
     },
-    // SCSS CSS variables mixin
+    // SCSS CSS variables mixin — emits CSS custom properties, so empty-value tokens correctly emit as `initial`
     {
       format: 'css/variables/custom/sass/mixin',
       destination: '_mixins.scss',

--- a/tokens/source/components/button.json
+++ b/tokens/source/components/button.json
@@ -1,0 +1,310 @@
+{
+  "button": {
+    "border": {
+      "radius": {
+        "$description": "The border radius of the button.",
+        "$value": ""
+      },
+      "width": {
+        "$description": "The border width of the button.",
+        "$value": ""
+      }
+    },
+    "color": {
+      "background": {
+        "danger": {
+          "_": {
+            "$description": "The background color of the danger button in its default state.",
+            "$value": ""
+          },
+          "active": {
+            "$description": "The background color of the danger button in its active state.",
+            "$value": ""
+          },
+          "disabled": {
+            "$description": "The background color of the danger button in its disabled state.",
+            "$value": ""
+          },
+          "hover": {
+            "$description": "The background color of the danger button in its hover state.",
+            "$value": ""
+          }
+        },
+        "primary": {
+          "_": {
+            "$description": "The background color of the primary button in its default state.",
+            "$value": ""
+          },
+          "active": {
+            "$description": "The background color of the primary button in its active state.",
+            "$value": ""
+          },
+          "disabled": {
+            "$description": "The background color of the primary button in its disabled state.",
+            "$value": ""
+          },
+          "hover": {
+            "$description": "The background color of the primary button in its hover state.",
+            "$value": ""
+          }
+        },
+        "secondary": {
+          "_": {
+            "$description": "The background color of the secondary button in its default state.",
+            "$value": ""
+          },
+          "active": {
+            "$description": "The background color of the secondary button in its active state.",
+            "$value": ""
+          },
+          "disabled": {
+            "$description": "The background color of the secondary button in its disabled state.",
+            "$value": ""
+          },
+          "hover": {
+            "$description": "The background color of the secondary button in its hover state.",
+            "$value": ""
+          }
+        },
+        "tertiary": {
+          "_": {
+            "$description": "The background color of the tertiary button in its default state.",
+            "$value": ""
+          },
+          "active": {
+            "$description": "The background color of the tertiary button in its active state.",
+            "$value": ""
+          },
+          "disabled": {
+            "$description": "The background color of the tertiary button in its disabled state.",
+            "$value": ""
+          },
+          "hover": {
+            "$description": "The background color of the tertiary button in its hover state.",
+            "$value": ""
+          }
+        }
+      },
+      "border": {
+        "danger": {
+          "_": {
+            "$description": "The border color of the danger button in its default state.",
+            "$value": ""
+          },
+          "active": {
+            "$description": "The border color of the danger button in its active state.",
+            "$value": ""
+          },
+          "disabled": {
+            "$description": "The border color of the danger button in its disabled state.",
+            "$value": ""
+          },
+          "hover": {
+            "$description": "The border color of the danger button in its hover state.",
+            "$value": ""
+          }
+        },
+        "primary": {
+          "_": {
+            "$description": "The border color of the primary button in its default state.",
+            "$value": ""
+          },
+          "active": {
+            "$description": "The border color of the primary button in its active state.",
+            "$value": ""
+          },
+          "disabled": {
+            "$description": "The border color of the primary button in its disabled state.",
+            "$value": ""
+          },
+          "hover": {
+            "$description": "The border color of the primary button in its hover state.",
+            "$value": ""
+          }
+        },
+        "secondary": {
+          "_": {
+            "$description": "The border color of the secondary button in its default state.",
+            "$value": ""
+          },
+          "active": {
+            "$description": "The border color of the secondary button in its active state.",
+            "$value": ""
+          },
+          "disabled": {
+            "$description": "The border color of the secondary button in its disabled state.",
+            "$value": ""
+          },
+          "hover": {
+            "$description": "The border color of the secondary button in its hover state.",
+            "$value": ""
+          }
+        },
+        "tertiary": {
+          "_": {
+            "$description": "The border color of the tertiary button in its default state.",
+            "$value": ""
+          },
+          "active": {
+            "$description": "The border color of the tertiary button in its active state.",
+            "$value": ""
+          },
+          "disabled": {
+            "$description": "The border color of the tertiary button in its disabled state.",
+            "$value": ""
+          },
+          "hover": {
+            "$description": "The border color of the tertiary button in its hover state.",
+            "$value": ""
+          }
+        }
+      },
+      "text": {
+        "danger": {
+          "_": {
+            "$description": "The text color of the danger button in its default state.",
+            "$value": ""
+          },
+          "active": {
+            "$description": "The text color of the danger button in its active state.",
+            "$value": ""
+          },
+          "disabled": {
+            "$description": "The text color of the danger button in its disabled state.",
+            "$value": ""
+          },
+          "hover": {
+            "$description": "The text color of the danger button in its hover state.",
+            "$value": ""
+          }
+        },
+        "primary": {
+          "_": {
+            "$description": "The text color of the primary button in its default state.",
+            "$value": ""
+          },
+          "active": {
+            "$description": "The text color of the primary button in its active state.",
+            "$value": ""
+          },
+          "disabled": {
+            "$description": "The text color of the primary button in its disabled state.",
+            "$value": ""
+          },
+          "hover": {
+            "$description": "The text color of the primary button in its hover state.",
+            "$value": ""
+          }
+        },
+        "secondary": {
+          "_": {
+            "$description": "The text color of the secondary button in its default state.",
+            "$value": ""
+          },
+          "active": {
+            "$description": "The text color of the secondary button in its active state.",
+            "$value": ""
+          },
+          "disabled": {
+            "$description": "The text color of the secondary button in its disabled state.",
+            "$value": ""
+          },
+          "hover": {
+            "$description": "The text color of the secondary button in its hover state.",
+            "$value": ""
+          }
+        },
+        "tertiary": {
+          "_": {
+            "$description": "The text color of the tertiary button in its default state.",
+            "$value": ""
+          },
+          "active": {
+            "$description": "The text color of the tertiary button in its active state.",
+            "$value": ""
+          },
+          "disabled": {
+            "$description": "The text color of the tertiary button in its disabled state.",
+            "$value": ""
+          },
+          "hover": {
+            "$description": "The text color of the tertiary button in its hover state.",
+            "$value": ""
+          }
+        }
+      }
+    },
+    "font": {
+      "family": {
+        "$description": "The font family for all buttons.",
+        "$type": "font",
+        "$value": ""
+      },
+      "size": {
+        "large": {
+          "$description": "The font size for large buttons.",
+          "$value": ""
+        },
+        "medium": {
+          "$description": "The font size for medium (default) buttons.",
+          "$value": ""
+        },
+        "small": {
+          "$description": "The font size for small buttons.",
+          "$value": ""
+        }
+      },
+      "weight": {
+        "$description": "The font weight for all buttons.",
+        "$type": "font",
+        "$value": ""
+      }
+    },
+    "line_height": {
+      "large": {
+        "$description": "The line-height for large buttons.",
+        "$value": ""
+      },
+      "medium": {
+        "$description": "The line-height for medium (default) buttons.",
+        "$value": ""
+      },
+      "small": {
+        "$description": "The line-height for small buttons.",
+        "$value": ""
+      }
+    },
+    "padding": {
+      "large": {
+        "x": {
+          "$description": "The left and right padding for large buttons.",
+          "$value": ""
+        },
+        "y": {
+          "$description": "The top and bottom padding for large buttons.",
+          "$value": ""
+        }
+      },
+      "medium": {
+        "x": {
+          "$description": "The left and right padding for medium (default) buttons.",
+          "$value": ""
+        },
+        "y": {
+          "$description": "The top and bottom padding for medium (default) buttons.",
+          "$value": ""
+        }
+      },
+      "small": {
+        "x": {
+          "$description": "The left and right padding for small buttons.",
+          "$value": ""
+        },
+        "y": {
+          "$description": "The top and bottom padding for small buttons.",
+          "$value": ""
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Summary

Adds `button` component tokens to emitted CSS custom properties with no value. (Restores tokens originally introduced in #645)

The tokens are only present in the CSS Custom Properties output via `@kong/design-tokens/tokens/css/custom-properties.css` and have no default value so that usage falls back to the underlying semantic token(s).

## Tokens

### Border

- Border radius (one token, assuming all buttons use the same value from the prototype)
  - `kui-button-border-radius`
- Border width (one token, assuming all buttons use the same value from the prototype)
  - `kui-button-border-width`

## Font

- Font family (one token, assuming all buttons use the same value)
  - `kui-button-font-family`
- Font weight (one token, assuming all buttons use the same value)
  - `kui-button-font-weight`

### Padding (for each size - we must define x/y separately to account for square icon buttons)

- `kui-button-padding-<size>-x`
- `kui-button-padding-<size>-y`

### Font-size (for each size)

- `kui-button-font-size-<size>`

### Line-height (for each size)

- `kui-button-line-height-<size>`

### Background (for each appearance)

- `kui-button-color-background-<appearance>`
- `kui-button-color-background-<appearance>-hover`
- `kui-button-color-background-<appearance>-active`
- `kui-button-color-background-<appearance>-disabled`

### Color (for each appearance)

- `kui-button-color-text-<appearance>`
- `kui-button-color-text-<appearance>-hover`
- `kui-button-color-text-<appearance>-active`
- `kui-button-color-text-<appearance>-disabled`

### Border color (for each appearance)

- `kui-button-color-border-<appearance>`
- `kui-button-color-border-<appearance>-hover`
- `kui-button-color-border-<appearance>-active`
- `kui-button-color-border-<appearance>-disabled`
