### PR TITLE
fix(themes): classic night colors

### DIFF
--- a/packages/design-tokens/__snapshots__/themes/classic-night.css
+++ b/packages/design-tokens/__snapshots__/themes/classic-night.css
@@ -29,7 +29,7 @@
     --kui-color-background-decorative-aqua-weakest: #ECFCFF;
     --kui-color-background-decorative-purple: #6F28FF;
     --kui-color-background-decorative-purple-weakest: #F1F0FF;
-    --kui-color-background-disabled: #E0E4EA;
+    --kui-color-background-disabled: #232633;
     --kui-color-background-info: #0044F4;
     --kui-color-background-info-strong: #0030CC;
     --kui-color-background-info-stronger: #002099;
@@ -109,7 +109,7 @@
     --kui-color-text-decorative-pink: #D60067;
     --kui-color-text-decorative-purple: #6F28FF;
     --kui-color-text-decorative-purple-strong: #5E00F5;
-    --kui-color-text-disabled: #3A3F51;
+    --kui-color-text-disabled: #C7CED8;
     --kui-color-text-info: #0044F4;
     --kui-color-text-info-strong: #0030CC;
     --kui-color-text-info-stronger: #002099;

--- a/packages/design-tokens/themes/classic-night/classic-night.theme.json
+++ b/packages/design-tokens/themes/classic-night/classic-night.theme.json
@@ -91,7 +91,7 @@
   },
   "kui-color-background-disabled": {
     "$description": "Background color for disabled elements.",
-    "$value": "{color.alias.gray.20}"
+    "$value": "{color.alias.gray.90}"
   },
   "kui-color-background-info": {
     "$description": "Background color for info elements.",
@@ -411,7 +411,7 @@
   },
   "kui-color-text-disabled": {
     "$description": "Text color for disabled elements.",
-    "$value": "{color.alias.gray.80}"
+    "$value": "{color.alias.gray.30}"
   },
   "kui-color-text-info": {
     "$description": "Text color for info elements.",


### PR DESCRIPTION
# Summary

Fixes the `color-text-disabled` and `color-background-disabled` colors in the `classic-night` theme.