### PR TITLE
fix(design-tokens): icon-color-warning

### DIFF
--- a/packages/design-tokens/__snapshots__/themes/electric-lime-day.css
+++ b/packages/design-tokens/__snapshots__/themes/electric-lime-day.css
@@ -435,7 +435,7 @@
     --kui-icon-color-neutral: #697769;
     --kui-icon-color-primary: #3094FF;
     --kui-icon-color-success: #00A17B;
-    --kui-icon-color-warning: #FFE500;
+    --kui-icon-color-warning: #807300;
     --kui-icon-size-10: 10px;
     --kui-icon-size-20: 12px;
     --kui-icon-size-30: 16px;

--- a/packages/design-tokens/__snapshots__/themes/electric-lime-night.css
+++ b/packages/design-tokens/__snapshots__/themes/electric-lime-night.css
@@ -435,7 +435,7 @@
     --kui-icon-color-neutral: #697769;
     --kui-icon-color-primary: #5485BA;
     --kui-icon-color-success: #3D8776;
-    --kui-icon-color-warning: #B5A72C;
+    --kui-icon-color-warning: #665E19;
     --kui-icon-size-10: 10px;
     --kui-icon-size-20: 12px;
     --kui-icon-size-30: 16px;

--- a/packages/design-tokens/themes/electric-lime-day/electric-lime-day.theme.json
+++ b/packages/design-tokens/themes/electric-lime-day/electric-lime-day.theme.json
@@ -1703,7 +1703,7 @@
   },
   "kui-icon-color-warning": {
     "$description": "Warning color for icons.",
-    "$value": "{color.alias.yellow.40}"
+    "$value": "{color.alias.yellow.70}"
   },
   "kui-icon-size-10": {
     "$value": "10px"

--- a/packages/design-tokens/themes/electric-lime-night/electric-lime-night.theme.json
+++ b/packages/design-tokens/themes/electric-lime-night/electric-lime-night.theme.json
@@ -1703,7 +1703,7 @@
   },
   "kui-icon-color-warning": {
     "$description": "Warning color for icons.",
-    "$value": "{color.alias.yellow.40}"
+    "$value": "{color.alias.yellow.70}"
   },
   "kui-icon-size-10": {
     "$value": "10px"


### PR DESCRIPTION
# Summary

Update the pointer for `icon-color-warning` in `electric-lime-day` and `electric-lime-night` themes