### PR TITLE
fix(classic-night): color-text-inverse to black

### DIFF
--- a/packages/design-tokens/__snapshots__/themes/classic-night.css
+++ b/packages/design-tokens/__snapshots__/themes/classic-night.css
@@ -117,7 +117,7 @@
     --kui-color-text-info-weak: #5F9AFF;
     --kui-color-text-info-weaker: #BEE2FF;
     --kui-color-text-info-weakest: #EEFAFF;
-    --kui-color-text-inverse: #FFF;
+    --kui-color-text-inverse: #000;
     --kui-color-text-neutral: #6C7489;
     --kui-color-text-neutral-strong: #AFB7C5;
     --kui-color-text-neutral-stronger: #C7CED8;

--- a/packages/design-tokens/themes/classic-night/classic-night.theme.json
+++ b/packages/design-tokens/themes/classic-night/classic-night.theme.json
@@ -443,7 +443,7 @@
   },
   "kui-color-text-inverse": {
     "$description": "Inverse text color.",
-    "$value": "{color.alias.white}"
+    "$value": "{color.alias.black}"
   },
   "kui-color-text-neutral": {
     "$description": "Text color for neutral elements.",


### PR DESCRIPTION
# Summary

The `color-text-inverse` in classic night was flipped