### PR TITLE
ci: publish all packages if files change

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -45,6 +45,22 @@ jobs:
         run: |
           changed=$(pnpm lerna changed --since "origin/${BASE_REF}" --json 2>/dev/null || echo '[]')
           changed=$(echo "$changed" | jq -c '[.[].name]' 2>/dev/null || echo '[]')
+
+          # If any critical root-level files changed, force CI for all packages
+          critical_files="pnpm-workspace.yaml pnpm-lock.yaml package.json eslint.config.mjs tsconfig.base.json tsconfig.json"
+          changed_files=$(git diff --name-only "origin/${BASE_REF}...HEAD")
+          force_all=false
+          for f in $critical_files; do
+            if echo "$changed_files" | grep -qx "$f"; then
+              force_all=true
+              break
+            fi
+          done
+          if [ "$force_all" = "true" ]; then
+            echo "Critical root-level file(s) changed - forcing CI for all packages"
+            changed=$(pnpm lerna ls --json 2>/dev/null | jq -c '[.[].name]' 2>/dev/null || echo '[]')
+          fi
+
           # Echo the packages to the console and set it as an output for the next job
           echo "changed=${changed}"
           echo "changed=${changed}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -46,8 +46,10 @@ jobs:
           changed=$(pnpm lerna changed --since "origin/${BASE_REF}" --json 2>/dev/null || echo '[]')
           changed=$(echo "$changed" | jq -c '[.[].name]' 2>/dev/null || echo '[]')
 
-          # If any critical root-level files changed, force CI for all packages
-          critical_files="pnpm-workspace.yaml pnpm-lock.yaml package.json eslint.config.mjs tsconfig.base.json tsconfig.json"
+          # If any critical root-level files changed, force preview publish for all packages.
+          # Only include files that genuinely affect build output; lint/ts config and the lockfile
+          # do not change dist artifacts and should not trigger unnecessary publishes.
+          critical_files="pnpm-workspace.yaml package.json"
           changed_files=$(git diff --name-only "origin/${BASE_REF}...HEAD")
           force_all=false
           for f in $critical_files; do


### PR DESCRIPTION
# Summary

If certain core files in the repo change, ensure we test and publish all packages.