### PR TITLE
fix: date time picker disabled tokens [KHCP-21429]

### DIFF
--- a/packages/design-tokens/__snapshots__/themes/electric-lime-day-high-contrast.css
+++ b/packages/design-tokens/__snapshots__/themes/electric-lime-day-high-contrast.css
@@ -334,7 +334,7 @@
     --kui-date-time-picker-day-color-background-selected-hover: #3D443D;
     --kui-date-time-picker-day-color-background-today: #FAFBFA;
     --kui-date-time-picker-day-color-text: #3D443D;
-    --kui-date-time-picker-day-color-text-disabled: #4E594E;
+    --kui-date-time-picker-day-color-text-disabled: #9DA99D;
     --kui-date-time-picker-day-color-text-selected: #FFFFFF;
     --kui-date-time-picker-shadow-focus: 0px 0px 0px 4px rgba(24, 27, 24, 0.15);
     --kui-dropdown-border-radius: 6px;

--- a/packages/design-tokens/__snapshots__/themes/electric-lime-day.css
+++ b/packages/design-tokens/__snapshots__/themes/electric-lime-day.css
@@ -334,7 +334,7 @@
     --kui-date-time-picker-day-color-background-selected-hover: #3D443D;
     --kui-date-time-picker-day-color-background-today: #F1F3F1;
     --kui-date-time-picker-day-color-text: #3D443D;
-    --kui-date-time-picker-day-color-text-disabled: #4E594E;
+    --kui-date-time-picker-day-color-text-disabled: #9DA99D;
     --kui-date-time-picker-day-color-text-selected: #FFFFFF;
     --kui-date-time-picker-shadow-focus: 0px 0px 0px 4px rgba(24, 27, 24, 0.15);
     --kui-dropdown-border-radius: 6px;

--- a/packages/design-tokens/__snapshots__/themes/electric-lime-night-high-contrast.css
+++ b/packages/design-tokens/__snapshots__/themes/electric-lime-night-high-contrast.css
@@ -334,7 +334,7 @@
     --kui-date-time-picker-day-color-background-selected-hover: #D2D7D2;
     --kui-date-time-picker-day-color-background-today: #242824;
     --kui-date-time-picker-day-color-text: #D2D7D2;
-    --kui-date-time-picker-day-color-text-disabled: #9DA99D;
+    --kui-date-time-picker-day-color-text-disabled: #697769;
     --kui-date-time-picker-day-color-text-selected: #070807;
     --kui-date-time-picker-shadow-focus: 0px 0px 0px 4px rgba(241, 243, 241, 0.15);
     --kui-dropdown-border-radius: 6px;

--- a/packages/design-tokens/__snapshots__/themes/electric-lime-night.css
+++ b/packages/design-tokens/__snapshots__/themes/electric-lime-night.css
@@ -334,7 +334,7 @@
     --kui-date-time-picker-day-color-background-selected-hover: #D2D7D2;
     --kui-date-time-picker-day-color-background-today: #242824;
     --kui-date-time-picker-day-color-text: #D2D7D2;
-    --kui-date-time-picker-day-color-text-disabled: #9DA99D;
+    --kui-date-time-picker-day-color-text-disabled: #697769;
     --kui-date-time-picker-day-color-text-selected: #070807;
     --kui-date-time-picker-shadow-focus: 0px 0px 0px 4px rgba(241, 243, 241, 0.15);
     --kui-dropdown-border-radius: 6px;

--- a/packages/design-tokens/themes/electric-lime-day-high-contrast/electric-lime-day-high-contrast.theme.json
+++ b/packages/design-tokens/themes/electric-lime-day-high-contrast/electric-lime-day-high-contrast.theme.json
@@ -1309,7 +1309,7 @@
   },
   "kui-date-time-picker-day-color-text-disabled": {
     "$description": "Date time picker calendar disabled day cell text color.",
-    "$value": "{color.alias.gray.60}"
+    "$value": "{color.alias.gray.40}"
   },
   "kui-date-time-picker-day-color-text-selected": {
     "$description": "Date time picker calendar inverse text color (used for content rendered on top of accent/selected backgrounds).",

--- a/packages/design-tokens/themes/electric-lime-day/electric-lime-day.theme.json
+++ b/packages/design-tokens/themes/electric-lime-day/electric-lime-day.theme.json
@@ -1309,7 +1309,7 @@
   },
   "kui-date-time-picker-day-color-text-disabled": {
     "$description": "Date time picker calendar disabled day cell text color.",
-    "$value": "{color.alias.gray.60}"
+    "$value": "{color.alias.gray.40}"
   },
   "kui-date-time-picker-day-color-text-selected": {
     "$description": "Date time picker calendar inverse text color (used for content rendered on top of accent/selected backgrounds).",

--- a/packages/design-tokens/themes/electric-lime-night-high-contrast/electric-lime-night-high-contrast.theme.json
+++ b/packages/design-tokens/themes/electric-lime-night-high-contrast/electric-lime-night-high-contrast.theme.json
@@ -1309,7 +1309,7 @@
   },
   "kui-date-time-picker-day-color-text-disabled": {
     "$description": "Date time picker calendar disabled day cell text color.",
-    "$value": "{color.alias.gray.40}"
+    "$value": "{color.alias.gray.50}"
   },
   "kui-date-time-picker-day-color-text-selected": {
     "$description": "Date time picker calendar inverse text color (used for content rendered on top of accent/selected backgrounds).",

--- a/packages/design-tokens/themes/electric-lime-night/electric-lime-night.theme.json
+++ b/packages/design-tokens/themes/electric-lime-night/electric-lime-night.theme.json
@@ -1309,7 +1309,7 @@
   },
   "kui-date-time-picker-day-color-text-disabled": {
     "$description": "Date time picker calendar disabled day cell text color.",
-    "$value": "{color.alias.gray.40}"
+    "$value": "{color.alias.gray.50}"
   },
   "kui-date-time-picker-day-color-text-selected": {
     "$description": "Date time picker calendar inverse text color (used for content rendered on top of accent/selected backgrounds).",


### PR DESCRIPTION
# Summary

Tweak `kui-date-time-picker-day-color-text-disabled` tokens in all themes to make disabled dates visually distinguishable

Before

<img width="306" height="305" alt="Screenshot 2026-08-05 at 3 30 45 PM" src="https://github.com/user-attachments/assets/9f032e6a-dfa8-4a50-90fe-0e5b9eaf05ea" />
<img width="304" height="310" alt="Screenshot 2026-08-05 at 3 32 47 PM" src="https://github.com/user-attachments/assets/833cacfb-2b04-4e63-81d2-e33f0a61ad8a" />

After

<img width="306" height="304" alt="Screenshot 2026-08-05 at 3 30 27 PM" src="https://github.com/user-attachments/assets/b9c1e4f2-ed23-4759-bd08-4f32368fbae2" />
<img width="306" height="309" alt="Screenshot 2026-08-05 at 3 33 18 PM" src="https://github.com/user-attachments/assets/8f22ea8c-0b45-43a7-bab0-13ba4d09079b" />

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
