### PR TITLE
fix(themes): tweak disabled primary button background [KHCP-21429]

### DIFF
--- a/packages/design-tokens/__snapshots__/themes/electric-lime-day-high-contrast.css
+++ b/packages/design-tokens/__snapshots__/themes/electric-lime-day-high-contrast.css
@@ -88,7 +88,7 @@
     --kui-button-color-background-danger-hover: #850018;
     --kui-button-color-background-primary: #090D09;
     --kui-button-color-background-primary-active: #242824;
-    --kui-button-color-background-primary-disabled: #FAFBFA;
+    --kui-button-color-background-primary-disabled: #E5E9E5;
     --kui-button-color-background-primary-hover: #181B18;
     --kui-button-color-background-secondary: transparent;
     --kui-button-color-background-secondary-active: transparent;

--- a/packages/design-tokens/themes/electric-lime-day-high-contrast/electric-lime-day-high-contrast.theme.json
+++ b/packages/design-tokens/themes/electric-lime-day-high-contrast/electric-lime-day-high-contrast.theme.json
@@ -327,7 +327,7 @@
   },
   "kui-button-color-background-primary-disabled": {
     "$description": "Primary button background color when disabled.",
-    "$value": "{color.alias.gray.10}"
+    "$value": "{color.alias.gray.20}"
   },
   "kui-button-color-background-primary-hover": {
     "$description": "Primary button background color on hover.",


### PR DESCRIPTION
# Summary

Tweak disabled primary button background in high contrast day theme

Before

<img width="439" height="191" alt="Screenshot 2026-08-06 at 8 53 09 AM" src="https://github.com/user-attachments/assets/281f67ab-512d-4652-a449-58329ac4776a" />
<img width="890" height="581" alt="Screenshot 2026-08-06 at 8 52 25 AM" src="https://github.com/user-attachments/assets/9064985b-2eaa-42cc-87c7-5f598f45401f" />

After

<img width="445" height="190" alt="Screenshot 2026-08-06 at 8 54 25 AM" src="https://github.com/user-attachments/assets/690c86ca-c80e-4424-9a19-df742202dee8" />
<img width="911" height="611" alt="Screenshot 2026-08-06 at 8 53 57 AM" src="https://github.com/user-attachments/assets/77f6a68f-4543-4895-b5b1-fa6130e15e1f" />

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
