### PR TITLE
fix: update dropdown item color text danger tokens [KHCP-21429]

### DIFF
--- a/packages/design-tokens/__snapshots__/themes/electric-lime-day-high-contrast.css
+++ b/packages/design-tokens/__snapshots__/themes/electric-lime-day-high-contrast.css
@@ -348,7 +348,7 @@
     --kui-dropdown-item-color-background-selected-disabled: #FAFBFA;
     --kui-dropdown-item-color-border-divider: #D2D7D2;
     --kui-dropdown-item-color-text: #3D443D;
-    --kui-dropdown-item-color-text-danger: #000000;
+    --kui-dropdown-item-color-text-danger: #AA001F;
     --kui-dropdown-item-color-text-disabled: #697769;
     --kui-dropdown-item-color-text-selected: #181B18;
     --kui-dropdown-item-font-family: 'Funnel Sans', Roboto, Helvetica, sans-serif;

--- a/packages/design-tokens/__snapshots__/themes/electric-lime-night-high-contrast.css
+++ b/packages/design-tokens/__snapshots__/themes/electric-lime-night-high-contrast.css
@@ -348,7 +348,7 @@
     --kui-dropdown-item-color-background-selected-disabled: #242824;
     --kui-dropdown-item-color-border-divider: #4E594E;
     --kui-dropdown-item-color-text: #D2D7D2;
-    --kui-dropdown-item-color-text-danger: #EFCDD3;
+    --kui-dropdown-item-color-text-danger: #FF9BA8;
     --kui-dropdown-item-color-text-disabled: #9DA99D;
     --kui-dropdown-item-color-text-selected: #F1F3F1;
     --kui-dropdown-item-font-family: 'Funnel Sans', Roboto, Helvetica, sans-serif;

--- a/packages/design-tokens/__snapshots__/themes/electric-lime-night.css
+++ b/packages/design-tokens/__snapshots__/themes/electric-lime-night.css
@@ -348,7 +348,7 @@
     --kui-dropdown-item-color-background-selected-disabled: #242824;
     --kui-dropdown-item-color-border-divider: #3D443D;
     --kui-dropdown-item-color-text: #D2D7D2;
-    --kui-dropdown-item-color-text-danger: #EFCDD3;
+    --kui-dropdown-item-color-text-danger: #D78392;
     --kui-dropdown-item-color-text-disabled: #9DA99D;
     --kui-dropdown-item-color-text-selected: #F1F3F1;
     --kui-dropdown-item-font-family: 'Funnel Sans', Roboto, Helvetica, sans-serif;

--- a/packages/design-tokens/themes/electric-lime-day-high-contrast/electric-lime-day-high-contrast.theme.json
+++ b/packages/design-tokens/themes/electric-lime-day-high-contrast/electric-lime-day-high-contrast.theme.json
@@ -1365,7 +1365,7 @@
   },
   "kui-dropdown-item-color-text-danger": {
     "$description": "Danger dropdown item text color.",
-    "$value": "{color.alias.black}"
+    "$value": "{color.alias.red.60}"
   },
   "kui-dropdown-item-color-text-disabled": {
     "$description": "Disabled dropdown item text color.",

--- a/packages/design-tokens/themes/electric-lime-night-high-contrast/electric-lime-night-high-contrast.theme.json
+++ b/packages/design-tokens/themes/electric-lime-night-high-contrast/electric-lime-night-high-contrast.theme.json
@@ -1365,7 +1365,7 @@
   },
   "kui-dropdown-item-color-text-danger": {
     "$description": "Danger dropdown item text color.",
-    "$value": "{color.alias.red.20}"
+    "$value": "{color.alias.red.40}"
   },
   "kui-dropdown-item-color-text-disabled": {
     "$description": "Disabled dropdown item text color.",

--- a/packages/design-tokens/themes/electric-lime-night/electric-lime-night.theme.json
+++ b/packages/design-tokens/themes/electric-lime-night/electric-lime-night.theme.json
@@ -1365,7 +1365,7 @@
   },
   "kui-dropdown-item-color-text-danger": {
     "$description": "Danger dropdown item text color.",
-    "$value": "{color.alias.red.20}"
+    "$value": "{color.alias.red.30}"
   },
   "kui-dropdown-item-color-text-disabled": {
     "$description": "Disabled dropdown item text color.",


### PR DESCRIPTION
# Summary

Update `kui-dropdown-item-color-text-danger` token in `electric-lime-night`, `electric-lime-day-high-contrast` and `electric-lime-night-high-contrast` themes

**Before**

Electric lime night theme

<img width="267" height="381" alt="Screenshot 2026-08-05 at 9 38 16 AM" src="https://github.com/user-attachments/assets/563187ef-42fe-4d70-abfb-972294fb18e9" />

Both high contrast themes

<img width="242" height="362" alt="Screenshot 2026-08-05 at 9 37 59 AM" src="https://github.com/user-attachments/assets/64f3fdf8-3b05-429a-be71-b02cf0223a39" />
<img width="264" height="376" alt="Screenshot 2026-08-05 at 9 19 32 AM" src="https://github.com/user-attachments/assets/ad694d55-caac-47d4-b6e9-dd4c2e7ba775" />

**After**

Electric lime night theme

<img width="261" height="375" alt="Screenshot 2026-08-05 at 9 38 57 AM" src="https://github.com/user-attachments/assets/232e4fa5-f993-4650-a586-720b59d11490" />

Both high contrast themes

<img width="254" height="389" alt="Screenshot 2026-08-05 at 9 16 52 AM" src="https://github.com/user-attachments/assets/d396d6a4-a0f7-4f09-8d20-53102b33d22f" />
<img width="242" height="372" alt="Screenshot 2026-08-05 at 9 34 56 AM" src="https://github.com/user-attachments/assets/b37129d7-e352-4a3e-a544-b304227249bf" />


<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
