### PR TITLE
fix(design-tokens): update color-text-disabled for electric-lime-night

### DIFF
--- a/packages/design-tokens/__snapshots__/themes/electric-lime-night.css
+++ b/packages/design-tokens/__snapshots__/themes/electric-lime-night.css
@@ -289,7 +289,7 @@
     --kui-color-text-decorative-pink: #E2B6CB;
     --kui-color-text-decorative-purple: #CBBCE8;
     --kui-color-text-decorative-purple-strong: #9175C7;
-    --kui-color-text-disabled: #9DA99D;
+    --kui-color-text-disabled: #4E594E;
     --kui-color-text-info: #BCD1E8;
     --kui-color-text-info-strong: #D7E3EF;
     --kui-color-text-info-stronger: #F7F9FC;

--- a/packages/design-tokens/themes/electric-lime-night/electric-lime-night.theme.json
+++ b/packages/design-tokens/themes/electric-lime-night/electric-lime-night.theme.json
@@ -1129,7 +1129,7 @@
   },
   "kui-color-text-disabled": {
     "$description": "Text color for disabled elements.",
-    "$value": "{color.alias.gray.40}"
+    "$value": "{color.alias.gray.60}"
   },
   "kui-color-text-info": {
     "$description": "Text color for info elements.",


### PR DESCRIPTION
# Summary

Update the `electric-lime-night` theme to point `kui-color-text-disabled` to `gray.60` (via triage doc)